### PR TITLE
[FEAT] 초기 도메인 환경 및 도커 컴포즈 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
@@ -34,7 +35,37 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
+    //querydsl
+    implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta" // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응 코드
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응 코드
 }
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+
+services:
+  mysql-db:
+    image: mysql:8.0
+    container_name: local-mysql-db
+    ports:
+      - "3306:3306"
+    environment:
+      # These environment variables match the default values in your application-dev.yml
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}  # Corresponds to DB_PASSWORD default
+      MYSQL_DATABASE: ${DB_NAME}  # Corresponds to dev_database in the URL
+
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command:
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_bin
+
+volumes:
+  mysql_data:

--- a/src/main/java/com/example/thirdtool/Deck/Deck.java
+++ b/src/main/java/com/example/thirdtool/Deck/Deck.java
@@ -1,4 +1,0 @@
-package com.example.thirdtool.Deck;
-
-public class Deck {
-}

--- a/src/main/java/com/example/thirdtool/Deck/DeckRepository.java
+++ b/src/main/java/com/example/thirdtool/Deck/DeckRepository.java
@@ -1,4 +1,0 @@
-package com.example.thirdtool.Deck;
-
-public interface DeckRepository {
-}

--- a/src/main/java/com/example/thirdtool/Deck/domain/model/Deck.java
+++ b/src/main/java/com/example/thirdtool/Deck/domain/model/Deck.java
@@ -1,0 +1,89 @@
+package com.example.thirdtool.Deck.domain.model;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.User.domain.model.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Deck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String name;
+
+    // ✅ lastAccessed 필드 추가
+    private LocalDateTime lastAccessed;
+
+    // ✅ scoringAlgorithmType 필드 추가
+    @Column(nullable = false, length = 50)
+    private String scoringAlgorithmType;
+
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_deck_id")
+    private Deck parentDeck;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "parentDeck")
+    private List<Deck> subDecks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "deck", cascade = CascadeType.ALL)
+    private List<Card> cards = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY) // ✅ User 엔티티와의 다대일 관계
+    @JoinColumn(name = "user_id", nullable = false) // ✅ 외래 키 설정
+    private User user;
+
+    @Builder(builderMethodName = "internalBuilder")
+    private Deck(String name, Deck parentDeck, String scoringAlgorithmType, User user) { // ✅ User 인자 추가
+        this.name = name;
+        this.parentDeck = parentDeck;
+        this.lastAccessed = LocalDateTime.now();
+        this.scoringAlgorithmType = scoringAlgorithmType;
+        this.user = user; // ✅ user 필드 초기화
+    }
+
+    public static Deck of(String name, Deck parentDeck, String scoringAlgorithmType, User user) { // ✅ User 인자 추가
+        return internalBuilder()
+                .name(name)
+                .parentDeck(parentDeck)
+                .scoringAlgorithmType(scoringAlgorithmType)
+                .user(user) // ✅ user 전달
+                .build();
+    }
+
+    public static Deck of(String name, String scoringAlgorithmType, User user) { // ✅ User 인자 추가
+        return internalBuilder()
+                .name(name)
+                .scoringAlgorithmType(scoringAlgorithmType)
+                .user(user) // ✅ user 전달
+                .build();
+    }
+    public void updateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("덱 이름은 비어있을 수 없습니다.");
+        }
+        this.name = name;
+    }
+
+    public void updateLastAccessed() {
+        this.lastAccessed = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=third-tool


### PR DESCRIPTION
---

### **개요**

- `Deck` 엔티티를 기존 구조에서 `domain/model` 계층으로 이동 및 리팩토링했습니다.  
- `User` 엔티티와 연관 관계를 설정하여 사용자 단위로 덱을 관리할 수 있도록 수정했습니다.  
- `lastAccessed`, `scoringAlgorithmType` 필드를 추가하여 덱 접근 시간 및 알고리즘 종류를 추적할 수 있도록 확장했습니다.  
- Querydsl 및 Swagger 설정을 `build.gradle`에 추가했습니다.  
- `docker-compose.yml` 파일을 통해 로컬 개발 환경에서 MySQL 실행을 지원하도록 구성했습니다.  

---

### **🧾 관련 이슈**

#189  

---

### **🔍 참고 사항 (선택)**

- 저희 리포지토리명을 `Eatda-Server`로 변경하는 것을 제안합니다.  

---

### **🔍 깨달은 점 (선택)**

- 도메인 구조를 명확히 분리함으로써 유지보수성과 확장성이 높아진다는 점을 체감했습니다.  
- 로컬 개발 환경에서 `docker-compose`를 활용하면 DB 설정 및 실행 과정이 훨씬 단순화됨을 알게 되었습니다.  

---