### PR TITLE
최근 덱 조회 기능 추가 및 덱 관리 로직 개선

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/BaseEntity.java
+++ b/src/main/java/com/example/thirdtool/Common/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.thirdtool.Common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // 여러 엔티티에서 공통적으로 사용하는 필드를 정의할 때 사용
+@EntityListeners(AuditingEntityListener.class) // ✅ Auditing 기능을 활성화
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false) // 생성 시간은 수정되지 않도록 설정
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+}

--- a/src/main/java/com/example/thirdtool/Deck/application/service/DeckService.java
+++ b/src/main/java/com/example/thirdtool/Deck/application/service/DeckService.java
@@ -1,0 +1,98 @@
+package com.example.thirdtool.Deck.application.service;
+
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.repository.DeckRepository;
+
+import com.example.thirdtool.Deck.presentation.dto.DeckCreateRequestDto;
+import com.example.thirdtool.User.domain.model.User;
+import com.example.thirdtool.User.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class DeckService {
+
+    private final DeckRepository deckRepository;
+    private final UserRepository userRepository; // ✅ UserRepository 주입
+
+    //최상위 덱 가져오기(parentId 값이 null인)
+    //최상위 덱 가져올 때는 업데이트 안하고 -> 그 밑에 있는 카드를 누를 때
+    @Transactional(readOnly = true)
+    public List<Deck> getTopLevelDecks() {
+        return deckRepository.findByParentDeckIsNull();
+    }
+
+    //서브 덱들 가져오기
+    @Transactional(readOnly = true)
+    public List<Deck> getSubDecks(Long parentDeckId) {
+        List<Deck> decks = deckRepository.findByParentDeckId(parentDeckId);
+        decks.forEach(Deck::updateLastAccessed); // ✅
+        return decks;
+    }
+
+    // ✅ 덱 생성 로직에 알고리즘 선택 기능 추가
+    @Transactional
+    public Deck createDeck(DeckCreateRequestDto deckRequestDto) {
+        Long userId = 1L; // ✅ 임시로 userId를 1로 가정합니다. 실제 구현 시 수정 필요- 추후 무조건 수정
+
+        User user = userRepository.findById(userId)
+                                  .orElseThrow(() -> new IllegalArgumentException("우리 서비스 유저가 아닙니다!"));
+
+        Deck deck;
+
+        // 부모 덱이 없는 경우 (최상위 덱)
+        if (deckRequestDto.parentDeckId() == null) {
+            deck = Deck.of(deckRequestDto.name(), deckRequestDto.scoringAlgorithmType(), user); // ✅ user 전달
+        } else {
+            Deck parentDeck = deckRepository.findById(deckRequestDto.parentDeckId())
+                                            .orElseThrow(() -> new IllegalArgumentException("부모 덱이 존재하지 않습니다."));
+
+            // ✅ 부모 덱의 알고리즘 타입을 상속받아 새 덱을 생성
+            String inheritedAlgorithmType = parentDeck.getScoringAlgorithmType();
+            deck = Deck.of(deckRequestDto.name(), parentDeck, inheritedAlgorithmType, user); // ✅ user 전달
+
+        }
+
+        return deckRepository.save(deck);
+    }
+
+
+
+    //최신 덱 가져오기
+    @Transactional(readOnly = true)
+    public List<Deck> getRecentDecks() {
+        // 최근 학습한 덱 로직 (예: lastAccessed가 가장 최근인 덱 5개)
+        // Deck 엔티티에 lastAccessed 필드가 필요합니다.
+        return deckRepository.findTop5ByOrderByLastAccessedDesc();
+    }
+
+
+    //덱 삭제하기
+    @Transactional
+    public void deleteDeck(Long deckId) {
+        // 특정 덱 ID를 가진 덱을 삭제합니다.
+        deckRepository.deleteById(deckId);
+    }
+
+    // ✅ 덱을 수정하는 메서드
+    @Transactional
+    public Deck updateDeck(Long deckId, DeckCreateRequestDto deckRequestDto) {
+        // 1. deckId로 기존 덱을 찾습니다.
+        Deck deck = deckRepository.findById(deckId)
+                                  .orElseThrow(() -> new IllegalArgumentException("Deck not found"));
+
+        // 2. 덱의 이름을 업데이트합니다.
+        deck.updateName(deckRequestDto.name());
+
+        // 3. 트랜잭션이 완료되면 변경사항이 자동으로 반영됩니다.
+        return deck;
+    }
+
+    //최근 접속한 접속한 데이터
+}


### PR DESCRIPTION
### **개요(작업내용)**

- DeckService에 카드 및 덱 관련 recent 기능 구현 및 개선 진행
- 최상위 덱/서브 덱 조회 로직 개선, 덱 생성 시 부모 덱 알고리즘 상속 및 사용자 연결 처리
- 최근 학습 덱 조회 기능 추가 (`getRecentDecks`)

---

### **🧾 관련 이슈**

#189

---

### **🔍 참고 사항 (선택)**

- 추가적으로 리포지토리명을 `Eatda-Server`로 수정하는 것을 제안합니다.

---

### **🔍 깨달은 점 (선택)**

- `BaseEntity`를 활용하여 `createdDate`, `updatedDate` 자동 관리 가능
- 덱 조회 시 `lastAccessed` 업데이트를 통해 최근 활동 추적 가능
- 덱 생성 시 부모 덱 알고리즘 타입 상속을 통해 일관된 학습 로직 유지