### PR TITLE
카드 CRUD 및 학습 API 구현

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/domain/repository/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/repository/CardRepository.java
@@ -1,0 +1,19 @@
+package com.example.thirdtool.Card.domain.repository;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CardRepository extends JpaRepository<Card, Long>,CardRepositoryCustom {
+
+    List<Card> findByDeckIdAndMode(Long deckId, DeckMode mode);
+
+    List<Card> findByDeckId(Long deckId);
+
+    // ✅ 덱 ID와 모드를 기반으로 점수가 낮은 상위 N개의 카드를 가져오는 메서드
+    List<Card> findByDeckIdAndModeOrderByScoreAsc(Long deckId, DeckMode mode, Pageable pageable);
+
+}

--- a/src/main/java/com/example/thirdtool/Card/domain/repository/CardRepositoryCustom.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/repository/CardRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.example.thirdtool.Card.domain.repository;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardRankType;
+import com.example.thirdtool.Card.presentation.dto.CardInfoDto;
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+
+import java.util.List;
+
+public interface CardRepositoryCustom {
+
+    List<CardInfoDto> findCardsByRankWithQuerydsl(Long userId, Long deckId, CardRankType rankName, DeckMode mode); // ✅ deckId 추가
+
+    // ✅ 랭크, 모드 기준으로 점수가 낮은 상위 N개의 카드를 조회하는 메서드
+    List<Card> findTopNCardsByRankAndMode(Long userId, String rankName, DeckMode mode, int count);
+}

