### PR TITLE
Deck API 구현 및 DeckRepository recent 기능 추가

### DIFF
--- a/src/main/java/com/example/thirdtool/Deck/domain/repository/DeckRepository.java
+++ b/src/main/java/com/example/thirdtool/Deck/domain/repository/DeckRepository.java
@@ -1,0 +1,28 @@
+package com.example.thirdtool.Deck.domain.repository;
+
+import com.example.thirdtool.Deck.domain.model.Deck;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface DeckRepository extends JpaRepository<Deck, Long> {
+        // parentDeck이 null인 모든 덱을 조회하는 메서드
+        List<Deck> findByParentDeckIsNull();
+
+        // ✅ 최근 학습한 덱 5개를 가져오는 쿼리 메서드
+        List<Deck> findTop5ByOrderByLastAccessedDesc();
+
+        // ✅ 특정 부모 덱 ID를 가진 하위 덱들을 조회하는 쿼리 메서드
+        List<Deck> findByParentDeckId(Long parentDeckId);
+
+        // ✅ lastAccessed 필드를 원자적으로 업데이트하는 JPQL 쿼리
+        @Modifying
+        @Query("UPDATE Deck d SET d.lastAccessed = :lastAccessed WHERE d.id = :deckId")
+        void updateLastAccessed(@Param("deckId") Long deckId, @Param("lastAccessed") LocalDateTime lastAccessed);
+}

--- a/src/main/java/com/example/thirdtool/Deck/presentation/controller/DeckController.java
+++ b/src/main/java/com/example/thirdtool/Deck/presentation/controller/DeckController.java
@@ -1,0 +1,67 @@
+package com.example.thirdtool.Deck.presentation.controller;
+
+import com.example.thirdtool.Deck.application.service.DeckService;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.presentation.dto.DeckCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/decks")
+public class DeckController {
+
+    private final DeckService deckService;
+
+    //카 생성 ㅇㅇ
+    //확인 완료
+    @PostMapping
+    public ResponseEntity<Deck> createDeck(@RequestBody DeckCreateRequestDto deckRequestDto) {
+        Deck newDeck = deckService.createDeck(deckRequestDto);
+        return ResponseEntity.ok(newDeck);
+    }
+
+    // parentId가 null인 최상위 덱들을 조회하는 API
+    //확인 완료
+    @GetMapping
+    public ResponseEntity<List<Deck>> getTopLevelDecks() {
+        List<Deck> topLevelDecks = deckService.getTopLevelDecks();
+        return ResponseEntity.ok(topLevelDecks);
+    }
+    //
+    //확인 완료
+    @GetMapping("/{deckId}/sub-decks")
+    public ResponseEntity<List<Deck>> getSubDecks(@PathVariable Long deckId) {
+        List<Deck> subDecks = deckService.getSubDecks(deckId);
+        return ResponseEntity.ok(subDecks);
+    }
+
+    //최신덱 가져오기
+    @GetMapping("/recent")
+    public ResponseEntity<List<Deck>> getRecentDecks() {
+        List<Deck> recentDecks = deckService.getRecentDecks();
+
+        return ResponseEntity.ok(recentDecks);
+    }
+
+
+    //카드 삭제
+    //확인 완료
+    @DeleteMapping("/{deckId}")
+    public ResponseEntity<Void> deleteDeck(@PathVariable Long deckId) {
+        deckService.deleteDeck(deckId);
+        return ResponseEntity.noContent().build();
+    }
+
+    //확인 완료
+    @PutMapping("/{deckId}")
+    public ResponseEntity<Deck> updateDeck(@PathVariable Long deckId, @RequestBody DeckCreateRequestDto deckRequestDto) {
+        Deck updatedDeck = deckService.updateDeck(deckId, deckRequestDto);
+        return ResponseEntity.ok(updatedDeck);
+    }
+
+
+}


### PR DESCRIPTION
### **개요(작업내용)**

- DeckRepository 및 DeckController를 추가하여 덱 관련 API 기능 구현
- 최상위 덱 조회, 하위 덱 조회, 최근 학습 덱 조회, 덱 생성/수정/삭제 API 구현
- DeckRepository에 최근 학습 덱 조회 및 lastAccessed 업데이트 메서드 추가

---

### **🧾 관련 이슈**

#189

---

### **🔍 참고 사항 (선택)**

- 덱 관련 API 기능 테스트 완료
- 리포지토리명 `Eatda-Server`로 통일하는 것을 제안

---

### **🔍 깨달은 점 (선택)**

- JPQL을 활용해 lastAccessed 필드를 원자적으로 업데이트 가능
- Controller에서 Service 호출 구조를 통해 API 로직과 도메인 로직을 명확히 분리 가능
- 최근 활동 덱 조회 기능과 계층별 덱 조회 기능을 API 단에서 손쉽게 제공할 수 있음