### PR TITLE
[JWT] feat: AT 쿠키 보안 속성 프로파일 외부화 + ADR008 (Story 1-3)

### DIFF
--- a/docs/adr/ADR009.md
+++ b/docs/adr/ADR009.md
@@ -1,0 +1,78 @@
+# ADR009: Access Token은 HttpOnly Cookie, Refresh Token은 React 메모리에 저장한다
+
+- **상태**: Accepted
+- **날짜**: 2026-05-27
+- **관련**: Product 1 (인증 인프라 재설계), Story 1-3 (AT Cookie + 쿠키 보안 속성 프로파일 분기)
+
+> 본 ADR은 원래 ADR008로 작성되었으나, 평행 브랜치(`feat/006-deck-progress-status`)의 로깅 인프라 결정이 동일 번호(ADR008)로 develop에 먼저 머지됨에 따라 ADR009로 재번호되었다. 로깅 인프라 결정은 [ADR008](ADR008.md) 참조.
+
+## 컨텍스트
+
+Product 1 이전의 인증 인프라는 다음 상태였다.
+
+- Access Token(AT)과 Refresh Token(RT) 모두 응답 바디로 전달 (`TokenResponse(accessToken, refreshToken)`)
+- 소셜 로그인은 RT를 쿠키로도 발급 (`Secure=false`, `SameSite` 미설정, `MaxAge=10`)
+- `/jwt/exchange`라는 임시 변환 엔드포인트로 쿠키→헤더 전환
+
+이 구조의 핵심 위험은 **AT가 응답 바디로 노출되는 순간 프론트엔드 로그·브라우저 확장·네트워크 패널 어디서든 평문으로 관측된다**는 점이다. XSS 상황에서 FE 메모리 덤프나 fetch interception으로 AT를 탈취할 수 있다.
+
+업계 표준은 **AT를 메모리(JS 변수)에, RT를 HttpOnly Cookie**에 두는 것이지만, 본 프로젝트는 반대 방향을 채택한다 — 다음 두 가지 이유에서.
+
+## 결정
+
+**AT = HttpOnly Cookie (30분 TTL) / RT = React 메모리 (7일 TTL)**.
+
+- AT (30분, HttpOnly Cookie)
+    - XSS로 탈취 불가 — JavaScript에서 접근 자체가 불가능 (`HttpOnly=true`)
+    - 브라우저가 모든 API 요청에 자동 첨부 — FE는 `Authorization` 헤더 주입 코드가 불필요
+    - CSRF는 `SameSite=Strict` + `/api/**` 경로 한정으로 방어
+- RT (7일, React 메모리)
+    - 페이지 새로고침 시 유실되지만 AT가 쿠키로 살아있으므로 AT 만료 전까지는 자동 재인증 가능
+    - AT 만료 후 새로고침 발생 시 재로그인 요구 — **보안 관점에서 수용 가능한 트레이드오프**
+    - RT를 XSS로 탈취해도 fetch가 새 오리진에서 실행되므로 CORS로 2차 방어 가능
+    - `localStorage` / `sessionStorage` 절대 금지 — React 컴포넌트 상태/변수만 허용
+
+### 쿠키 보안 속성
+
+| 속성 | local/dev | prod |
+| --- | --- | --- |
+| `HttpOnly` | `true` | `true` |
+| `SameSite` | `Strict` | `Strict` |
+| `Secure` | `false` | `true` |
+| `Path` | `/` | `/` |
+| `Max-Age` | AT TTL | AT TTL |
+| `Name` | `access_token` | `access_token` |
+
+`Secure=true` 강제는 prod 프로파일에서만. 로컬은 HTTPS 환경 미보장이라 `Secure=false`. `application.yml`의 `jwt.cookie.*` 키로 외부화되며 `JwtCookieProperties` `@ConfigurationProperties`가 부팅 시 `SameSite` 값을 `Strict|Lax|None`으로 제한 (그 외 값이면 `BeanCreationException`).
+
+## 결과 (Consequences)
+
+**긍정적**
+
+- XSS로 AT 탈취 경로가 원천 차단 (HttpOnly)
+- FE 코드에서 토큰 관리 로직 제거 — `fetch(url, { credentials: 'include' })`만 추가
+- 보안 경계가 서버 측에 집중되어 토큰 정책 변경 시 클라이언트 배포 불요
+- 쿠키 보안 속성이 프로파일별로 외부화되어 운영자가 설정만으로 환경 분기 가능
+- `TokenIssuer` 단일 진입점 + ResponseCookie 빌더 — 정책 변경 시 한 곳만 수정
+
+**트레이드오프 / 부정적**
+
+- **AT 만료 후 새로고침 → 재로그인** — 30분 후 새로고침하면 RT가 메모리에 없어 재로그인 필요. 사용자 경험 trade-off
+- **모바일 앱(WebView 비사용) 대응 불가** — 쿠키는 브라우저 컨텍스트 의존. 향후 모바일 앱 도입 시 별도 토큰 전달 경로 필요
+- **로컬 개발의 Secure=false** — HTTPS 미사용 환경 운영자 책임. 프로덕션 환경에서는 `JwtCookieProperties`가 부팅 시 검증 (단, secure: false 자체는 검증 못함 — 운영자 실수 가능. 별도 hardening 필요)
+- **CSRF 방어가 SameSite=Strict에 의존** — 동일 사이트 내 GET 링크 클릭에서 쿠키 전송이 막혀 일부 UX 시나리오(이메일 링크 등)는 추가 처리 필요
+
+**대안 비교**
+
+| 대안 | 거부 사유 |
+| --- | --- |
+| AT 메모리 + RT HttpOnly Cookie (업계 표준) | FE가 매 요청에 `Authorization` 헤더 주입 코드 필요. XSS로 AT 탈취 가능 (메모리). 본 프로젝트의 FE 단순화 우선순위에 부적합 |
+| AT/RT 모두 HttpOnly Cookie | RT가 모든 요청에 자동 첨부되어 불필요 노출. `/jwt/refresh` 외 경로에서도 RT가 보임 — 공격 표면 확대 |
+| AT/RT 모두 응답 바디 (현재 상태) | XSS 위험 + FE 메모리 덤프 노출 — 본 ADR이 해결하려는 문제 자체 |
+
+**후속 작업**
+
+- Story 1-4: `JWTFilter`가 `Authorization` 헤더 대신 쿠키 배열에서 `access_token` 추출
+- Story 1-5: `TokenResponse.accessToken` 필드 제거 (응답 바디에서 AT 완전 제거)
+- Story 2-2: `/jwt/exchange` 엔드포인트 제거 (쿠키→헤더 변환 임시 다리 불필요)
+- 후속 ADR: 모바일 앱 도입 시 토큰 전달 경로 (별도 검토)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -10,3 +10,4 @@
 | [ADR006](ADR006.md) | 문서 체계를 docs/ 단일 진입으로 압축한다 | Accepted | 2026-05-14 |
 | [ADR007](ADR007.md) | BC 간 협력에 동기 도메인 이벤트를 도입한다 | Accepted | 2026-05-14 |
 | [ADR008](ADR008.md) | 로깅 인프라 — profile별 Appender 분기 + LogstashEncoder + MDC 화이트리스트 | Accepted | 2026-05-17 |
