### PR TITLE
Feat(LearningFacade): 수정 이유 기록 및 이력 조회

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisTopic.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisTopic.java
@@ -17,6 +17,13 @@ import java.time.LocalDateTime;
 @Table(name = "axis_topic")
 public class AxisTopic {
 
+    /**
+     * 주제가 "단련 중"으로 간주되는 이름 수정 횟수 임계값.
+     * 이 값 이상이면 {@link #isRefinementSuggested()}가 true를 반환한다.
+     * 운영 중 동적 조정이 필요해지면 Admin BC 시스템 설정으로 이관한다.
+     */
+    public static final int REFINEMENT_THRESHOLD = 3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "axis_topic_id")
@@ -39,6 +46,13 @@ public class AxisTopic {
     @Column(name = "coverage_status", nullable = false, length = 20)
     private CoverageStatus coverageStatus;
 
+    /**
+     * 이름 수정 누적 횟수. 생성 시 0. {@link #updateName(String)}이 실제 변경을 일으킬 때마다 +1.
+     * 동일 값(trim 후 같은 값) 입력 또는 description 단독 수정 시 증가하지 않는다.
+     */
+    @Column(name = "revision_count", nullable = false)
+    private int revisionCount;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -53,6 +67,7 @@ public class AxisTopic {
         this.description    = description;
         this.displayOrder   = displayOrder;
         this.coverageStatus = CoverageStatus.NO_MATERIAL;
+        this.revisionCount  = 0;
     }
 
     static AxisTopic create(LearningAxis axis, String name, String description, int displayOrder) {
@@ -69,6 +84,7 @@ public class AxisTopic {
 
     /**
      * 이름을 갱신한다. 동일 값(trim 후)이 들어오면 상태를 바꾸지 않고 {@code false}를 반환한다.
+     * 실제 변경이 발생한 경우에만 {@code revisionCount}를 1 증가시킨다.
      */
     public boolean updateName(String newName) {
         validateName(newName);
@@ -77,7 +93,16 @@ public class AxisTopic {
             return false;
         }
         this.name = trimmed;
+        this.revisionCount++;
         return true;
+    }
+
+    /**
+     * 이름 수정 누적 횟수가 임계값(REFINEMENT_THRESHOLD) 이상인지 여부.
+     * Application Service가 응답에 안내 플래그로 포함한다 (UX는 강제가 아닌 안내).
+     */
+    public boolean isRefinementSuggested() {
+        return this.revisionCount >= REFINEMENT_THRESHOLD;
     }
 
     /**

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
@@ -267,6 +267,8 @@ public class LearningFacadeResponse {
             String description,
             int displayOrder,
             String coverageStatus,
+            int revisionCount,
+            boolean isRefinementSuggested,
             LocalDateTime updatedAt
     ) {
         public static UpdateTopic of(AxisTopic topic) {
@@ -277,6 +279,8 @@ public class LearningFacadeResponse {
                     topic.getDescription(),
                     topic.getDisplayOrder(),
                     topic.getCoverageStatus().name(),
+                    topic.getRevisionCount(),
+                    topic.isRefinementSuggested(),
                     topic.getUpdatedAt()
             );
         }

--- a/src/main/resources/db/migration/V4__axis_topic_revision_count.sql
+++ b/src/main/resources/db/migration/V4__axis_topic_revision_count.sql
@@ -1,0 +1,18 @@
+-- =============================================================
+-- V4__axis_topic_revision_count.sql
+-- Epic-003 Story-003-3: 주제 이름 수정 누적 횟수(revisionCount) 컬럼 추가
+-- - AxisTopic.updateName()이 실제 변경 시 +1 (동일 값·설명 단독 수정 미증가)
+-- - REFINEMENT_THRESHOLD(=3) 도달 시 isRefinementSuggested = true
+-- - db-conventions.md §8 정합: 컬럼 추가 + NOT NULL 전환은 3단계
+-- =============================================================
+
+-- 1. NULL 허용 + DEFAULT 0으로 컬럼 추가
+ALTER TABLE axis_topic
+    ADD COLUMN revision_count INT DEFAULT 0;
+
+-- 2. 기존 행 백필 (DEFAULT가 처리하지만 명시적 보장)
+UPDATE axis_topic SET revision_count = 0 WHERE revision_count IS NULL;
+
+-- 3. NOT NULL 전환
+ALTER TABLE axis_topic
+    MODIFY COLUMN revision_count INT NOT NULL DEFAULT 0;

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceUpdateTopicTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceUpdateTopicTest.java
@@ -148,4 +148,37 @@ class LearningFacadeCommandServiceUpdateTopicTest {
             verify(topicRevisionRepository, never()).save(any());
         }
     }
+
+    @Nested
+    @DisplayName("isRefinementSuggested 플래그 응답 (Story-003-3)")
+    class RefinementFlagInResponse {
+
+        @Test
+        @DisplayName("revisionCount=0 신규 주제는 응답에 isRefinementSuggested=false")
+        void noChange_flag_false() {
+            var response = service.updateTopic(user, 10L, 100L,
+                    command("REST API 설계 원칙", null));   // 동일 값 → 미증가
+            assertThat(response.revisionCount()).isZero();
+            assertThat(response.isRefinementSuggested()).isFalse();
+        }
+
+        @Test
+        @DisplayName("이름 1회 변경 후 응답 revisionCount=1, isRefinementSuggested=false")
+        void changed_once_flag_false() {
+            var response = service.updateTopic(user, 10L, 100L,
+                    command("API 명세 작성", null));
+            assertThat(response.revisionCount()).isEqualTo(1);
+            assertThat(response.isRefinementSuggested()).isFalse();
+        }
+
+        @Test
+        @DisplayName("이름 3회 누적 변경 후 응답 isRefinementSuggested=true (임계값 도달)")
+        void changed_three_times_flag_true() {
+            service.updateTopic(user, 10L, 100L, command("v1", null));
+            service.updateTopic(user, 10L, 100L, command("v2", null));
+            var response = service.updateTopic(user, 10L, 100L, command("v3", null));
+            assertThat(response.revisionCount()).isEqualTo(3);
+            assertThat(response.isRefinementSuggested()).isTrue();
+        }
+    }
 }

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisTopicTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisTopicTest.java
@@ -205,4 +205,89 @@ class AxisTopicTest {
             assertThat(last.isFocused(3)).isFalse();
         }
     }
+
+    @Nested
+    @DisplayName("revisionCount (Story-003-3)")
+    class RevisionCount {
+
+        @Test
+        @DisplayName("생성 직후 revisionCount는 0")
+        void createInitialRevisionCount() {
+            AxisTopic topic = createTopic();
+            assertThat(topic.getRevisionCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("이름이 실제로 변경되면 revisionCount가 1 증가한다")
+        void updateName_changed_increments() {
+            AxisTopic topic = createTopic();
+            topic.updateName("API 명세 작성");
+            assertThat(topic.getRevisionCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("동일 값(trim 후) 입력 시 revisionCount는 증가하지 않는다 (멱등)")
+        void updateName_same_value_no_increment() {
+            AxisTopic topic = createTopic();
+            topic.updateName("  REST API 설계 원칙  ");
+            assertThat(topic.getRevisionCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("description 단독 수정 시 revisionCount는 증가하지 않는다 (이름 변경만 카운트)")
+        void updateDescription_only_no_increment() {
+            AxisTopic topic = createTopic();
+            topic.updateDescription("새 설명");
+            assertThat(topic.getRevisionCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("이름이 여러 번 변경되면 revisionCount가 누적된다")
+        void updateName_multiple_increments() {
+            AxisTopic topic = createTopic();
+            topic.updateName("API 명세 작성");
+            topic.updateName("OpenAPI 작성");
+            topic.updateName("REST 설계 가이드");
+            assertThat(topic.getRevisionCount()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("isRefinementSuggested (Story-003-3)")
+    class IsRefinementSuggested {
+
+        @Test
+        @DisplayName("revisionCount = 0 (신규 주제)이면 false")
+        void newTopic_false() {
+            AxisTopic topic = createTopic();
+            assertThat(topic.isRefinementSuggested()).isFalse();
+        }
+
+        @Test
+        @DisplayName("경계값: revisionCount = 2 → false (임계값 직전)")
+        void boundary_2_false() {
+            AxisTopic topic = createTopic();
+            topic.updateName("v1");
+            topic.updateName("v2");
+            assertThat(topic.getRevisionCount()).isEqualTo(2);
+            assertThat(topic.isRefinementSuggested()).isFalse();
+        }
+
+        @Test
+        @DisplayName("경계값: revisionCount = 3 → true (임계값 도달)")
+        void boundary_3_true() {
+            AxisTopic topic = createTopic();
+            topic.updateName("v1");
+            topic.updateName("v2");
+            topic.updateName("v3");
+            assertThat(topic.getRevisionCount()).isEqualTo(3);
+            assertThat(topic.isRefinementSuggested()).isTrue();
+        }
+
+        @Test
+        @DisplayName("REFINEMENT_THRESHOLD 상수가 도메인에 노출된다 (외부 재정의 방지)")
+        void thresholdConstantExposed() {
+            assertThat(AxisTopic.REFINEMENT_THRESHOLD).isEqualTo(3);
+        }
+    }
 }


### PR DESCRIPTION
  ## 개요

  ## 연관 이슈

  - Epic 문서: `workflow/epics/Epic-003.md`
  - 포함된 Story 문서:
    - `workflow/stories/Story-003-2.md` (TopicRevision + 이력 조회)
    - `workflow/stories/Story-003-3.md` (수정 빈도 단련 안내)
  - 관련 ADR:
    - `private-docs/adr/ADR001.md` — Surrogate PK BIGINT AUTO_INCREMENT
    - `private-docs/adr/ADR002.md` — Enum = VARCHAR + CHECK
    - `private-docs/adr/ADR004.md` — AxisTopic 명사구 표현 (단일 동사 강제 폐지)
  - GitHub 이슈: #(미연결 — 필요 시 채움)

  ## 배경 및 문제

  원 Story-000.md(R-1·R-2·R-3)는 `AxisAction` + 단일 동사 강제 모델 기반이었으나, Epic-002에서 ADR004에 따라
  `AxisTopic`(명사구)으로 전환되며 이력 모델·수정 빈도 안내가 Epic 3 이관 항목으로 보류됐다.

  본 PR은 이 보류 항목을 AxisTopic 컨텍스트로 재해석해 마무리한다.
  - **이력 보존 부재**: `AxisTopic.updateName()`은 변경 감지(boolean)만 했고, 누가 언제 어떤 이유로 바꿨는지
  기록되지 않음.
  - **단련 신호 부재**: 같은 주제를 반복 수정하는 패턴(유저가 이 축에서 진짜 다루고 싶은 게 무엇인지 탐색 중인
  신호)을 시스템이 감지·표시하지 않음.

  ## 해결 방법

  ### Story-003-2: 수정 이유 기록 + 이력 조회

  - `feat(learningfacade): TopicRevision 엔티티 추가` — `@ManyToOne` AxisTopic,
  `previousName`/`newName`/`revisionReasonLabel` snapshot, `@CreationTimestamp revisedAt`.
  - `feat(learningfacade): RevisionReasonOption 엔티티 + REVISION_REASON_NOT_FOUND ErrorCode 추가` —
  label/displayOrder/active 관리 엔티티.
  - `feat(learningfacade): TopicRevision·RevisionReasonOption Repository Port + Adapter 추가` — port/adapter 패턴
  정합.
  - `feat(learningfacade): V3 마이그레이션 — revision_reason_option(seed 4건) + topic_revision 테이블` —
  `(axis_topic_id, revised_at)` 인덱스 + FK CASCADE.
  - `feat(learningfacade): UpdateTopic 요청에 revisionReasonOptionId + 응답 DTO 추가` — Jackson setter 호출 추적
  패턴 유지.
  - `feat(learningfacade): 주제 이름 수정 시 TopicRevision 이력 저장 + TopicRevisionQueryService 분리` —
  Command/Query 분리 + 비활성 reason 거부(이중 방어).
  - `feat(learningfacade): 주제 이력·이유 선택지 조회 GET 엔드포인트 추가` — `GET /topics/{topicId}/revisions`,
  `GET /revision-reason-options`.

  ### Story-003-3: 수정 빈도 기반 단련 안내

  - `feat(learningfacade): AxisTopic.revisionCount + REFINEMENT_THRESHOLD + isRefinementSuggested 도입` — 도메인
  상수(=3) + boolean 플래그.
  - `feat(learningfacade): V4 마이그레이션 — axis_topic.revision_count 컬럼 추가 (3단계 NOT NULL 전환)` —
  db-conventions.md §8 정합 (NULL → 백필 → NOT NULL).
  - `feat(learningfacade): UpdateTopic 응답에 revisionCount + isRefinementSuggested 노출` —
  `UpdateTopic.of(topic)` 자동 위임.
  - 증가 규칙: `updateName` 실제 변경 시에만 +1. 동일 값(trim 후 같은 값) 또는 description 단독 수정 시 미증가.

  ### 누적 변경 요약

  - **도메인 모델**: `TopicRevision`, `RevisionReasonOption` 신설. `AxisTopic` 확장(`revisionCount`,
  `REFINEMENT_THRESHOLD`, `isRefinementSuggested()`).
  - **DB 스키마**: `V3` (revision_reason_option 신규 + seed 4건, topic_revision 신규), `V4`
  (axis_topic.revision_count 추가).
  - **API**: `PATCH /topics/{topicId}` 응답에 `revisionCount`, `isRefinementSuggested` 추가. `GET
  /topics/{topicId}/revisions`, `GET /revision-reason-options` 신설.
  - **ErrorCode**: `REVISION_REASON_NOT_FOUND` (TR001, 404) 등록.

  ## 트레이드오프

  - **`revisionReasonLabel` 텍스트 스냅샷** (FK 아님) — 라벨 통계 시 컬럼 분포 직접 집계 필요. 대신 관리자가 라벨
  변경해도 과거 이력 표현 보존.
  - **`topic_revision` soft delete 미적용** (ADR003 정합) — 주제 삭제 시 cascade. 삭제 주제 회고는 v2에서 별도
  archive 모델로.
  - **`LearningFacadeCommandService` 의존성 증가 2건** (`TopicRevisionRepository`,
  `RevisionReasonOptionRepository`) — Topic 명령이 더 늘면 `TopicCommandService`로 분리 검토.
  - **`revisionCount` 도메인 리셋 없음** — 누적값. 한번 오르면 내려가지 않음 (의도적: 단련 횟수는 사실 기록).
  - **임계값 도메인 하드코딩** (`REFINEMENT_THRESHOLD = 3`) — 운영 중 동적 조정이 필요해지면 Admin BC 시스템
  설정으로 이관 (domain-conventions.md §9 정합).
  - **브랜치 명 부정합** — `feat/story-002-2-topic-refinements`는 구 규칙 잔재. 다음 Epic부터 새
  규칙(`{type}/{NNN}-{slug}`).

  ## 완료 조건

  ### Story-003-2 Acceptance Criteria
  - [x] 이유 선택 + 저장 시 `previousName`/`newName`/`revisionReasonLabel` 함께 저장
  - [x] 이유 미선택 + 저장 시 이력 생성 + `revisionReasonLabel = null`
  - [x] 동일 값(trim 후) 저장 시 이력 미생성
  - [x] 이력 조회는 `revisedAt` 오름차순 반환
  - [x] 비활성 선택지의 라벨은 기존 이력에서 변경되지 않음 (스냅샷 패턴으로 보장)
  - [x] 이력이 없는 주제 조회 시 빈 목록 반환
  - [x] 주제 삭제 시 이력 cascade (FK ON DELETE CASCADE)
  - [x] 비활성·미존재 선택지 id 전달 시 `REVISION_REASON_NOT_FOUND` 예외