--- a/src/main/java/com/example/thirdtool/Card/domain/repository/CardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/repository/CardRepositoryCustomImpl.java
@@ -1,0 +1,66 @@
+package com.example.thirdtool.Card.domain.repository;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardRank;
+import com.example.thirdtool.Card.domain.model.CardRankType;
+import com.example.thirdtool.Card.domain.model.QCardRank;
+import com.example.thirdtool.Card.presentation.dto.CardInfoDto;
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+import com.example.thirdtool.User.domain.model.QUser;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.thirdtool.Card.domain.model.QCard.card;
+import static com.example.thirdtool.Card.domain.model.QCardRank.cardRank;
+import static com.example.thirdtool.User.domain.model.QUser.user;
+
+@RequiredArgsConstructor
+@Repository
+public class CardRepositoryCustomImpl implements CardRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CardInfoDto> findCardsByRankWithQuerydsl(Long userId, Long deckId, CardRankType rankName, DeckMode mode) {
+        // 랭크의 점수 범위를 찾기 위한 서브쿼리
+        CardRank rankInfo = queryFactory
+                .selectFrom(cardRank)
+                .where(cardRank.user.id.eq(userId).and(cardRank.name.eq(rankName.name()))) // ✅ .name() 추가
+                .fetchOne();
+
+        if (rankInfo == null) {
+            return List.of();
+        }
+
+        // 메인 쿼리: 랭크의 점수 범위를 사용해 카드를 조회
+        BooleanExpression scoreBetween = card.score.between(rankInfo.getMinScore(), rankInfo.getMaxScore());
+        BooleanExpression deckModeEq = card.mode.eq(mode);
+        BooleanExpression deckIdEq = card.deck.id.eq(deckId);
+
+        return queryFactory
+                .select(Projections.constructor(CardInfoDto.class,
+                        card.id, card.question, card.answer, card.score, card.mode)) // ✅ score와 mode 필드 추가
+                .from(card)
+                .where(scoreBetween.and(deckModeEq).and(deckIdEq))
+                .fetch();
+    }
+
+    // ✅ 랭크, 모드 기준으로 점수가 낮은 상위 N개의 카드를 조회하는 로직
+    @Override
+    public List<Card> findTopNCardsByRankAndMode(Long userId, String rankName, DeckMode mode, int count) {
+        return queryFactory
+                .selectFrom(card)
+                .join(cardRank).on(card.score.between(cardRank.minScore, cardRank.maxScore)
+                                             .and(cardRank.user.id.eq(userId))
+                                             .and(cardRank.name.eq(rankName)))
+                .where(card.mode.eq(mode))
+                .orderBy(card.score.asc()) // 점수가 낮은 순서로 정렬
+                .limit(count) // N개만 가져오기
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/thirdtool/Card/presentation/controller/CardController.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/controller/CardController.java
@@ -1,0 +1,136 @@
+package com.example.thirdtool.Card.presentation.controller;
+
+import com.example.thirdtool.Card.application.service.CardService;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardRankType;
+import com.example.thirdtool.Card.presentation.dto.CardInfoDto;
+import com.example.thirdtool.Card.presentation.dto.FeedbackRequestDto;
+import com.example.thirdtool.Card.presentation.dto.ResetScoreRequestDto;
+import com.example.thirdtool.Card.presentation.dto.WriteCardDto;
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cards/")
+public class CardController {
+
+    private final CardService cardService;
+    //카드 단건 조회 api
+    @GetMapping("/{cardId}")
+    public ResponseEntity<Card> getCardById(@PathVariable("cardId") Long cardId) {
+        Card card = cardService.getCardById(cardId);
+        return ResponseEntity.ok().body(card);
+    }
+
+    // 덱 ID와 학습 모드에 따라 카드 목록을 조회하는 API
+    // 덱 모드는 필수입니다!
+    // GET /api/cards/decks/{deckId}?mode=THREE_DAY
+    // 초기 3day와
+    @GetMapping("/decks/{deckId}")
+    public ResponseEntity<List<Card>> getCardsByDeckAndMode(
+            @PathVariable Long deckId,
+            @RequestParam DeckMode mode
+                                                           ) {
+        List<Card> cards = cardService.getCardsByDeckIdAndMode(deckId, mode);
+        return ResponseEntity.ok(cards);
+    }
+
+    // ✅ 덱 ID를 기반으로 특정 랭크의 카드 목록을 조회하는 API
+    // GET /api/cards/by-rank?deckId=1&rankName=SILVER
+    @GetMapping("/by-rank")
+    public ResponseEntity<List<CardInfoDto>> getCardsByRank(
+            @RequestParam Long deckId, // ✅ deckId 추가
+            @RequestParam CardRankType rankName) {
+
+        Long userId = 1L; // 예시
+        // deckId를 포함하여 서비스로 전달
+        List<CardInfoDto> cards = cardService.getCardsByRank(userId, deckId, rankName);
+        return ResponseEntity.ok(cards);
+    }
+
+    //카드 가져오기 api
+    @GetMapping("/decks/{deckId}/all")
+    public ResponseEntity<List<Card>> getCardsById(@PathVariable Long deckId) {
+        List<Card> cards=cardService.getCardsByDeckId(deckId);
+        return ResponseEntity.ok(cards);
+    }
+
+    // 카드 생성 API
+    // POST /api/cards/decks/{deckId}
+    @PostMapping("/decks/{deckId}")
+    public ResponseEntity<Void> createCard(@PathVariable Long deckId,
+                                           @RequestBody WriteCardDto writeCardDto) {
+        cardService.createCard(deckId, writeCardDto);
+        return ResponseEntity.ok().build();
+    }
+    // ✅ 카드 수정 API
+    // PUT /api/cards/{cardId}
+    @PutMapping("/{cardId}")
+    public ResponseEntity<Void> updateCard(@PathVariable Long cardId,
+                                           @RequestBody WriteCardDto writeCardDto) {
+        cardService.updateCard(cardId, writeCardDto);
+        return ResponseEntity.ok().build();
+    }
+
+    // ✅ 카드 삭제 API
+    // DELETE /api/cards/{cardId}
+    @DeleteMapping("/{cardId}")
+    public ResponseEntity<Void> deleteCard(@PathVariable Long cardId) {
+        cardService.deleteCard(cardId);
+        return ResponseEntity.ok().build();
+    }
+
+
+    // 카드에 대한 학습 피드백 전달 API
+    // POST /api/cards/feedback
+    @PostMapping("/feedback")
+    public ResponseEntity<Void> giveFeedback(@RequestBody FeedbackRequestDto feedbackDto) {
+        cardService.giveFeedback(feedbackDto);
+        return ResponseEntity.ok().build();
+    }
+
+
+    // ✅ 카드 초기화 및 점수 설정 API
+    // POST /api/cards/{cardId}/reset-with-score
+    @PostMapping("/{cardId}/reset-with-score")
+    public ResponseEntity<Void> resetCardWithScore(@PathVariable Long cardId,
+                                                   @RequestBody ResetScoreRequestDto requestDto) {
+        cardService.resetCardWithScore(cardId, requestDto.newScore());
+        return ResponseEntity.ok().build();
+    }
+
+    //카드 랜덤 학습 시스템
+    @GetMapping("/decks/{deckId}/learning-session")
+    public ResponseEntity<List<Card>> getLearningSession(
+            @PathVariable Long deckId,
+            @RequestParam DeckMode mode,
+            @RequestParam(defaultValue = "10") int count) {
+
+        // Service로부터 List<Card>를 받음
+        List<Card> cards = cardService.getTopNLowScoreCardsForLearningSession(deckId, mode, count);
+
+        // JSON 배열 형태로 클라이언트에 반환
+        return ResponseEntity.ok(cards);
+    }
+
+    // ✅ 랭크, 모드, 개수 기반 학습 세션용 카드 조회 API
+    // GET /api/cards/learning-session-by-rank?rankName=SILVER&mode=THREE_DAY&count=10
+    @GetMapping("/learning-session-by-rank")
+    public ResponseEntity<List<Card>> getLearningSessionByRank(
+            @RequestParam String rankName,
+            @RequestParam DeckMode mode,
+            @RequestParam(defaultValue = "10") int count) {
+
+        // userId는 임시로 하드코딩
+        Long userId = 1L;
+
+        List<Card> cards = cardService.getTopNCardsByRankAndModeForLearning(userId, rankName, mode, count);
+        return ResponseEntity.ok(cards);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/CardInfoDto.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/CardInfoDto.java
@@ -1,0 +1,29 @@
+package com.example.thirdtool.Card.presentation.dto;
+
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter // ✅ getter를 자동으로 생성
+@NoArgsConstructor // ✅ 기본 생성자를 자동으로 생성
+@ToString
+public class CardInfoDto {
+
+    private Long id;
+    private String question;
+    private String answer;
+    private Integer score;
+    private DeckMode mode;
+
+    // ✅ 모든 필드를 포함하는 생성자 추가
+    @Builder
+    public CardInfoDto(Long id, String question, String answer, Integer score, DeckMode mode) {
+        this.id = id;
+        this.question = question;
+        this.answer = answer;
+        this.score = score;
+        this.mode = mode;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/CardRankUpdateRequestDto.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/CardRankUpdateRequestDto.java
@@ -1,0 +1,7 @@
+package com.example.thirdtool.Card.presentation.dto;
+
+public record CardRankUpdateRequestDto(
+        String name, // 수정할 랭크의 이름 (예: "SILVER")
+        int minScore,
+        int maxScore
+) {}

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/FeedbackRequestDto.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/FeedbackRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.thirdtool.Card.presentation.dto;
+
+import com.example.thirdtool.Card.domain.model.FeedbackType;
+
+public record FeedbackRequestDto(
+        Long cardId,
+        FeedbackType feedback
+) {}

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/WriteCardDto.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/WriteCardDto.java
@@ -1,0 +1,8 @@
+package com.example.thirdtool.Card.presentation.dto;
+
+public record WriteCardDto(
+        String question,
+        String answer
+) {
+
+}


### PR DESCRIPTION
# [PR] 카드 CRUD 및 학습 API 구현

### **개요(작업내용)**
- 카드 CRUD 및 학습 API 추가  
- Querydsl 기반 카드 조회/학습 로직 구현  
- DTO 추가 (`CardInfoDto`, `WriteCardDto`, `FeedbackRequestDto`, `CardRankUpdateRequestDto`)  

---

### **🧾 관련 이슈**
- #189  

---

### **🔍 참고 사항**
- 리포지토리명을 **`Eatda-Server`** 로 변경 제안  

---

### **주요 변경사항 요약**
- **CardController**  
  - 단건/목록 조회, 생성, 수정, 삭제 API  
  - 학습 세션 API (덱 기반 / 랭크 기반)  
  - 피드백 및 점수 초기화 API  

- **Repository**  
  - `findByDeckIdAndMode`, `findByDeckIdAndModeOrderByScoreAsc` 조회 메서드 추가  
  - Querydsl 기반 `CardRepositoryCustom` 구현 → 랭크/모드 조건 카드 조회  

- **DTO**  
  - `CardInfoDto`  
  - `WriteCardDto`  
  - `FeedbackRequestDto`  
  - `CardRankUpdateRequestDto`  