+| [ADR009](ADR009.md) | Access Token은 HttpOnly Cookie, Refresh Token은 React 메모리에 저장한다 | Accepted | 2026-05-27 |

--- a/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtCookieProperties.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/jwt/JwtCookieProperties.java
@@ -1,0 +1,28 @@
+package com.example.thirdtool.Common.security.auth.jwt;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Access Token 쿠키 보안 속성 외부화.
+ *
+ * - `prod` 프로파일은 반드시 secure=true, sameSite=Strict
+ * - `local`/`dev` 프로파일은 HTTPS 없는 환경을 위해 secure=false 허용
+ *
+ * SameSite는 RFC 6265bis 가능 값 (Strict, Lax, None)만 허용.
+ */
+@Validated
+@ConfigurationProperties(prefix = "jwt.cookie")
+public record JwtCookieProperties(
+        @NotBlank String name,
+        @NotBlank String path,
+        @NotNull Boolean httpOnly,
+        @NotNull Boolean secure,
+        @NotBlank
+        @Pattern(regexp = "Strict|Lax|None", message = "SameSite는 Strict/Lax/None 중 하나여야 합니다")
+        String sameSite
+) {
+}

--- a/src/main/java/com/example/thirdtool/Common/security/auth/token/JwtTokenIssuer.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/token/JwtTokenIssuer.java
@@ -3,6 +3,7 @@ package com.example.thirdtool.Common.security.auth.token;
 import com.example.thirdtool.Common.Util.JWTUtil;
 import com.example.thirdtool.Common.security.auth.RefreshEntity;
 import com.example.thirdtool.Common.security.auth.RefreshRepository;
