### PR TITLE
Querydsl 초기 세팅 및 JPAQueryFactory Bean 등록

### DIFF
--- a/src/main/generated/com/example/thirdtool/Card/domain/model/QCard.java
+++ b/src/main/generated/com/example/thirdtool/Card/domain/model/QCard.java
@@ -1,0 +1,79 @@
+package com.example.thirdtool.Card.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCard is a Querydsl query type for Card
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCard extends EntityPathBase<Card> {
+
+    private static final long serialVersionUID = 29465633L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCard card = new QCard("card");
+
+    public final com.example.thirdtool.Common.QBaseEntity _super = new com.example.thirdtool.Common.QBaseEntity(this);
+
+    public final StringPath answer = createString("answer");
+
+    public final NumberPath<Integer> badCount = createNumber("badCount", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+
+    public final com.example.thirdtool.Deck.domain.model.QDeck deck;
+
+    public final NumberPath<Double> easinessFactor = createNumber("easinessFactor", Double.class);
+
+    public final NumberPath<Integer> goodCount = createNumber("goodCount", Integer.class);
+
+    public final NumberPath<Integer> greatCount = createNumber("greatCount", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<com.example.thirdtool.Deck.domain.model.DeckMode> mode = createEnum("mode", com.example.thirdtool.Deck.domain.model.DeckMode.class);
+
+    public final NumberPath<Integer> normalCount = createNumber("normalCount", Integer.class);
+
+    public final StringPath question = createString("question");
+
+    public final NumberPath<Integer> repetition = createNumber("repetition", Integer.class);
+
+    public final NumberPath<Integer> score = createNumber("score", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedDate = _super.updatedDate;
+
+    public QCard(String variable) {
+        this(Card.class, forVariable(variable), INITS);
+    }
+
+    public QCard(Path<? extends Card> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCard(PathMetadata metadata, PathInits inits) {
+        this(Card.class, metadata, inits);
+    }
+
+    public QCard(Class<? extends Card> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.deck = inits.isInitialized("deck") ? new com.example.thirdtool.Deck.domain.model.QDeck(forProperty("deck"), inits.get("deck")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/Card/domain/model/QCardRank.java
+++ b/src/main/generated/com/example/thirdtool/Card/domain/model/QCardRank.java
@@ -1,0 +1,57 @@
+package com.example.thirdtool.Card.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCardRank is a Querydsl query type for CardRank
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCardRank extends EntityPathBase<CardRank> {
+
+    private static final long serialVersionUID = -779394067L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCardRank cardRank = new QCardRank("cardRank");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> maxScore = createNumber("maxScore", Integer.class);
+
+    public final NumberPath<Integer> minScore = createNumber("minScore", Integer.class);
+
+    public final StringPath name = createString("name");
+
+    public final com.example.thirdtool.User.domain.model.QUser user;
+
+    public QCardRank(String variable) {
+        this(CardRank.class, forVariable(variable), INITS);
+    }
+
+    public QCardRank(Path<? extends CardRank> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCardRank(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCardRank(PathMetadata metadata, PathInits inits) {
+        this(CardRank.class, metadata, inits);
+    }
+
+    public QCardRank(Class<? extends CardRank> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.example.thirdtool.User.domain.model.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/Deck/domain/model/QDeck.java
+++ b/src/main/generated/com/example/thirdtool/Deck/domain/model/QDeck.java
@@ -1,0 +1,64 @@
+package com.example.thirdtool.Deck.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDeck is a Querydsl query type for Deck
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDeck extends EntityPathBase<Deck> {
+
+    private static final long serialVersionUID = -942093549L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QDeck deck = new QDeck("deck");
+
+    public final ListPath<com.example.thirdtool.Card.domain.model.Card, com.example.thirdtool.Card.domain.model.QCard> cards = this.<com.example.thirdtool.Card.domain.model.Card, com.example.thirdtool.Card.domain.model.QCard>createList("cards", com.example.thirdtool.Card.domain.model.Card.class, com.example.thirdtool.Card.domain.model.QCard.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> lastAccessed = createDateTime("lastAccessed", java.time.LocalDateTime.class);
+
+    public final StringPath name = createString("name");
+
+    public final QDeck parentDeck;
+
+    public final StringPath scoringAlgorithmType = createString("scoringAlgorithmType");
+
+    public final ListPath<Deck, QDeck> subDecks = this.<Deck, QDeck>createList("subDecks", Deck.class, QDeck.class, PathInits.DIRECT2);
+
+    public final com.example.thirdtool.User.domain.model.QUser user;
+
+    public QDeck(String variable) {
+        this(Deck.class, forVariable(variable), INITS);
+    }
+
+    public QDeck(Path<? extends Deck> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QDeck(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QDeck(PathMetadata metadata, PathInits inits) {
+        this(Deck.class, metadata, inits);
+    }
+
+    public QDeck(Class<? extends Deck> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parentDeck = inits.isInitialized("parentDeck") ? new QDeck(forProperty("parentDeck"), inits.get("parentDeck")) : null;
+        this.user = inits.isInitialized("user") ? new com.example.thirdtool.User.domain.model.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/User/domain/model/QUser.java
+++ b/src/main/generated/com/example/thirdtool/User/domain/model/QUser.java
@@ -1,0 +1,41 @@
+package com.example.thirdtool.User.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = -703863593L;
+
+    public static final QUser user = new QUser("user");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath password = createString("password");
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/thirdtool/Common/config/QuerydslConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.thirdtool.Common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
### **개요(작업내용)**

- Querydsl 초기 세팅 및 JPAQueryFactory Bean 등록
- Card, CardRank, Deck, User 도메인에 대한 Q타입 생성
- Querydsl을 활용한 타입 안전한 쿼리 작성 준비 완료

---

### **🧾 관련 이슈**

#189

---

### **🔍 참고 사항 (선택)**

- `QuerydslConfig`를 통해 `JPAQueryFactory` Bean 등록
- Q타입은 `src/main/generated` 경로에 자동 생성

---

### **🔍 깨달은 점 (선택)**

- Querydsl 초기 세팅 시 EntityManager 주입과 JPAQueryFactory Bean 등록 필수
- Q타입을 활용하면 컴파일 시점에 쿼리 검증 가능
- 향후 복잡한 조건 검색이나 동적 쿼리 작성 시 Querydsl 활용 가능