### PR TITLE
Feat(LearningFacade): Layer 2 세부 축 구성 및 행동 정의 도메인 구현

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -53,7 +53,13 @@ public enum ErrorCode {
     LEARNING_FACADE_NOT_FOUND("LF001",       "LearningFacade를 찾을 수 없습니다.",              HttpStatus.NOT_FOUND),
     LEARNING_FACADE_ALREADY_EXISTS("LF002",  "이미 LearningFacade가 존재합니다.",               HttpStatus.CONFLICT),
     LEARNING_FACADE_CONCEPT_BLANK("LF003",   "직업적 컨셉은 비어 있을 수 없습니다.",            HttpStatus.BAD_REQUEST),
-    LEARNING_FACADE_FORBIDDEN("LF004",       "본인의 LearningFacade가 아닙니다.",            HttpStatus.FORBIDDEN),
+    LEARNING_FACADE_FORBIDDEN("LF004",       "본인의 LearningFacade가 아닙니다.",               HttpStatus.FORBIDDEN),
+
+    // ─── LearningAxis ─────────────────────────────────────
+    LEARNING_AXIS_NOT_FOUND("LA001",              "세부 축을 찾을 수 없습니다.",                          HttpStatus.NOT_FOUND),
+    LEARNING_AXIS_NAME_BLANK("LA002",             "축 이름은 비어 있을 수 없습니다.",                     HttpStatus.BAD_REQUEST),
+    LEARNING_AXIS_NAME_DUPLICATE("LA003",         "동일한 이름의 축이 이미 존재합니다.",                  HttpStatus.CONFLICT),
+    LEARNING_AXIS_REORDER_ID_MISMATCH("LA004",    "순서 변경 id 목록이 현재 축 id 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
             // ─── 파일 / 스토리지 ──────────────────────────────────
     FILE_EMPTY("FILE001",                   "파일이 비어있습니다.",               HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
     // ─── AxisAction ───────────────────────────────────────
     LEARNING_AXIS_ACTION_NOT_FOUND("ACTION001",          "행동을 찾을 수 없습니다.",              HttpStatus.NOT_FOUND),
     LEARNING_AXIS_ACTION_DESCRIPTION_BLANK("ACTION002",  "행동 설명은 비어 있을 수 없습니다.",    HttpStatus.BAD_REQUEST),
+    LEARNING_AXIS_ACTION_DESCRIPTION_MULTI_VERB("ACTION003", "행동은 동사 하나로만 입력할 수 있습니다. 공백 없이 단일 동사로 입력해주세요.", HttpStatus.BAD_REQUEST),
 
     // ─── ActionRevision / RevisionReasonOption ────────────
     REVISION_REASON_NOT_FOUND("REVISION001", "수정 이유 선택지를 찾을 수 없거나 비활성화되어 있습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -50,16 +50,23 @@ public enum ErrorCode {
     REVIEW_SESSION_FORBIDDEN("REVIEW005", "본인의 리뷰 세션이 아닙니다.", HttpStatus.FORBIDDEN),
 
     // ─── LearningFacade ───────────────────────────────────
-    LEARNING_FACADE_NOT_FOUND("LF001",       "LearningFacade를 찾을 수 없습니다.",              HttpStatus.NOT_FOUND),
-    LEARNING_FACADE_ALREADY_EXISTS("LF002",  "이미 LearningFacade가 존재합니다.",               HttpStatus.CONFLICT),
-    LEARNING_FACADE_CONCEPT_BLANK("LF003",   "직업적 컨셉은 비어 있을 수 없습니다.",            HttpStatus.BAD_REQUEST),
-    LEARNING_FACADE_FORBIDDEN("LF004",       "본인의 LearningFacade가 아닙니다.",               HttpStatus.FORBIDDEN),
+    LEARNING_FACADE_NOT_FOUND("LF001",       "LearningFacade를 찾을 수 없습니다.",   HttpStatus.NOT_FOUND),
+    LEARNING_FACADE_ALREADY_EXISTS("LF002",  "이미 LearningFacade가 존재합니다.",    HttpStatus.CONFLICT),
+    LEARNING_FACADE_CONCEPT_BLANK("LF003",   "직업적 컨셉은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    LEARNING_FACADE_FORBIDDEN("LF004",       "본인의 LearningFacade가 아닙니다.",    HttpStatus.FORBIDDEN),
 
     // ─── LearningAxis ─────────────────────────────────────
-    LEARNING_AXIS_NOT_FOUND("LA001",              "세부 축을 찾을 수 없습니다.",                          HttpStatus.NOT_FOUND),
-    LEARNING_AXIS_NAME_BLANK("LA002",             "축 이름은 비어 있을 수 없습니다.",                     HttpStatus.BAD_REQUEST),
-    LEARNING_AXIS_NAME_DUPLICATE("LA003",         "동일한 이름의 축이 이미 존재합니다.",                  HttpStatus.CONFLICT),
-    LEARNING_AXIS_REORDER_ID_MISMATCH("LA004",    "순서 변경 id 목록이 현재 축 id 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    LEARNING_AXIS_NOT_FOUND("LA001",              "세부 축을 찾을 수 없습니다.",                             HttpStatus.NOT_FOUND),
+    LEARNING_AXIS_NAME_BLANK("LA002",             "축 이름은 비어 있을 수 없습니다.",                        HttpStatus.BAD_REQUEST),
+    LEARNING_AXIS_DUPLICATE_NAME("LA003",         "동일한 이름의 축이 이미 존재합니다.",                     HttpStatus.CONFLICT),
+    LEARNING_AXIS_REORDER_MISMATCH("LA004",       "순서 변경 id 목록이 현재 축 id 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // ─── AxisAction ───────────────────────────────────────
+    LEARNING_AXIS_ACTION_NOT_FOUND("ACTION001",          "행동을 찾을 수 없습니다.",              HttpStatus.NOT_FOUND),
+    LEARNING_AXIS_ACTION_DESCRIPTION_BLANK("ACTION002",  "행동 설명은 비어 있을 수 없습니다.",    HttpStatus.BAD_REQUEST),
+
+    // ─── ActionRevision / RevisionReasonOption ────────────
+    REVISION_REASON_NOT_FOUND("REVISION001", "수정 이유 선택지를 찾을 수 없거나 비활성화되어 있습니다.", HttpStatus.NOT_FOUND),
 
             // ─── 파일 / 스토리지 ──────────────────────────────────
     FILE_EMPTY("FILE001",                   "파일이 비어있습니다.",               HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/ActionChangeRecord.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/ActionChangeRecord.java
@@ -1,0 +1,28 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ActionChangeRecord {
+
+    private final boolean changed;
+    private final String  previousDescription;
+    private final String  newDescription;
+
+    static ActionChangeRecord changed(String previousDescription, String newDescription) {
+        return new ActionChangeRecord(true, previousDescription, newDescription);
+    }
+
+    static ActionChangeRecord unchanged(String description) {
+        return new ActionChangeRecord(false, description, description);
+    }
+
+    // ─── 행위 ─────────────────────────────────────────────
+
+    public boolean isChanged() {
+        return changed;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/ActionRevision.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/ActionRevision.java
@@ -1,0 +1,84 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "action_revision")
+public class ActionRevision {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "action_revision_id")
+    private Long id;
+
+    // ─── 소속 행동 ────────────────────────────────────────
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "axis_action_id", nullable = false, updatable = false)
+    private AxisAction action;
+
+    // ─── 수정 전후 설명 ───────────────────────────────────
+    @Column(name = "previous_description", nullable = false, length = 200, updatable = false)
+    private String previousDescription;
+
+    @Column(name = "new_description", nullable = false, length = 200, updatable = false)
+    private String newDescription;
+
+    // ─── 수정 이유 스냅샷 ─────────────────────────────────
+    @Column(name = "revision_reason_label", length = 100, updatable = false)
+    private String revisionReasonLabel;
+
+    // ─── 시각 ─────────────────────────────────────────────
+    @CreationTimestamp
+    @Column(name = "revised_at", nullable = false, updatable = false)
+    private LocalDateTime revisedAt;
+
+    private ActionRevision(AxisAction action,
+                           String previousDescription,
+                           String newDescription,
+                           String revisionReasonLabel) {
+        this.action              = action;
+        this.previousDescription = previousDescription;
+        this.newDescription      = newDescription;
+        this.revisionReasonLabel = revisionReasonLabel;
+    }
+
+    // ─── 생성 ─────────────────────────────────────────────
+
+    public static ActionRevision create(AxisAction action,
+                                        String previousDescription,
+                                        String newDescription,
+                                        String revisionReasonLabel) {
+        requireNonNull(action, "action");
+        if (previousDescription == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT, "previousDescription은(는) null일 수 없습니다.");
+        }
+        if (newDescription == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT, "newDescription은(는) null일 수 없습니다.");
+        }
+        return new ActionRevision(action, previousDescription, newDescription, revisionReasonLabel);
+    }
+
+    // ─── 내부 검증 ────────────────────────────────────────
+
+    private static void requireNonNull(Object value, String fieldName) {
+        if (value == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    fieldName + "은(는) null일 수 없습니다."
+                                                  );
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
@@ -1,0 +1,22 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "axis_action")
+public class AxisAction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "axis_action_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "learning_axis_id", nullable = false, updatable = false)
+    private LearningAxis axis;
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
@@ -36,19 +36,14 @@ public class AxisAction {
     @Column(name = "description", nullable = false, length = 200)
     private String description;
 
-    // ─── 커버리지 상태 ────────────────────────────────────
     // 학습 자료 매핑 이벤트 또는 동사 수정에 의해서만 변경된다.
     @Enumerated(EnumType.STRING)
     @Column(name = "coverage_status", nullable = false, length = 20)
     private CoverageStatus coverageStatus;
 
-    // ─── 수정 횟수 ────────────────────────────────────────
-    // 동일 값 재입력 시 증가하지 않는다.
     @Column(name = "revision_count", nullable = false)
     private int revisionCount;
 
-    // ─── 수정 이력 ────────────────────────────────────────
-    // 행동 삭제 시 orphanRemoval로 함께 삭제된다.
     @OneToMany(
             mappedBy      = "action",
             cascade       = CascadeType.ALL,
@@ -72,11 +67,6 @@ public class AxisAction {
 
     // ─── 생성 ─────────────────────────────────────────────
 
-    /**
-     * 행동을 생성한다. {@link LearningAxis#addAction(String)} 내부에서만 호출한다.
-     *
-     * <p>커버리지는 {@link CoverageStatus#NO_MATERIAL}로, {@code revisionCount}는 0으로 초기화된다.
-     */
     static AxisAction create(LearningAxis axis, String description) {
         requireNonNull(axis, "axis");
         validateDescription(description);
@@ -85,21 +75,6 @@ public class AxisAction {
 
     // ─── 행위 ─────────────────────────────────────────────
 
-    /**
-     * 행동 설명(동사)을 변경한다.
-     *
-     * <p>기존 값과 동일한 경우 상태를 변경하지 않고 {@code unchanged} 결과를 반환한다.
-     * 커버리지 초기화와 {@code revisionCount} 증가도 발생하지 않는다.
-     *
-     * <p>실제 변경이 발생하면:
-     * <ul>
-     *   <li>커버리지를 {@link CoverageStatus#NO_MATERIAL}로 초기화한다.</li>
-     *   <li>{@code revisionCount}를 1 증가시킨다.</li>
-     * </ul>
-     *
-     * @return 수정 결과를 담은 {@link ActionChangeRecord}.
-     *         Application Service는 이 객체로 이력 생성 여부와 저장 실행 여부를 판단한다.
-     */
     public ActionChangeRecord updateDescription(String newDescription) {
         validateDescription(newDescription);
         String trimmed = newDescription.trim();
@@ -115,12 +90,6 @@ public class AxisAction {
         return ActionChangeRecord.changed(previous, this.description);
     }
 
-    /**
-     * 커버리지 상태를 변경한다.
-     *
-     * <p>학습 자료 매핑 이벤트에 의해서만 호출된다.
-     * Application Service가 직접 호출하지 않는다.
-     */
     void updateCoverageStatus(CoverageStatus status) {
         requireNonNull(status, "coverageStatus");
         this.coverageStatus = status;
@@ -128,11 +97,6 @@ public class AxisAction {
 
     // ─── 보조 조회 ────────────────────────────────────────
 
-    /**
-     * 수정 횟수가 임계값({@value REFINEMENT_THRESHOLD}) 이상이면 {@code true}를 반환한다.
-     *
-     * <p>Application Service가 "이 행동이 아직 단련 중이에요" 안내 플래그로 사용한다.
-     */
     public boolean isRefinementSuggested() {
         return revisionCount >= REFINEMENT_THRESHOLD;
     }

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
@@ -13,6 +13,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * 축({@link LearningAxis}) 아래에 위치하는 구체적인 학습 행동.
+ *
+ * <p>AxisAction은 인터페이스의 메서드 시그니처와 같다.
+ * "무엇을 하는가"만 단일 동사로 선언하고, "어떻게 하는가"는 유저의 구현에 맡긴다.
+ * 예: "설계하다", "문서화하다", "검증하다"
+ *
+ * <p><b>단일 동사 원칙</b>: {@code description}에 공백이 포함되면 예외를 발생시킨다.
+ * "설계하다"는 허용, "설계하고 분석하다"는 불허.
+ *
+ * <p>외부에서 직접 생성하지 않는다. 반드시 {@link LearningAxis#addAction(String)}을 통해 생성한다.
+ */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -21,21 +33,22 @@ public class AxisAction {
 
     private static final int REFINEMENT_THRESHOLD = 3;
 
-    // ─── 식별자 ───────────────────────────────────────────
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "axis_action_id")
     private Long id;
 
-    // ─── 소속 축 ──────────────────────────────────────────
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "learning_axis_id", nullable = false, updatable = false)
     private LearningAxis axis;
 
-    // ─── 행동 설명 ────────────────────────────────────────
-    @Column(name = "description", nullable = false, length = 200)
+    // ─── 행동 동사 ────────────────────────────────────────
+    // 단일 동사 하나로만 구성한다. 공백 포함 시 도메인이 예외를 발생시킨다. - 중요 규칙
+    // 동사형 어미("하다") 여부는 Application Service의 VerbFormValidator가 안내 플래그로 감지한다.
+    @Column(name = "description", nullable = false, length = 50)
     private String description;
 
+    // ─── 커버리지 상태 ────────────────────────────────────
     // 학습 자료 매핑 이벤트 또는 동사 수정에 의해서만 변경된다.
     @Enumerated(EnumType.STRING)
     @Column(name = "coverage_status", nullable = false, length = 20)
@@ -85,11 +98,16 @@ public class AxisAction {
 
         String previous     = this.description;
         this.description    = trimmed;
-        this.coverageStatus = CoverageStatus.NO_MATERIAL; // 커버리지 초기화
-        this.revisionCount++;                              // 수정 횟수 누적
+        this.coverageStatus = CoverageStatus.NO_MATERIAL; // 동사 바뀌면 커버리지 초기화
+        this.revisionCount++;
         return ActionChangeRecord.changed(previous, this.description);
     }
 
+    /**
+     * 커버리지 상태를 변경한다.
+     *
+     * <p>학습 자료 매핑 이벤트에 의해서만 호출된다. package-private.
+     */
     void updateCoverageStatus(CoverageStatus status) {
         requireNonNull(status, "coverageStatus");
         this.coverageStatus = status;
@@ -97,6 +115,11 @@ public class AxisAction {
 
     // ─── 보조 조회 ────────────────────────────────────────
 
+    /**
+     * 수정 횟수가 임계값({@value REFINEMENT_THRESHOLD}) 이상이면 {@code true}를 반환한다.
+     *
+     * <p>Application Service가 "이 행동이 아직 단련 중이에요" 안내 플래그로 사용한다.
+     */
     public boolean isRefinementSuggested() {
         return revisionCount >= REFINEMENT_THRESHOLD;
     }
@@ -109,7 +132,16 @@ public class AxisAction {
 
     private static void validateDescription(String description) {
         if (description == null || description.isBlank()) {
-            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_ACTION_DESCRIPTION_BLANK);
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_AXIS_ACTION_DESCRIPTION_BLANK
+                                                  );
+        }
+        // 단일 동사 원칙: 공백이 포함되면 복수 동사로 간주해 차단한다. - 추후 추가 업그레이드 예정
+        // trim 이전에 검사한다. 앞뒤 공백은 trim으로 허용하되, 중간 공백은 불허.
+        if (description.trim().contains(" ")) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_AXIS_ACTION_DESCRIPTION_MULTI_VERB
+                                                  );
         }
     }
 

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisAction.java
@@ -1,9 +1,17 @@
 package com.example.thirdtool.LearningFacade.domain.model;
 
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,12 +19,142 @@ import lombok.NoArgsConstructor;
 @Table(name = "axis_action")
 public class AxisAction {
 
+    private static final int REFINEMENT_THRESHOLD = 3;
+
+    // ─── 식별자 ───────────────────────────────────────────
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "axis_action_id")
     private Long id;
 
+    // ─── 소속 축 ──────────────────────────────────────────
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "learning_axis_id", nullable = false, updatable = false)
     private LearningAxis axis;
+
+    // ─── 행동 설명 ────────────────────────────────────────
+    @Column(name = "description", nullable = false, length = 200)
+    private String description;
+
+    // ─── 커버리지 상태 ────────────────────────────────────
+    // 학습 자료 매핑 이벤트 또는 동사 수정에 의해서만 변경된다.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "coverage_status", nullable = false, length = 20)
+    private CoverageStatus coverageStatus;
+
+    // ─── 수정 횟수 ────────────────────────────────────────
+    // 동일 값 재입력 시 증가하지 않는다.
+    @Column(name = "revision_count", nullable = false)
+    private int revisionCount;
+
+    // ─── 수정 이력 ────────────────────────────────────────
+    // 행동 삭제 시 orphanRemoval로 함께 삭제된다.
+    @OneToMany(
+            mappedBy      = "action",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch         = FetchType.LAZY
+    )
+    private final List<ActionRevision> revisions = new ArrayList<>();
+
+    // ─── 시각 ─────────────────────────────────────────────
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** create() 내부 전용 생성자. */
+    private AxisAction(LearningAxis axis, String description) {
+        this.axis           = axis;
+        this.description    = description;
+        this.coverageStatus = CoverageStatus.NO_MATERIAL;
+        this.revisionCount  = 0;
+    }
+
+    // ─── 생성 ─────────────────────────────────────────────
+
+    /**
+     * 행동을 생성한다. {@link LearningAxis#addAction(String)} 내부에서만 호출한다.
+     *
+     * <p>커버리지는 {@link CoverageStatus#NO_MATERIAL}로, {@code revisionCount}는 0으로 초기화된다.
+     */
+    static AxisAction create(LearningAxis axis, String description) {
+        requireNonNull(axis, "axis");
+        validateDescription(description);
+        return new AxisAction(axis, description.trim());
+    }
+
+    // ─── 행위 ─────────────────────────────────────────────
+
+    /**
+     * 행동 설명(동사)을 변경한다.
+     *
+     * <p>기존 값과 동일한 경우 상태를 변경하지 않고 {@code unchanged} 결과를 반환한다.
+     * 커버리지 초기화와 {@code revisionCount} 증가도 발생하지 않는다.
+     *
+     * <p>실제 변경이 발생하면:
+     * <ul>
+     *   <li>커버리지를 {@link CoverageStatus#NO_MATERIAL}로 초기화한다.</li>
+     *   <li>{@code revisionCount}를 1 증가시킨다.</li>
+     * </ul>
+     *
+     * @return 수정 결과를 담은 {@link ActionChangeRecord}.
+     *         Application Service는 이 객체로 이력 생성 여부와 저장 실행 여부를 판단한다.
+     */
+    public ActionChangeRecord updateDescription(String newDescription) {
+        validateDescription(newDescription);
+        String trimmed = newDescription.trim();
+
+        if (this.description.equals(trimmed)) {
+            return ActionChangeRecord.unchanged(this.description); // 동일 값 — 변경 없음
+        }
+
+        String previous     = this.description;
+        this.description    = trimmed;
+        this.coverageStatus = CoverageStatus.NO_MATERIAL; // 커버리지 초기화
+        this.revisionCount++;                              // 수정 횟수 누적
+        return ActionChangeRecord.changed(previous, this.description);
+    }
+
+    /**
+     * 커버리지 상태를 변경한다.
+     *
+     * <p>학습 자료 매핑 이벤트에 의해서만 호출된다.
+     * Application Service가 직접 호출하지 않는다.
+     */
+    void updateCoverageStatus(CoverageStatus status) {
+        requireNonNull(status, "coverageStatus");
+        this.coverageStatus = status;
+    }
+
+    // ─── 보조 조회 ────────────────────────────────────────
+
+    /**
+     * 수정 횟수가 임계값({@value REFINEMENT_THRESHOLD}) 이상이면 {@code true}를 반환한다.
+     *
+     * <p>Application Service가 "이 행동이 아직 단련 중이에요" 안내 플래그로 사용한다.
+     */
+    public boolean isRefinementSuggested() {
+        return revisionCount >= REFINEMENT_THRESHOLD;
+    }
+
+    public List<ActionRevision> getRevisions() {
+        return Collections.unmodifiableList(revisions);
+    }
+
+    // ─── 내부 검증 ────────────────────────────────────────
+
+    private static void validateDescription(String description) {
+        if (description == null || description.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_ACTION_DESCRIPTION_BLANK);
+        }
+    }
+
+    private static void requireNonNull(Object value, String fieldName) {
+        if (value == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    fieldName + "은(는) null일 수 없습니다."
+                                                  );
+        }
+    }
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/CoverageStatus.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/CoverageStatus.java
@@ -1,8 +1,21 @@
 package com.example.thirdtool.LearningFacade.domain.model;
 
-public enum CoverageStatus {
-    NO_MATERIAL,
-    PARTIAL,
-    COVERED
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
+public enum CoverageStatus {
+
+    NO_MATERIAL("⚠️ 자료 없음",
+            "연결된 학습 자료가 없는 초기 상태. 행동 동사 수정 시에도 이 상태로 초기화된다."),
+
+    PARTIAL("🔵 일부 커버",
+            "자료가 1개 이상 연결되어 있으나 충분하지 않다고 판단되는 상태. 기준은 v2에서 정의한다."),
+
+    COVERED("✅ 커버됨",
+            "자료가 충분히 연결된 상태. 전환 기준은 v2에서 정의한다.");
+
+    private final String displayName;
+    private final String description;
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/CoverageStatus.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/CoverageStatus.java
@@ -1,0 +1,8 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+public enum CoverageStatus {
+    NO_MATERIAL,
+    PARTIAL,
+    COVERED
+
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -68,10 +68,6 @@ public class LearningAxis {
 
     // ─── 생성 ─────────────────────────────────────────────
 
-    /**
-     * 축을 생성한다.
-     * {@link LearningFacade#addAxis(String)} 내부에서만 호출한다.
-     */
     static LearningAxis create(LearningFacade facade, String name, int displayOrder) {
         requireNonNull(facade, "facade");
         validateName(name);

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -44,8 +43,7 @@ public class LearningAxis {
     private int displayOrder;
 
     // ─── 행동 목록 ────────────────────────────────────────
-    // 축 삭제 시 orphanRemoval로 함께 삭제된다.
-    // AxisAction은 Epic 2 Story 2-2에서 추가 예정
+
     @OneToMany(
             mappedBy      = "axis",
             cascade       = CascadeType.ALL,
@@ -59,7 +57,6 @@ public class LearningAxis {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    /** create() 내부 전용 생성자. */
     private LearningAxis(LearningFacade facade, String name, int displayOrder) {
         this.facade       = facade;
         this.name         = name;
@@ -97,10 +94,33 @@ public class LearningAxis {
         this.displayOrder = newOrder;
     }
 
+    public AxisAction addAction(String description) {
+        AxisAction action = AxisAction.create(this, description);
+        actions.add(action);
+        return action;
+    }
+
+    public void removeAction(Long actionId) {
+        AxisAction target = findAction(actionId);
+        actions.remove(target);
+    }
+
     // ─── 조회 ─────────────────────────────────────────────
 
     public List<AxisAction> getActions() {
         return Collections.unmodifiableList(actions);
+    }
+
+    // ─── 내부 유틸 ────────────────────────────────────────
+
+    AxisAction findAction(Long actionId) {
+        return actions.stream()
+                      .filter(a -> a.getId().equals(actionId))
+                      .findFirst()
+                      .orElseThrow(() -> LearningFacadeDomainException.of(
+                              ErrorCode.LEARNING_AXIS_ACTION_NOT_FOUND,
+                              "actionId=" + actionId
+                                                                         ));
     }
 
     // ─── 내부 검증 ────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -1,0 +1,126 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "learning_axis",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_learning_axis_facade_name",
+                columnNames = {"learning_facade_id", "name"}
+        )
+)
+public class LearningAxis {
+
+    // ─── 식별자 ───────────────────────────────────────────
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "learning_axis_id")
+    private Long id;
+
+    // ─── 소속 Facade ──────────────────────────────────────
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "learning_facade_id", nullable = false, updatable = false)
+    private LearningFacade facade;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    // ─── 행동 목록 ────────────────────────────────────────
+    // 축 삭제 시 orphanRemoval로 함께 삭제된다.
+    // AxisAction은 Epic 2 Story 2-2에서 추가 예정
+    @OneToMany(
+            mappedBy      = "axis",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch         = FetchType.LAZY
+    )
+    private final List<AxisAction> actions = new ArrayList<>();
+
+    // ─── 시각 ─────────────────────────────────────────────
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** create() 내부 전용 생성자. */
+    private LearningAxis(LearningFacade facade, String name, int displayOrder) {
+        this.facade       = facade;
+        this.name         = name;
+        this.displayOrder = displayOrder;
+    }
+
+    // ─── 생성 ─────────────────────────────────────────────
+
+    /**
+     * 축을 생성한다.
+     * {@link LearningFacade#addAxis(String)} 내부에서만 호출한다.
+     */
+    static LearningAxis create(LearningFacade facade, String name, int displayOrder) {
+        requireNonNull(facade, "facade");
+        validateName(name);
+        if (displayOrder < 0) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 0 이상이어야 합니다. displayOrder=" + displayOrder
+                                                  );
+        }
+        return new LearningAxis(facade, name.trim(), displayOrder);
+    }
+
+    // ─── 행위 ─────────────────────────────────────────────
+
+    public void updateName(String newName) {
+        validateName(newName);
+        this.name = newName.trim();
+    }
+
+    void updateDisplayOrder(int newOrder) {
+        if (newOrder < 0) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 0 이상이어야 합니다. newOrder=" + newOrder
+                                                  );
+        }
+        this.displayOrder = newOrder;
+    }
+
+    // ─── 조회 ─────────────────────────────────────────────
+
+    public List<AxisAction> getActions() {
+        return Collections.unmodifiableList(actions);
+    }
+
+    // ─── 내부 검증 ────────────────────────────────────────
+
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_NAME_BLANK);
+        }
+    }
+
+    private static void requireNonNull(Object value, String fieldName) {
+        if (value == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    fieldName + "은(는) null일 수 없습니다."
+                                                  );
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -11,12 +11,20 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "learning_facade")
 public class LearningFacade {
+
+    private static final int RECOMMENDED_AXIS_LIMIT = 5;
 
     // ─── 식별자 ───────────────────────────────────────────
     @Id
@@ -29,9 +37,18 @@ public class LearningFacade {
     @JoinColumn(name = "user_id", nullable = false, updatable = false)
     private UserEntity user;
 
-    // ─── 직업적 컨셉 ──────────────────────────────────────
     @Column(name = "concept", nullable = false, length = 100)
     private String concept;
+
+    // ─── 세부 축 목록 ─────────────────────────────────────
+    @OneToMany(
+            mappedBy      = "facade",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("displayOrder ASC")
+    private final List<LearningAxis> axes = new ArrayList<>();
 
     // ─── 시각 ─────────────────────────────────────────────
     @CreationTimestamp
@@ -52,7 +69,6 @@ public class LearningFacade {
     public static LearningFacade create(UserEntity user, String concept) {
         requireNonNull(user, "user");
         validateConcept(concept);
-
         return new LearningFacade(user, concept.trim());
     }
 
@@ -62,21 +78,93 @@ public class LearningFacade {
         validateConcept(newConcept);
 
         String trimmed = newConcept.trim();
-
         if (this.concept.equals(trimmed)) {
-            return ConceptChangeRecord.unchanged(this.concept); // 동일 값 — 변경 없음
+            return ConceptChangeRecord.unchanged(this.concept);
         }
 
         String previous = this.concept;
-        this.concept    = trimmed;
+        this.concept = trimmed;
         return ConceptChangeRecord.changed(previous, this.concept);
+    }
+
+    public LearningAxis addAxis(String name) {
+        validateAxisNameDuplicate(name);
+
+        int nextOrder = axes.size(); // 0-based: 현재 크기가 곧 다음 인덱스
+        LearningAxis axis = LearningAxis.create(this, name, nextOrder);
+        axes.add(axis);
+        return axis;
+    }
+
+    public void removeAxis(Long axisId) {
+        LearningAxis target = findAxis(axisId);
+        axes.remove(target);
+    }
+
+    public void reorderAxes(List<Long> orderedAxisIds) {
+        validateReorderIds(orderedAxisIds);
+
+        IntStream.range(0, orderedAxisIds.size()).forEach(i -> {
+            LearningAxis axis = findAxis(orderedAxisIds.get(i));
+            axis.updateDisplayOrder(i);
+        });
     }
 
     public boolean isOwnedBy(Long userId) {
         return this.user.getId().equals(userId);
     }
 
+    // ─── 보조 조회 ────────────────────────────────────────
+
+    public boolean isAxisCountExceedsRecommended() {
+        return axes.size() > RECOMMENDED_AXIS_LIMIT;
+    }
+
+    public List<LearningAxis> getAxes() {
+        return Collections.unmodifiableList(axes);
+    }
+
+    // ─── 내부 유틸 ────────────────────────────────────────
+
+    LearningAxis findAxis(Long axisId) {
+        return axes.stream()
+                   .filter(a -> a.getId().equals(axisId))
+                   .findFirst()
+                   .orElseThrow(() -> LearningFacadeDomainException.of(
+                           ErrorCode.LEARNING_AXIS_NOT_FOUND,
+                           "axisId=" + axisId
+                                                                      ));
+    }
+
     // ─── 내부 검증 ────────────────────────────────────────
+
+    private void validateAxisNameDuplicate(String name) {
+        if (name == null) return; // validateName이 이후에 처리
+
+        String trimmed = name.trim();
+        boolean duplicated = axes.stream()
+                                 .anyMatch(a -> a.getName().equals(trimmed));
+        if (duplicated) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_AXIS_DUPLICATE_NAME,
+                    "name=" + trimmed
+                                                  );
+        }
+    }
+
+    private void validateReorderIds(List<Long> orderedAxisIds) {
+        Set<Long> currentIds = axes.stream()
+                                   .map(LearningAxis::getId)
+                                   .collect(Collectors.toSet());
+        Set<Long> incomingIds = Set.copyOf(orderedAxisIds);
+
+        if (!currentIds.equals(incomingIds)) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_AXIS_REORDER_MISMATCH,
+                    "전달된 축 id 목록이 현재 axes id 집합과 일치하지 않습니다."
+                                                  );
+        }
+    }
 
     private static void validateConcept(String concept) {
         if (concept == null || concept.isBlank()) {


### PR DESCRIPTION
# feat(LearningFacade): Layer 2 세부 축 구성 및 행동 정의 도메인 구현

## 개요

LearningFacade BC의 핵심 도메인 모델을 구현한다.
`LearningAxis`, `AxisAction`, `ActionRevision`, `CoverageStatus`, `ActionChangeRecord`를 포함하며,
행동 동사 수정 이력 추적과 커버리지 상태 관리까지 다룬다.

## 연관 이슈

- close #106  (Layer 2 세부 축 구성)
- ref #xx (AxisAction 행동 정의 및 동사 수정)

---

## 배경 및 문제

**1. AxisAction의 동사 범위 문제**

행동을 자유 텍스트로 받으면 "설계하고 분석하다"처럼 복수 책임이 하나의 행동에 묶인다.
이 경우 커버리지 판단 기준이 모호해지고, 학습 자료와의 매핑 단위도 불명확해진다.

**2. 동사 수정 시 커버리지 일관성 문제**

동사가 바뀌면 기존에 연결된 자료가 새 행동을 여전히 뒷받침하는지 보장할 수 없다.
수정 후 커버리지를 그대로 유지하면 유저는 자료 재검토 없이 넘어갈 수 있다.

**3. 동사 수정 결과를 호출부에서 판단해야 하는 문제**

`updateDescription()`이 `void`를 반환하면 Application Service가
"실제로 변경이 일어났는가"를 직접 추적해야 한다.
저장 쿼리 발생 여부와 이력 생성 여부를 호출부가 별도로 관리하게 되어 책임이 분산된다.

---

## 해결 방법

**단일 동사 원칙 — 도메인 강제**

`AxisAction.validateDescription()`에서 `description.trim().contains(" ")` 검사로
공백이 포함된 입력을 차단한다.

동사 형식("하다" 어미 여부)은 도메인이 강제하지 않고 App Service의 `VerbFormValidator`가
안내 플래그로만 전달한다.
"무엇을 포함하면 안 되는가"는 도메인 규칙, "어떻게 끝나야 하는가"는 언어 처리 규칙으로 분리했다.

**동사 수정 시 커버리지 자동 초기화**

`updateDescription()` 내부에서 실제 변경이 발생하면 `coverageStatus`를 `NO_MATERIAL`로
초기화하고 `revisionCount`를 증가시킨다.
동일 값 입력 시에는 아무것도 변경하지 않는다.

**ActionChangeRecord 도입 — ConceptChangeRecord와 동일 패턴**

`updateDescription()`이 `ActionChangeRecord`를 반환하도록 변경했다.
Application Service는 `record.isChanged()`로 저장 실행 여부와 이력 생성 여부를 단일 결과로 판단한다.
`ConceptChangeRecord`와 동일한 패턴을 유지해 도메인 전반의 수정 결과 표현 방식을 통일했다.

---

## 트레이드오프

| 결정 | 선택 | 포기한 것 |
|---|---|---|
| 단일 동사 강제 | 공백 기준으로 도메인이 차단 | "API를 설계하다" 같은 목적어 포함 표현 불허 |
| 동사 수정 시 커버리지 초기화 | 자료 재검토 유도 | 자료가 많을 경우 유저 재작업 부담 |
| ActionChangeRecord 반환 | 호출부 판단 단순화 | void보다 반환 타입이 복잡해짐 |

단일 동사 강제에서 목적어 포함 표현을 포기한 이유는,
AxisAction을 인터페이스의 메서드 시그니처처럼 "무엇을 하는가"만 선언하는 단위로 설계하기 때문이다.
"API를 설계하다"의 "API"는 구현 맥락이며, 행동의 본질은 "설계하다"다.

---

## 완료 조건

- [x] `LearningFacade` — `addAxis`, `removeAxis`, `reorderAxes`, `findAxis` 구현
- [x] `LearningAxis` — `addAction`, `removeAction`, `findAction` 구현
- [x] `AxisAction` — 단일 동사 검증, `updateDescription` (ActionChangeRecord 반환), `isRefinementSuggested`
- [x] `CoverageStatus` — `displayName`, `description` 필드 포함 enum
- [x] `ActionChangeRecord` — `changed` / `unchanged` 팩토리, `isChanged()`
- [x] `ActionRevision` — 불변 이력 엔티티, `revisionReasonLabel` 스냅샷
- [x] `ErrorCode` — `LA001~004`, `ACTION001~003`, `REVISION001` 추가