+import com.example.thirdtool.Common.security.auth.jwt.JwtCookieProperties;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
@@ -13,14 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class JwtTokenIssuer implements TokenIssuer {
 
-    private static final String ACCESS_COOKIE_NAME = "access_token";
-
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
+    private final JwtCookieProperties cookieProperties;
 
-    public JwtTokenIssuer(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+    public JwtTokenIssuer(JWTUtil jwtUtil,
+                          RefreshRepository refreshRepository,
+                          JwtCookieProperties cookieProperties) {
         this.jwtUtil = jwtUtil;
         this.refreshRepository = refreshRepository;
+        this.cookieProperties = cookieProperties;
     }
 
     @Override
@@ -50,12 +53,12 @@ public class JwtTokenIssuer implements TokenIssuer {
     }
 
     private void writeAccessTokenCookie(HttpServletResponse response, String accessToken) {
-        ResponseCookie cookie = ResponseCookie.from(ACCESS_COOKIE_NAME, accessToken)
-                                              .httpOnly(true)
-                                              // Story 1-3에서 프로파일별 외부화 예정. 1-2에서는 안전한 기본값.
-                                              .secure(false)
-                                              .sameSite("Strict")
-                                              .path("/")
+        // Story 1-3: 쿠키 속성을 jwt.cookie.* 프로파일 외부화 값에서 주입
+        ResponseCookie cookie = ResponseCookie.from(cookieProperties.name(), accessToken)
+                                              .httpOnly(cookieProperties.httpOnly())
+                                              .secure(cookieProperties.secure())
+                                              .sameSite(cookieProperties.sameSite())
+                                              .path(cookieProperties.path())
                                               .maxAge(jwtUtil.accessTokenTtl())
                                               .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/src/test/java/com/example/thirdtool/Common/security/auth/token/JwtTokenIssuerTest.java
+++ b/src/test/java/com/example/thirdtool/Common/security/auth/token/JwtTokenIssuerTest.java
@@ -3,6 +3,7 @@ package com.example.thirdtool.Common.security.auth.token;
 import com.example.thirdtool.Common.Util.JWTUtil;
 import com.example.thirdtool.Common.security.auth.RefreshEntity;
 import com.example.thirdtool.Common.security.auth.RefreshRepository;
+import com.example.thirdtool.Common.security.auth.jwt.JwtCookieProperties;
 import com.example.thirdtool.Common.security.auth.jwt.JwtProperties;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,13 +36,24 @@ class JwtTokenIssuerTest {
     void setUp() {
         JwtProperties props = new JwtProperties(SECRET, Duration.ofMinutes(30), Duration.ofDays(7));
         jwtUtil = new JWTUtil(props);
+        // Test default: prod-like (secure=true) — 별도 케이스에서 override
+        JwtCookieProperties cookieProps = new JwtCookieProperties(
+                "access_token", "/", true, true, "Strict"
+        );
         refreshRepository = mock(RefreshRepository.class);
-        issuer = new JwtTokenIssuer(jwtUtil, refreshRepository);
+        issuer = new JwtTokenIssuer(jwtUtil, refreshRepository, cookieProps);
         response = new MockHttpServletResponse();
 
         when(refreshRepository.findEntityByUsername(any())).thenReturn(Optional.empty());
         when(refreshRepository.save(any(RefreshEntity.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private JwtTokenIssuer issuerWithCookie(boolean secure, String sameSite) {
+        JwtCookieProperties props = new JwtCookieProperties(
+                "access_token", "/", true, secure, sameSite
+        );
+        return new JwtTokenIssuer(jwtUtil, refreshRepository, props);
     }
 
     @Nested
@@ -90,6 +102,52 @@ class JwtTokenIssuerTest {
             issuer.issue(user, response);
 
             verify(refreshRepository, times(1)).save(any(RefreshEntity.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠키 보안 속성 프로파일 분기 (Story 1-3)")
+    class CookieAttributes {
+
+        @Test
+        @DisplayName("prod 프로파일(secure=true) 발급 시 Set-Cookie에 Secure 포함")
+        void issue_prodSecureTrue_setCookieHasSecure() {
+            JwtTokenIssuer prodIssuer = issuerWithCookie(true, "Strict");
+            UserEntity user = UserEntity.ofLocal("alice", "encoded", "alice-nick", "alice@example.com");
+
+            prodIssuer.issue(user, response);
+
+            String setCookie = response.getHeader("Set-Cookie");
+            assertThat(setCookie).contains("Secure");
+            assertThat(setCookie).contains("SameSite=Strict");
+            assertThat(setCookie).contains("HttpOnly");
+        }
+
+        @Test
+        @DisplayName("local/dev 프로파일(secure=false) 발급 시 Set-Cookie에 Secure 미포함")
+        void issue_devSecureFalse_setCookieNoSecure() {
+            JwtTokenIssuer devIssuer = issuerWithCookie(false, "Strict");
+            UserEntity user = UserEntity.ofLocal("alice", "encoded", "alice-nick", "alice@example.com");
+
+            devIssuer.issue(user, response);
+
+            String setCookie = response.getHeader("Set-Cookie");
+            assertThat(setCookie).doesNotContain("Secure;").doesNotContain(" Secure");
+            // SameSite=Strict / HttpOnly는 유지
+            assertThat(setCookie).contains("SameSite=Strict");
+            assertThat(setCookie).contains("HttpOnly");
+        }
+
+        @Test
+        @DisplayName("SameSite=Lax 설정도 Set-Cookie에 반영된다")
+        void issue_sameSiteLax_reflectedInSetCookie() {
+            JwtTokenIssuer laxIssuer = issuerWithCookie(true, "Lax");
+            UserEntity user = UserEntity.ofLocal("alice", "encoded", "alice-nick", "alice@example.com");
+
+            laxIssuer.issue(user, response);
+
+            String setCookie = response.getHeader("Set-Cookie");
+            assertThat(setCookie).contains("SameSite=Lax");
         }
     }
 


### PR DESCRIPTION
> **⚠️ Stacked PR**: Story 1-2(PR #124) 기반. 의존 머지 순서 #123 → #124 → #125.

## What

Product 1 Story 1-3 구현. AT HttpOnly Cookie 보안 속성을 `application.yml`로 외부화하고 프로파일별 분기 (`dev`: Secure=false, `prod`: Secure=true). Token Storage Strategy 의사결정을 ADR008로 기록.

- 신규: `Common/security/auth/jwt/JwtCookieProperties` (`@ConfigurationProperties("jwt.cookie")` record + `@Validated`)
- 변경: `JwtTokenIssuer.writeAccessTokenCookie` — 하드코딩 → `JwtCookieProperties` 주입
- 변경: `application.yml` — 공통 `jwt.cookie.*` + `dev`/`prod` 프로파일별 `secure` override
- 신규: `docs/adr/ADR008.md` — Token Storage Strategy + `docs/adr/index.md` 갱신
- 신규: `JwtTokenIssuerTest.CookieAttributes` 그룹 — 프로파일별 Set-Cookie 검증

## Why

Story 1-2에서 도입한 `JwtTokenIssuer`의 쿠키 발급 코드가 `secure=false`로 하드코딩되어 있어 프로덕션 배포 시 보안 우려. 동시에 `Secure=true`를 모든 환경에 강제하면 HTTPS 미사용 로컬 환경에서 쿠키가 전송되지 않아 개발이 막힘. 프로파일별 분기로 양쪽 모두 충족하며, 동시에 본 결정의 trade-off(AT Cookie vs RT Memory 역방향 선택)를 ADR008로 명문화.

## How

### 설계
- `JwtCookieProperties` (record):
  - `name`, `path`, `httpOnly`, `secure`, `sameSite` — Bean Validation + `@Pattern(Strict|Lax|None)`
  - 잘못된 sameSite 값 → 부팅 시 `BeanCreationException`
- `application.yml` 다중 문서 YAML 활용:
  - 공통: `jwt.cookie.secure: true` (안전한 기본값)
  - `dev` 프로파일: `secure: false` override (HTTPS 미사용 로컬)
  - `prod` 프로파일: `secure: true` override (HTTPS 강제)
- ADR008 핵심 결정:
  - AT 30분 HttpOnly Cookie / RT 7일 React 메모리
  - 업계 표준의 역방향. 트레이드오프(AT 만료 후 새로고침 시 재로그인)를 명시적으로 수용
  - 대안 3가지 비교 + 거부 사유 + 후속 Story 매핑 (1-4, 1-5, 2-2)

### 의식적 보류
- `JwtCookieProperties`에 `secure: false` + `prod` 프로파일 조합은 부팅 시 자동 차단 불가 — 운영자 실수 가능. 별도 hardening Story 필요 (PR 본문 명시)
- `application.yml`은 `.gitignore` — `dev`/`prod` 블록 변경분도 git에 반영되지 않음 — 동일하게 별도 정리 Story 필요

## Tradeoff

- `Secure=true` 프로덕션 강제 vs 운영자 설정 실수 가능성: `@Validated`는 enum/pattern까지만 강제. `prod + secure=false` 조합 차단은 별도 부팅 가드 필요
- ADR008의 "RT 메모리" 결정은 모바일 앱 도입 시 재검토 필요 — 후속 ADR 예고

## Test
- [x] `JwtTokenIssuerTest.CookieAttributes` (3건): prod/dev/SameSite=Lax Set-Cookie 검증
- [x] 기존 7건 + 신규 3건 모두 통과
- [x] `./gradlew compileJava` 통과
- [ ] `JwtCookieProperties` 부팅 검증(`@SpringBootTest`) — 본 PR 단위는 단위 검증으로 대체

## Checklist
- [x] AC 모두 충족 (prod Secure=true, local Secure=false, JwtCookieProperties 신설, AT body 없음, SameSite 검증, 잘못된 SameSite 부팅 실패)
- [x] ADR008 작성 + index.md 갱신
- [x] `[Story-1-3]` 태그 커밋

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)