### PR TITLE
Card 엔티티 구현 및 Swagger/OpenAPI, Querydsl 초기 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+application.yml
+.env.dev
+.env.prod
+.env

--- a/src/main/generated/com/example/thirdtool/Common/QBaseEntity.java
+++ b/src/main/generated/com/example/thirdtool/Common/QBaseEntity.java
@@ -1,0 +1,39 @@
+package com.example.thirdtool.Common;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 741765335L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdDate = createDateTime("createdDate", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedDate = createDateTime("updatedDate", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/thirdtool/Card/domain/model/Card.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/model/Card.java
@@ -1,4 +1,130 @@
 package com.example.thirdtool.Card.domain.model;
 
-public class Card {
+
+import com.example.thirdtool.Common.BaseEntity;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+import com.example.thirdtool.Scoring.domain.model.ScoringAlgorithm;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "cards")
+@Entity
+public class Card extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String question; // 질문
+
+    @Column(nullable = false, length = 500)
+    private String answer; // 답변
+
+    @ColumnDefault("0")
+    private int greatCount; // GREAT 선택 횟수
+    @ColumnDefault("0")
+    private int goodCount; // GOOD 선택 횟수
+    @ColumnDefault("0")
+    private int normalCount; // NORMAL 선택 횟수
+    @ColumnDefault("0")
+    private int badCount; // BAD 선택 횟수
+
+    private int score; // SM-2의 난이도를 기반으로 하는 점수
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deck_id", nullable = false)
+    private Deck deck; // Deck 엔티티와 다대일 관계 (FK)
+
+    // ✅ SM-2 알고리즘을 위한 추가 필드
+    private int repetition; // 반복 횟수
+    private double easinessFactor; // 난이도 계수
+
+    @Enumerated(EnumType.STRING)
+    private DeckMode mode;
+
+    @Builder(builderMethodName = "internalBuilder")
+    private Card(String question, String answer, int greatCount, int goodCount,
+                 int normalCount, int badCount, int score, Deck deck, int repetition, double easinessFactor, DeckMode mode) {
+        this.question = question;
+        this.answer = answer;
+        this.greatCount = greatCount;
+        this.goodCount = goodCount;
+        this.normalCount = normalCount;
+        this.badCount = badCount;
+        this.score = score;
+        this.deck = deck;
+        this.repetition = repetition;
+        this.easinessFactor = easinessFactor;
+        this.mode = mode;
+    }
+
+    public static Card of(String question, String answer, Deck deck) {
+        return internalBuilder()
+                .question(question)
+                .answer(answer)
+                .greatCount(0)
+                .goodCount(0)
+                .normalCount(0)
+                .badCount(0)
+                .score(0)
+                .deck(deck)
+                .repetition(0)
+                .easinessFactor(2.5)
+                .mode(DeckMode.THREE_DAY)
+                .build();
+    }
+
+    // ✅ 알고리즘을 받아 점수를 업데이트하는 퍼블릭 메서드 (엔티티가 로직 수행을 위임)
+    public void updateScoreWithAlgorithm(ScoringAlgorithm algorithm, FeedbackType feedback) {
+        algorithm.updateScore(this, feedback);
+    }
+
+    // ✅ Scoring 도메인에서 호출할 상태 변경 메서드 (캡슐화 유지)
+    public void setScoreByAlgorithm(int newScore, int newRepetition, double newEasinessFactor,
+                                    int newGreatCount, int newGoodCount, int newNormalCount, int newBadCount) {
+        this.score = newScore;
+        this.repetition = newRepetition;
+        this.easinessFactor = newEasinessFactor;
+        this.greatCount = newGreatCount;
+        this.goodCount = newGoodCount;
+        this.normalCount = newNormalCount;
+        this.badCount = newBadCount;
+    }
+
+
+    public void updateMode(DeckMode deckMode) {
+        this.mode = deckMode;
+    }
+
+    public void updateCard(String question, String answer) {
+        if (question == null || question.isBlank()) {
+            throw new IllegalArgumentException("카드 질문은 비어있을 수 없습니다.");
+        }
+        if (answer == null || answer.isBlank()) {
+            throw new IllegalArgumentException("카드 답변은 비어있을 수 없습니다.");
+        }
+        this.question = question;
+        this.answer = answer;
+    }
+
+    // ✅ 새로운 점수로 학습 지표를 재설정하는 메서드
+    public void resetLearningMetrics(int newScore) {
+        this.mode = DeckMode.THREE_DAY; // 모드를 3day로 변경
+        this.score = newScore; // 원하는 점수로 설정
+        this.easinessFactor = 2.5; // 난이도 계수 초기화
+    }
 }

--- a/src/main/java/com/example/thirdtool/Common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.example.thirdtool.Common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("API Documentation")
+                                .version("1.0")
+                                .description("API documentation with JWT authentication"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .name("bearerAuth")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}


### PR DESCRIPTION
### **개요(작업내용)**

- Card 엔티티 구현 및 SM-2 학습 알고리즘 적용 필드 추가
- BaseEntity Q타입 생성 완료 (Querydsl 사용 준비)
- Swagger OpenAPI 설정 추가 (JWT 인증 포함)
- 환경 변수 파일(.env, .env.dev, .env.prod) 및 application.yml 초기 설정

---

### **🧾 관련 이슈**

#189

---

### **🔍 참고 사항 (선택)**

- Card 엔티티에 점수 계산 및 학습 지표 관리 메서드 포함
- SwaggerConfig를 통해 JWT 인증 문서화
- Querydsl QBaseEntity 생성으로 타입 안전 쿼리 준비 완료

---

### **🔍 깨달은 점 (선택)**

- 엔티티 설계 시 도메인 로직을 엔티티 내부에 위임하면 서비스 계층 단순화 가능
- Swagger 설정 시 SecurityScheme 등록으로 JWT 인증 테스트 가능
- Querydsl 초기 세팅 시 Q타입 자동 생성 경로와 Bean 등록 확인 필요