### PR TITLE
[JWT] feat: Access/Refresh Token TTL 외부화 및 JWTUtil 경량화 (Story 1-1)

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Util/JWTUtil.java
+++ b/src/main/java/com/example/thirdtool/Common/Util/JWTUtil.java
@@ -1,105 +1,89 @@
 package com.example.thirdtool.Common.Util;
 
 
+import com.example.thirdtool.Common.security.auth.jwt.JwtProperties;
+import com.example.thirdtool.Common.security.auth.token.TokenType;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.time.Duration;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
+@Component
 public class JWTUtil {
 
-    private static final SecretKey secretKey;
-    private static final Long accessTokenExpiresIn;
-    private static final Long refreshTokenExpiresIn;
+    private final SecretKey secretKey;
+    private final JwtProperties properties;
 
-    static  {
-        String secretKeyString = "himynameiskimjihunmyyoutubechann";
-        secretKey = new SecretKeySpec(secretKeyString.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
-
-        accessTokenExpiresIn = 3600L * 1000; // 1시간
-        refreshTokenExpiresIn = 604800L * 1000; // 7일
+    public JWTUtil(JwtProperties properties) {
+        this.properties = properties;
+        this.secretKey = new SecretKeySpec(
+                properties.secretKey().getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm()
+        );
     }
 
-    // JWT 클레임 username 파싱
-    public static String getUsername(String token) {
-        return Jwts.parser()
-                   .verifyWith(secretKey)
-                   .build()
-                   .parseSignedClaims(token)
-                   .getPayload()
-                   .get("sub", String.class);
+    public String getUsername(String token) {
+        return parseClaims(token).get("sub", String.class);
     }
 
-    // JWT 클레임 role 파싱
-    public static String getRole(String token) {
-        return Jwts.parser()
-                   .verifyWith(secretKey)
-                   .build()
-                   .parseSignedClaims(token)
-                   .getPayload()
-                   .get("role", String.class);
+    public String getRole(String token) {
+        return parseClaims(token).get("role", String.class);
     }
 
-    // JWT 유효 여부 (위조, 시간, Access/Refresh 여부)
-    public static Boolean isValid(String token, Boolean isAccess) {
+    public boolean isValid(String token, TokenType expectedType) {
         try {
-            log.debug("[JWT-VALIDATION] 토큰 검증 시작: {}", token);
-            Claims claims = Jwts.parser()
-                                .verifyWith(secretKey)
-                                .build()
-                                .parseSignedClaims(token)
-                                .getPayload();
-
+            Claims claims = parseClaims(token);
             String type = claims.get("type", String.class);
-            log.debug("[JWT-VALIDATION] 추출된 type: {}", type);
-
             if (type == null) {
-                log.warn("[JWT-VALIDATION] 토큰에 type 클레임이 없음");
+                log.warn("[JWT-VALIDATION] type claim 누락");
                 return false;
             }
-
-            if (isAccess && !type.equals("access")) {
-                log.warn("[JWT-VALIDATION] Access 토큰 기대했는데 Refresh 토큰이 들어옴");
+            if (!type.equals(expectedType.claim())) {
+                log.warn("[JWT-VALIDATION] type 불일치 - 예상={}, 실제={}", expectedType.claim(), type);
                 return false;
             }
-            if (!isAccess && !type.equals("refresh")) {
-                log.warn("[JWT-VALIDATION] Refresh 토큰 기대했는데 Access 토큰이 들어옴");
-                return false;
-            }
-
-            log.debug("[JWT-VALIDATION] 토큰 검증 성공");
             return true;
-
         } catch (JwtException | IllegalArgumentException e) {
+            log.debug("[JWT-VALIDATION] 검증 실패: {}", e.getMessage());
             return false;
         }
     }
 
-    // JWT(Access/Refresh) 생성
-    public static String createJWT(String username, String role, Boolean isAccess) {
-
+    public String createJWT(String username, String role, Duration ttl, TokenType type) {
         long now = System.currentTimeMillis();
-        long expiry = isAccess ? accessTokenExpiresIn : refreshTokenExpiresIn;
-        String type = isAccess ? "access" : "refresh";
+        long expiry = ttl.toMillis();
 
         return Jwts.builder()
                    .claim("sub", username)
                    .claim("role", role)
-                   .claim("type", type)
+                   .claim("type", type.claim())
                    .issuedAt(new Date(now))
                    .expiration(new Date(now + expiry))
                    .signWith(secretKey)
                    .compact();
     }
 
+    public Duration accessTokenTtl() {
+        return properties.accessTokenTtl();
+    }
+
+    public Duration refreshTokenTtl() {
+        return properties.refreshTokenTtl();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                   .verifyWith(secretKey)
+                   .build()
+                   .parseSignedClaims(token)
+                   .getPayload();
+    }
 }

--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.thirdtool.Common.config;
 
 
+import com.example.thirdtool.Common.Util.JWTUtil;
 import com.example.thirdtool.Common.security.filter.JWTFilter;
 import com.example.thirdtool.User.domain.model.CustomOAuth2User;
 import com.example.thirdtool.User.domain.model.UserRoleType;
@@ -54,11 +55,14 @@ public class SecurityConfig {
     };
 
     private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
 
     public SecurityConfig(
-            UserRepository userRepository
+            UserRepository userRepository,
+            JWTUtil jwtUtil
                          ) {
         this.userRepository = userRepository;
+        this.jwtUtil = jwtUtil;
     }
 
     @PostConstruct
@@ -178,7 +182,7 @@ public class SecurityConfig {
         // ==============================
         // 6️⃣ JWT 인증 필터 추가
         // ==============================
-        http.addFilterBefore(new JWTFilter(userRepository), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JWTFilter(userRepository, jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtProperties.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.Common.security.auth.jwt;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -10,8 +11,13 @@ import java.time.Duration;
 @Validated
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
-        @NotBlank String secretKey,
+        @NotBlank
+        @Size(min = 32, message = "JWT secret-key는 HS256 알고리즘 기준 최소 32바이트(256bit) 이상이어야 합니다")
+        String secretKey,
+
         @NotNull Duration accessTokenTtl,
+
         @NotNull Duration refreshTokenTtl
 ) {
 }
+

--- a/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.example.thirdtool.Common.security.auth.jwt;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+@Validated
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        @NotBlank String secretKey,
+        @NotNull Duration accessTokenTtl,
+        @NotNull Duration refreshTokenTtl
+) {
+}

--- a/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtService.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtService.java
@@ -4,6 +4,7 @@ import com.example.thirdtool.Common.security.auth.RefreshEntity;
 import com.example.thirdtool.Common.security.auth.RefreshRepository;
 import com.example.thirdtool.Common.security.auth.dto.JWTResponseDTO;
 import com.example.thirdtool.Common.security.auth.dto.RefreshRequestDTO;
+import com.example.thirdtool.Common.security.auth.token.TokenType;
 import com.example.thirdtool.Common.Util.JWTUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,9 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class JwtService {
 
     private final RefreshRepository refreshRepository;
+    private final JWTUtil jwtUtil;
 
-    public JwtService(RefreshRepository refreshRepository) {
+    public JwtService(RefreshRepository refreshRepository, JWTUtil jwtUtil) {
         this.refreshRepository = refreshRepository;
+        this.jwtUtil = jwtUtil;
     }
 
     @Transactional
@@ -48,18 +51,18 @@ public class JwtService {
         }
 
         // Refresh 토큰 검증
-        Boolean isValid = JWTUtil.isValid(refreshToken, false);
+        boolean isValid = jwtUtil.isValid(refreshToken, TokenType.REFRESH);
         if (!isValid) {
             throw new RuntimeException("유효하지 않은 refreshToken입니다.");
         }
 
         // 정보 추출
-        String username = JWTUtil.getUsername(refreshToken);
-        String role = JWTUtil.getRole(refreshToken);
+        String username = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
 
         // 토큰 생성
-        String newAccessToken = JWTUtil.createJWT(username, role, true);
-        String newRefreshToken = JWTUtil.createJWT(username, role, false);
+        String newAccessToken = jwtUtil.createJWT(username, role, jwtUtil.accessTokenTtl(), TokenType.ACCESS);
+        String newRefreshToken = jwtUtil.createJWT(username, role, jwtUtil.refreshTokenTtl(), TokenType.REFRESH);
 
         // 기존 Refresh 토큰 DB 삭제 후 신규 추가
         RefreshEntity newRefreshEntity = RefreshEntity.builder()
@@ -90,7 +93,7 @@ public class JwtService {
         log.info("[REFRESH-ROTATE] 전달받은 RefreshToken: {}", refreshToken);
 
         // Refresh 토큰 검증
-        Boolean isValid = JWTUtil.isValid(refreshToken, false);
+        boolean isValid = jwtUtil.isValid(refreshToken, TokenType.REFRESH);
         log.info("[REFRESH-ROTATE] JWTUtil.isValid 결과: {}", isValid);
 
         if (!isValid) {
@@ -108,13 +111,13 @@ public class JwtService {
         }
 
         // 정보 추출
-        String username = JWTUtil.getUsername(refreshToken);
-        String role = JWTUtil.getRole(refreshToken);
+        String username = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
         log.info("[REFRESH-ROTATE] 토큰에서 추출한 username={}, role={}", username, role);
 
         // 토큰 생성
-        String newAccessToken = JWTUtil.createJWT(username, role, true);
-        String newRefreshToken = JWTUtil.createJWT(username, role, false);
+        String newAccessToken = jwtUtil.createJWT(username, role, jwtUtil.accessTokenTtl(), TokenType.ACCESS);
+        String newRefreshToken = jwtUtil.createJWT(username, role, jwtUtil.refreshTokenTtl(), TokenType.REFRESH);
         log.info("[REFRESH-ROTATE] 새 AccessToken 생성 완료");
         log.info("[REFRESH-ROTATE] 새 RefreshToken 생성 완료");
 
@@ -179,6 +182,6 @@ public class JwtService {
     }
 
     public String getUsername(String refreshToken) {
-        return JWTUtil.getUsername(refreshToken);
+        return jwtUtil.getUsername(refreshToken);
     }
 }

--- a/src/main/java/com/example/thirdtool/Common/security/auth/token/TokenType.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/token/TokenType.java
@@ -1,0 +1,17 @@
+package com.example.thirdtool.Common.security.auth.token;
+
+public enum TokenType {
+
+    ACCESS("access"),
+    REFRESH("refresh");
+
+    private final String claim;
+
+    TokenType(String claim) {
+        this.claim = claim;
+    }
+
+    public String claim() {
+        return claim;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Common/security/filter/JWTFilter.java
+++ b/src/main/java/com/example/thirdtool/Common/security/filter/JWTFilter.java
@@ -5,6 +5,7 @@ import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Common.Util.JWTUtil;
 import com.example.thirdtool.Common.Util.WhitelistPath;
+import com.example.thirdtool.Common.security.auth.token.TokenType;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.User.domain.repository.UserRepository;
 import jakarta.servlet.FilterChain;
@@ -29,6 +30,7 @@ import java.util.List;
 public class JWTFilter extends OncePerRequestFilter {
 
     private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
 
 
     @Override
@@ -79,10 +81,10 @@ public class JWTFilter extends OncePerRequestFilter {
 
         // 4️⃣ JWT 유효성 검증
         try {
-            if (JWTUtil.isValid(accessToken, true)) {
-                String username = JWTUtil.getUsername(accessToken);
-                String role = JWTUtil.getRole(accessToken);
-                log.info("[JWTFilter] ✅ JWT username claim = {}", JWTUtil.getUsername(accessToken));
+            if (jwtUtil.isValid(accessToken, TokenType.ACCESS)) {
+                String username = jwtUtil.getUsername(accessToken);
+                String role = jwtUtil.getRole(accessToken);
+                log.info("[JWTFilter] ✅ JWT username claim = {}", username);
                 log.info("[JWTFilter] ✅ JWT 유효함 → username={}, role={}", username, role);
 
                 // 5️⃣ DB에서 사용자 확인

--- a/src/main/java/com/example/thirdtool/ThirdToolApplication.java
+++ b/src/main/java/com/example/thirdtool/ThirdToolApplication.java
@@ -2,10 +2,12 @@ package com.example.thirdtool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @EnableJpaAuditing
+@ConfigurationPropertiesScan("com.example.thirdtool")
 @SpringBootApplication(scanBasePackages = "com.example.thirdtool")
 public class ThirdToolApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/example/thirdtool/User/application/UserService.java
+++ b/src/main/java/com/example/thirdtool/User/application/UserService.java
@@ -3,6 +3,7 @@ package com.example.thirdtool.User.application;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Common.Util.JWTUtil;
+import com.example.thirdtool.Common.security.auth.token.TokenType;
 import com.example.thirdtool.User.domain.model.CustomOAuth2User;
 import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.User.domain.model.UserEntity;
@@ -34,17 +35,20 @@ public class UserService extends DefaultOAuth2UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final JwtService jwtService;
+    private final JWTUtil jwtUtil;
     private final KakaoMemberRepository kakaoMemberRepository;
     private final NaverMemberRepository naverMemberRepository;
 
     public UserService(PasswordEncoder passwordEncoder,
                        UserRepository userRepository,
                        JwtService jwtService,
+                       JWTUtil jwtUtil,
                        KakaoMemberRepository kakaoMemberRepository,
                        NaverMemberRepository naverMemberRepository) {
         this.passwordEncoder = passwordEncoder;
         this.userRepository = userRepository;
         this.jwtService = jwtService;
+        this.jwtUtil = jwtUtil;
         this.kakaoMemberRepository = kakaoMemberRepository;
         this.naverMemberRepository = naverMemberRepository;
     }
@@ -140,8 +144,8 @@ public class UserService extends DefaultOAuth2UserService {
 
         // JWT(Access/Refresh) 발급
         String role = "ROLE_" + user.getRoleType().name();
-        String accessToken = JWTUtil.createJWT(user.getUsername(), role, true);
-        String refreshToken = JWTUtil.createJWT(user.getUsername(), role, false);
+        String accessToken = jwtUtil.createJWT(user.getUsername(), role, jwtUtil.accessTokenTtl(), TokenType.ACCESS);
+        String refreshToken = jwtUtil.createJWT(user.getUsername(), role, jwtUtil.refreshTokenTtl(), TokenType.REFRESH);
 
         // Refresh 토큰 DB 저장
         jwtService.addRefresh(user.getUsername(), refreshToken);

--- a/src/main/java/com/example/thirdtool/User/presentation/UserController.java
+++ b/src/main/java/com/example/thirdtool/User/presentation/UserController.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.User.presentation;
 
 import com.example.thirdtool.Common.Util.JWTUtil;
 import com.example.thirdtool.Common.security.auth.jwt.JwtService;
+import com.example.thirdtool.Common.security.auth.token.TokenType;
 import com.example.thirdtool.User.dto.*;
 import com.example.thirdtool.User.application.UserService;
 import com.example.thirdtool.User.domain.model.UserEntity;
@@ -22,11 +23,14 @@ public class UserController {
 
     private final UserService userService;
     private final JwtService jwtService;
+    private final JWTUtil jwtUtil;
 
     public UserController(UserService userService,
-                          JwtService jwtService) {
+                          JwtService jwtService,
+                          JWTUtil jwtUtil) {
         this.userService = userService;
         this.jwtService = jwtService;
+        this.jwtUtil = jwtUtil;
     }
 
     // ✅ 자체 로그인 (JWT 발급)
@@ -41,8 +45,8 @@ public class UserController {
         String role = "ROLE_" + user.getRoleType().name();
 
         // 3️⃣ JWT 발급
-        String accessToken = JWTUtil.createJWT(user.getUsername(), role, true);
-        String refreshToken = JWTUtil.createJWT(user.getUsername(), role, false);
+        String accessToken = jwtUtil.createJWT(user.getUsername(), role, jwtUtil.accessTokenTtl(), TokenType.ACCESS);
+        String refreshToken = jwtUtil.createJWT(user.getUsername(), role, jwtUtil.refreshTokenTtl(), TokenType.REFRESH);
 
         // 4️⃣ RefreshToken 저장
         jwtService.addRefresh(user.getUsername(), refreshToken);

--- a/src/test/java/com/example/thirdtool/Common/Util/JWTUtilTest.java
+++ b/src/test/java/com/example/thirdtool/Common/Util/JWTUtilTest.java
@@ -1,0 +1,169 @@
+package com.example.thirdtool.Common.Util;
+
+import com.example.thirdtool.Common.security.auth.jwt.JwtProperties;
+import com.example.thirdtool.Common.security.auth.token.TokenType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JWTUtil")
+class JWTUtilTest {
+
+    private static final String SECRET = "test-secret-key-must-be-32-bytes!!";
+    private static final Duration ACCESS_TTL = Duration.ofMinutes(30);
+    private static final Duration REFRESH_TTL = Duration.ofDays(7);
+
+    private JWTUtil jwtUtil;
+    private JwtProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new JwtProperties(SECRET, ACCESS_TTL, REFRESH_TTL);
+        jwtUtil = new JWTUtil(properties);
+    }
+
+    @Nested
+    @DisplayName("createJWT — 토큰 생성")
+    class CreateJWT {
+
+        @Test
+        @DisplayName("ACCESS 타입으로 발급한 토큰의 type claim은 'access'다")
+        void createJWT_ACCESS_typeClaim_access() {
+            String token = jwtUtil.createJWT("alice", "ROLE_USER", ACCESS_TTL, TokenType.ACCESS);
+
+            assertThat(jwtUtil.isValid(token, TokenType.ACCESS)).isTrue();
+            assertThat(jwtUtil.getUsername(token)).isEqualTo("alice");
+            assertThat(jwtUtil.getRole(token)).isEqualTo("ROLE_USER");
+        }
+
+        @Test
+        @DisplayName("REFRESH 타입으로 발급한 토큰의 type claim은 'refresh'다")
+        void createJWT_REFRESH_typeClaim_refresh() {
+            String token = jwtUtil.createJWT("bob", "ROLE_ADMIN", REFRESH_TTL, TokenType.REFRESH);
+
+            assertThat(jwtUtil.isValid(token, TokenType.REFRESH)).isTrue();
+            assertThat(jwtUtil.getUsername(token)).isEqualTo("bob");
+            assertThat(jwtUtil.getRole(token)).isEqualTo("ROLE_ADMIN");
+        }
+
+        @Test
+        @DisplayName("ttl이 다르면 같은 사용자라도 토큰 문자열은 동일할 수 없다")
+        void createJWT_다른ttl_다른토큰() {
+            String a = jwtUtil.createJWT("alice", "ROLE_USER", Duration.ofMinutes(30), TokenType.ACCESS);
+            String b = jwtUtil.createJWT("alice", "ROLE_USER", Duration.ofHours(1), TokenType.ACCESS);
+
+            // 발급 시각이 동일한 ms이면 같을 수도 있으니 만료 시각만 다르게 직접 비교
+            // 실제로는 시각 차이로 issuedAt도 달라지지만 안전한 비교는 둘 다 valid한 것만
+            assertThat(jwtUtil.isValid(a, TokenType.ACCESS)).isTrue();
+            assertThat(jwtUtil.isValid(b, TokenType.ACCESS)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("isValid — TokenType 검증")
+    class IsValid {
+
+        @Test
+        @DisplayName("ACCESS 토큰을 ACCESS로 검증하면 true")
+        void isValid_access_access_true() {
+            String token = jwtUtil.createJWT("alice", "ROLE_USER", ACCESS_TTL, TokenType.ACCESS);
+
+            assertThat(jwtUtil.isValid(token, TokenType.ACCESS)).isTrue();
+        }
+
+        @Test
+        @DisplayName("ACCESS 토큰을 REFRESH로 검증하면 false (type 불일치)")
+        void isValid_access_refresh_false() {
+            String token = jwtUtil.createJWT("alice", "ROLE_USER", ACCESS_TTL, TokenType.ACCESS);
+
+            assertThat(jwtUtil.isValid(token, TokenType.REFRESH)).isFalse();
+        }
+
+        @Test
+        @DisplayName("REFRESH 토큰을 ACCESS로 검증하면 false (type 불일치)")
+        void isValid_refresh_access_false() {
+            String token = jwtUtil.createJWT("alice", "ROLE_USER", REFRESH_TTL, TokenType.REFRESH);
+
+            assertThat(jwtUtil.isValid(token, TokenType.ACCESS)).isFalse();
+        }
+
+        @Test
+        @DisplayName("위조된 토큰은 false")
+        void isValid_garbage_false() {
+            assertThat(jwtUtil.isValid("garbage.token.string", TokenType.ACCESS)).isFalse();
+        }
+
+        @Test
+        @DisplayName("이미 만료된 토큰은 false")
+        void isValid_만료_false() {
+            String token = jwtUtil.createJWT("alice", "ROLE_USER", Duration.ZERO, TokenType.ACCESS);
+
+            // Duration.ZERO 발급 직후 만료. 시각 차이로 false 보장.
+            assertThat(jwtUtil.isValid(token, TokenType.ACCESS)).isFalse();
+        }
+
+        @Test
+        @DisplayName("null 또는 빈 문자열은 false (예외 없음)")
+        void isValid_null또는blank_false() {
+            assertThat(jwtUtil.isValid("", TokenType.ACCESS)).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 비밀키로 서명된 토큰은 false")
+        void isValid_다른secret_false() {
+            JwtProperties otherProps = new JwtProperties(
+                    "different-secret-key-32-bytes-XXXX!",
+                    ACCESS_TTL,
+                    REFRESH_TTL
+            );
+            JWTUtil otherUtil = new JWTUtil(otherProps);
+
+            String tokenFromOther = otherUtil.createJWT("alice", "ROLE_USER", ACCESS_TTL, TokenType.ACCESS);
+
+            assertThat(jwtUtil.isValid(tokenFromOther, TokenType.ACCESS)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("TTL 노출")
+    class TtlExposure {
+
+        @Test
+        @DisplayName("accessTokenTtl()은 properties.accessTokenTtl()을 반환한다")
+        void accessTokenTtl_returnsProperties() {
+            assertThat(jwtUtil.accessTokenTtl()).isEqualTo(ACCESS_TTL);
+        }
+
+        @Test
+        @DisplayName("refreshTokenTtl()은 properties.refreshTokenTtl()을 반환한다")
+        void refreshTokenTtl_returnsProperties() {
+            assertThat(jwtUtil.refreshTokenTtl()).isEqualTo(REFRESH_TTL);
+        }
+    }
+
+    @Nested
+    @DisplayName("getUsername / getRole — claim 추출")
+    class GetClaims {
+
+        @Test
+        @DisplayName("getUsername은 sub claim을 반환한다")
+        void getUsername_returns_sub() {
+            String token = jwtUtil.createJWT("charlie", "ROLE_USER", ACCESS_TTL, TokenType.ACCESS);
+
+            assertThat(jwtUtil.getUsername(token)).isEqualTo("charlie");
+        }
+
+        @Test
+        @DisplayName("getRole은 role claim을 반환한다")
+        void getRole_returns_role() {
+            String token = jwtUtil.createJWT("charlie", "ROLE_ADMIN", ACCESS_TTL, TokenType.ACCESS);
+
+            assertThat(jwtUtil.getRole(token)).isEqualTo("ROLE_ADMIN");
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/Common/Util/JWTUtilTest.java
+++ b/src/test/java/com/example/thirdtool/Common/Util/JWTUtilTest.java
@@ -52,15 +52,14 @@ class JWTUtilTest {
         }
 
         @Test
-        @DisplayName("ttl이 다르면 같은 사용자라도 토큰 문자열은 동일할 수 없다")
-        void createJWT_다른ttl_다른토큰() {
-            String a = jwtUtil.createJWT("alice", "ROLE_USER", Duration.ofMinutes(30), TokenType.ACCESS);
-            String b = jwtUtil.createJWT("alice", "ROLE_USER", Duration.ofHours(1), TokenType.ACCESS);
+        @DisplayName("같은 사용자에 ACCESS/REFRESH 두 타입을 동시 발급해도 각각 유효하다")
+        void createJWT_두타입_동시발급_각각유효() {
+            String access = jwtUtil.createJWT("alice", "ROLE_USER", ACCESS_TTL, TokenType.ACCESS);
+            String refresh = jwtUtil.createJWT("alice", "ROLE_USER", REFRESH_TTL, TokenType.REFRESH);
 
-            // 발급 시각이 동일한 ms이면 같을 수도 있으니 만료 시각만 다르게 직접 비교
-            // 실제로는 시각 차이로 issuedAt도 달라지지만 안전한 비교는 둘 다 valid한 것만
-            assertThat(jwtUtil.isValid(a, TokenType.ACCESS)).isTrue();
-            assertThat(jwtUtil.isValid(b, TokenType.ACCESS)).isTrue();
+            assertThat(jwtUtil.isValid(access, TokenType.ACCESS)).isTrue();
+            assertThat(jwtUtil.isValid(refresh, TokenType.REFRESH)).isTrue();
+            assertThat(access).isNotEqualTo(refresh);
         }
     }
 
@@ -108,9 +107,15 @@ class JWTUtilTest {
         }
 
         @Test
-        @DisplayName("null 또는 빈 문자열은 false (예외 없음)")
-        void isValid_null또는blank_false() {
+        @DisplayName("빈 문자열 토큰은 false (예외 없음)")
+        void isValid_emptyToken_false() {
             assertThat(jwtUtil.isValid("", TokenType.ACCESS)).isFalse();
+        }
+
+        @Test
+        @DisplayName("null 토큰은 false (IllegalArgumentException 내부 흡수)")
+        void isValid_nullToken_false() {
+            assertThat(jwtUtil.isValid(null, TokenType.ACCESS)).isFalse();
         }
 
         @Test
@@ -164,6 +169,39 @@ class JWTUtilTest {
             String token = jwtUtil.createJWT("charlie", "ROLE_ADMIN", ACCESS_TTL, TokenType.ACCESS);
 
             assertThat(jwtUtil.getRole(token)).isEqualTo("ROLE_ADMIN");
+        }
+
+        @Test
+        @DisplayName("getUsername에 위조 토큰 전달 시 JwtException 발생 (호출자는 isValid 통과 후 호출 전제)")
+        void getUsername_garbageToken_throwsJwtException() {
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                    () -> jwtUtil.getUsername("garbage.token.string")
+            ).isInstanceOf(io.jsonwebtoken.JwtException.class);
+        }
+
+        @Test
+        @DisplayName("getRole에 위조 토큰 전달 시 JwtException 발생 (호출자는 isValid 통과 후 호출 전제)")
+        void getRole_garbageToken_throwsJwtException() {
+            org.assertj.core.api.Assertions.assertThatThrownBy(
+                    () -> jwtUtil.getRole("garbage.token.string")
+            ).isInstanceOf(io.jsonwebtoken.JwtException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("TokenType — claim 매핑")
+    class TokenTypeClaimMapping {
+
+        @Test
+        @DisplayName("ACCESS.claim()은 'access'다")
+        void access_claim_isAccess() {
+            assertThat(TokenType.ACCESS.claim()).isEqualTo("access");
+        }
+
+        @Test
+        @DisplayName("REFRESH.claim()은 'refresh'다")
+        void refresh_claim_isRefresh() {
+            assertThat(TokenType.REFRESH.claim()).isEqualTo("refresh");
         }
     }
 }


### PR DESCRIPTION
## What

Product 1 (인증 인프라 재설계)의 Story 1-1 구현. JWT 토큰 TTL을 application.yml로 외부화하고 `JWTUtil`을 정적 메서드 기반에서 `@Component` 기반으로 전환했다.

- 신규: `Common/security/auth/jwt/JwtProperties` (`@ConfigurationProperties("jwt")` record + `@Validated`)
- 신규: `Common/security/auth/token/TokenType` enum (`ACCESS` / `REFRESH`)
- 변경: `Common/Util/JWTUtil` 정적 → `@Component`, `createJWT(username, role, Duration ttl, TokenType type)` 시그니처
- 변경: `JWTFilter`, `JwtService`, `SecurityConfig`, `UserController`, `UserService` — 정적 호출 → 인스턴스 호출로 일괄 전환
- 변경: `ThirdToolApplication`에 `@ConfigurationPropertiesScan` 추가
- 신규: `JWTUtilTest` (TokenType별 발급/검증/TTL 매트릭스 + Reviewer 보강분)

## Why

(Product 1 배경) AT·RT 발급 정책이 `JWTUtil` 정적 호출로 3곳에 분산되어 있어 TTL 변경이나 정책 수정 시 모두 동시 갱신 필요. TTL이 Magic Number(`3600L * 1000`)로 하드코딩되어 추적 어려움. 본 Story는 Story 1-2(TokenIssuer 단일화), Story 1-3(AT HttpOnly Cookie 발급)의 전제 조건.

## How

### 주요 설계 결정
- `JwtProperties`는 record + `@Validated` + `@NotBlank/@NotNull/@Size(min=32)` — TTL 누락 또는 secret-key 길이 부족 시 부팅 시점 `BeanCreationException` 발생 (Story AC 4번 보장)
- HS256 알고리즘 요구사항 충족을 위해 `secretKey @Size(min=32)` 적용
- `TokenType` enum의 `claim()` 메서드로 type 클레임 문자열 캡슐화 (`ACCESS.claim()` → `"access"`)
- `createJWT(Duration ttl, TokenType type)` — 호출자가 명시적으로 TTL을 전달 (Story 1-2에서 TokenIssuer가 흡수 예정)
- 누락된 `io.jsonwebtoken.JwtException` import 정정 (이전 코드의 `org.springframework...oauth2.jwt.JwtException`은 실제 JJWT 예외를 잡지 못하는 버그)

### 의식적 보류 (다음 Story로 이관)
- `JWTUtil.accessTokenTtl()/refreshTokenTtl()` 게터 노출은 Story 1-2의 `TokenIssuer`가 흡수 예정인 임시 API
- `presentation`/`application` 계층이 `JWTUtil` 직접 주입 → Story 1-2에서 Port 추상화
- `JWTFilter`의 `writeUnauthorizedResponse` 직접 응답 write → Story 3-1 `AuthenticationEntryPoint`로 정리
- `JwtService`의 `RuntimeException` 직접 throw → Story 2-1에서 `BusinessException(ErrorCode)` 통일
- AT TTL 30분(Product.md), 기존 60분 → 새 정책 반영 (yml 갱신만)

## Tradeoff

- `accessTokenTtl()`/`refreshTokenTtl()` 게터 5개 호출지점에 노출됨: Story 1-2에서 일괄 리팩토링되므로 단기 비용 수용
- `application.yml`이 `.gitignore`에 포함되어 있어 본 PR의 `jwt:` 섹션 변경분이 원격에 반영되지 않음 → 다른 개발자는 로컬 `application.yml`에 `jwt:` 섹션을 직접 추가해야 함. 별도 Story로 `application.yml` 추적 또는 템플릿 분리 필요 (보안 secret 외부화 동반)
- Product.md AC 1번 명시는 `application-local.yml/application-prod.yml`이지만 실제 프로젝트 컨벤션은 `application.yml` + `dev`/`prod` 프로파일 → Product.md 표기 정정(`dev`) 또는 `local` 프로파일 신설은 후속 결정으로 이관

## Reviewer 종합 (review.md §5 결과)

5관점 병렬 검토 — Critical 3건 / Major 다수.

**즉시 조치 완료**:
- [Sceptical-Critical] secret-key 길이 검증 부재 → `@Size(min=32)` 추가
- [Test-Critical] `getUsername`/`getRole` 위조 토큰 예외 케이스 추가
- [Test-Major] `isValid(null)` 케이스 분리 추가
- [Test-Minor] `TokenType.claim()` 매핑 단위 테스트 + 명명 컨벤션 정합

**의식적 보류** (다음 Story 책임):
- [Architecture] presentation/application의 JWTUtil 직접 의존 → Story 1-2
- [Architecture] JWTFilter `new JWTFilter(...)` 수동 instantiation → Story 3-1 또는 별도 정리
- [API/Exception] RuntimeException 잔존 → Story 2-1
- [Sceptical] `accessTokenTtl()` 게터 노출 → Story 1-2 TokenIssuer

**미해결 (운영 영역)**:
- `application.yml` `.gitignore` 문제 — 별도 보안 정리 Story 필요

## Test

- [x] 단위 테스트 추가 (`JWTUtilTest`, 16건) — 해피/엣지/예외 매트릭스 + `TokenType.claim()` 매핑 + `accessTokenTtl()`/`refreshTokenTtl()` 노출 + 위조 토큰 예외
- [x] `./gradlew test --tests "*.JWTUtilTest"` 통과
- [x] `./gradlew compileJava` 통과 (전체 main 컴파일)
- [ ] `JwtProperties` 부팅 검증 통합 테스트 (`@SpringBootTest`) — 본 Story에서 단위 검증으로 대체, 통합은 Story 1-2 이후 추가 예정

## Checklist

- [x] BC 의존 방향 위반 없음 (Common 내부)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] Reviewer 세션 통과 (Critical/Major 보강 커밋 1건 추가)
- [x] `[Story-1-1]` 태그 일관 커밋
- [x] 새 ErrorCode 등록 없음 (본 Story 범위)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 — 본 Story는 인프라 단순화로 도메인 의도 변경 없음. Story 1-3에서 ADR 작성(Token Storage Strategy) 예정

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)