### PR TITLE
DeckMode enum 및 Deck DTO(Create/Response) 추가

### DIFF
--- a/src/main/java/com/example/thirdtool/Deck/domain/model/DeckMode.java
+++ b/src/main/java/com/example/thirdtool/Deck/domain/model/DeckMode.java
@@ -1,0 +1,6 @@
+package com.example.thirdtool.Deck.domain.model;
+
+public enum DeckMode {
+    THREE_DAY,  // 3일 모드 ->
+    PERMANENT   //
+}

--- a/src/main/java/com/example/thirdtool/Deck/presentation/dto/DeckCreateRequestDto.java
+++ b/src/main/java/com/example/thirdtool/Deck/presentation/dto/DeckCreateRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.thirdtool.Deck.presentation.dto;
+
+
+public record DeckCreateRequestDto(String name,
+                                   Long parentDeckId,
+                                   String scoringAlgorithmType) {
+    //우선
+}

--- a/src/main/java/com/example/thirdtool/Deck/presentation/dto/DeckResponseDto.java
+++ b/src/main/java/com/example/thirdtool/Deck/presentation/dto/DeckResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.thirdtool.Deck.presentation.dto;
+
+import com.example.thirdtool.Deck.domain.model.Deck;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+// 예시: DeckResponseDto.java
+public record DeckResponseDto(
+        Long id,
+        String name,
+        List<DeckResponseDto> subDecks
+) {
+    // 팩토리 메서드: 엔티티를 DTO로 변환
+    public static DeckResponseDto from(Deck deck) {
+        // 하위 덱이 있다면 재귀적으로 DTO로 변환
+        List<DeckResponseDto> subDecks = deck.getSubDecks().stream()
+                                             .map(DeckResponseDto::from)
+                                             .collect(Collectors.toList());
+        return new DeckResponseDto(deck.getId(), deck.getName(), subDecks);
+    }
+}


### PR DESCRIPTION
### **개요(작업내용)**

- Deck 도메인 모드(enum) 추가 (`DeckMode`: THREE_DAY, PERMANENT)
- Deck 생성 요청 DTO (`DeckCreateRequestDto`) 추가
- Deck 응답 DTO (`DeckResponseDto`) 추가, 재귀적으로 하위 덱 변환 지원

---

### **🧾 관련 이슈**

#192

---

### **🔍 참고 사항 (선택)**

- `DeckMode`는 학습 모드 구분용 (3일 모드 / 영구 모드)
- `DeckResponseDto`는 엔티티 → DTO 변환 시 재귀적 하위 덱 변환 가능
- `DeckCreateRequestDto`는 덱 생성 시 요청 데이터 캡슐화

---

### **🔍 깨달은 점 (선택)**

- DTO를 사용하면 Presentation 계층과 도메인 계층 분리 용이
- 재귀 변환 패턴으로 계층적 데이터 표현 가능