### PR TITLE
[User] feat: User 도메인 BusinessException 계층 통일 (Story 5-1)

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -12,8 +12,16 @@ public enum ErrorCode {
     NOT_FOUND("C002",        "데이터를 찾을 수 없습니다.",   HttpStatus.NOT_FOUND),
 
     // ─── User ─────────────────────────────────────────────
-    USER_NOT_FOUND("USER001",  "사용자를 찾을 수 없습니다.",  HttpStatus.NOT_FOUND),
-    UNAUTHORIZED("USER002",    "인증이 필요합니다.",          HttpStatus.UNAUTHORIZED),
+    USER_NOT_FOUND("USER001",          "사용자를 찾을 수 없습니다.",       HttpStatus.NOT_FOUND),
+    UNAUTHORIZED("USER002",            "인증이 필요합니다.",               HttpStatus.UNAUTHORIZED),
+    USER_ALREADY_EXISTS("USER003",     "이미 가입된 사용자입니다.",         HttpStatus.CONFLICT),
+    USER_LOCKED("USER004",             "잠긴 계정입니다.",                  HttpStatus.FORBIDDEN),
+    // 로그인 실패는 USER_NOT_FOUND와 PASSWORD_NOT_MATCHED로 코드만 구분.
+    // 보안상 외부 응답 메시지는 USER_NOT_FOUND와 동일하게 유지한다.
+    PASSWORD_NOT_MATCHED("USER005",    "사용자를 찾을 수 없습니다.",       HttpStatus.UNAUTHORIZED),
+    USER_IS_SOCIAL("USER006",          "소셜 계정은 자체 로그인을 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    SOCIAL_PROVIDER_NOT_SUPPORTED("USER007", "지원하지 않는 소셜 제공자입니다.", HttpStatus.BAD_REQUEST),
+    SOCIAL_MEMBER_ALREADY_LINKED("USER008",  "이미 연동된 소셜 계정입니다.",     HttpStatus.CONFLICT),
 
     // ─── Refresh Token (Story 2-1) ────────────────────────
     REFRESH_TOKEN_INVALID("AUTH101",   "유효하지 않은 Refresh Token입니다.",               HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/example/thirdtool/User/application/UserService.java
+++ b/src/main/java/com/example/thirdtool/User/application/UserService.java
@@ -1,9 +1,9 @@
 package com.example.thirdtool.User.application;
 
-import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Common.security.auth.dto.TokenResponse;
 import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
 import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.User.domain.model.UserRoleType;
@@ -17,7 +17,6 @@ import com.example.thirdtool.User.infrastructure.kakao.KakaoMember;
 import com.example.thirdtool.Common.security.auth.jwt.JwtService;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +57,7 @@ public class UserService {
     public Long addUser(UserSignUpRequestDTO dto) {
 
         if (userRepository.existsByUsername(dto.getUsername())) {
-            throw new IllegalArgumentException("이미 유저가 존재합니다.");
+            throw UserDomainException.of(ErrorCode.USER_ALREADY_EXISTS);
         }
         UserEntity entity = UserEntity.ofLocal(
                 dto.getUsername(),
@@ -71,13 +70,23 @@ public class UserService {
     }
 
     // ✅ JWT 기반 자체 로그인 처리
+    // 보안: "사용자 없음"과 "비밀번호 불일치"는 외부에 동일 응답(PASSWORD_NOT_MATCHED, 401)으로 통일.
+    //       HTTP status code/code/message 모두 동일하게 노출해 enumeration attack 차단.
+    // 운영: IS_SOCIAL(소셜 계정 자체 로그인) / USER_LOCKED(잠긴 계정)은 별도 ErrorCode로 분기.
+    //       이 둘은 본인이 자기 계정 상태로 즉시 인지 가능한 정보라 누출 위험이 낮고 UX·운영에 필요.
     @Transactional
     public UserEntity loginLocal(String username, String password) {
-        UserEntity user = userRepository.findByUsernameAndIsLockAndIsSocial(username, false, false)
-                                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        UserEntity user = userRepository.findByUsername(username)
+                                        .orElseThrow(() -> UserDomainException.of(ErrorCode.PASSWORD_NOT_MATCHED));
 
+        if (Boolean.TRUE.equals(user.getIsSocial())) {
+            throw UserDomainException.of(ErrorCode.USER_IS_SOCIAL);
+        }
+        if (Boolean.TRUE.equals(user.getIsLock())) {
+            throw UserDomainException.of(ErrorCode.USER_LOCKED);
+        }
         if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+            throw UserDomainException.of(ErrorCode.PASSWORD_NOT_MATCHED);
         }
         return user;
     }
@@ -86,7 +95,7 @@ public class UserService {
     @Transactional
     public Long updateUser(String username, UserUpdateRequestDTO dto) throws AccessDeniedException {
         UserEntity entity = userRepository.findByUsernameAndIsLockAndIsSocial(username, false, false)
-                                          .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다: " + username));
+                                          .orElseThrow(() -> UserDomainException.of(ErrorCode.USER_NOT_FOUND));
 
         // 수정 권한 검증은 컨트롤러 또는 서비스 진입 전에 처리
         // if (!username.equals(entity.getUsername())) {
@@ -148,7 +157,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponseDTO readUser(String username) {
         UserEntity entity = userRepository.findByUsernameAndIsLock(username, false)
-                                          .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다: " + username));
+                                          .orElseThrow(() -> UserDomainException.of(ErrorCode.USER_NOT_FOUND));
         return new UserResponseDTO(username, entity.getIsSocial(), entity.getNickname(), entity.getEmail());
     }
 

--- a/src/main/java/com/example/thirdtool/User/domain/exception/UserDomainException.java
+++ b/src/main/java/com/example/thirdtool/User/domain/exception/UserDomainException.java
@@ -1,0 +1,32 @@
+package com.example.thirdtool.User.domain.exception;
+
+import com.example.thirdtool.Common.Exception.BusinessException;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+
+public class UserDomainException extends BusinessException {
+
+    private UserDomainException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    private UserDomainException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+
+    public static UserDomainException of(ErrorCode errorCode) {
+        return new UserDomainException(errorCode);
+    }
+
+    /**
+     * 부가 상세 메시지를 포함한 UserDomainException을 생성한다.
+     *
+     * <p>응답 body의 message: "{errorCode.message} — {detail}"
+     *
+     * <p>⚠ detail에 **사용자 입력값을 그대로 echo하지 말 것** — input reflection 패턴은
+     * 보안상 응답에 노출하지 않고 서버 로그에만 기록한다. 도메인 내부 컨텍스트
+     * (예: 자기 자신의 ID·DB식별자 등)에만 사용한다.
+     */
+    public static UserDomainException of(ErrorCode errorCode, String detail) {
+        return new UserDomainException(errorCode, detail);
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/presentation/SocialLoginController.java
+++ b/src/main/java/com/example/thirdtool/User/presentation/SocialLoginController.java
@@ -1,5 +1,7 @@
 package com.example.thirdtool.User.presentation;
 
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
 import com.example.thirdtool.User.infrastructure.Naver.NaverOAuthClient;
 import com.example.thirdtool.User.infrastructure.Naver.dto.NaverTokenResponse;
 import com.example.thirdtool.User.infrastructure.Naver.dto.NaverUserInfo;
@@ -11,12 +13,14 @@ import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.Common.security.auth.dto.TokenResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequestMapping("/social")
 @RequiredArgsConstructor
@@ -39,7 +43,14 @@ public class SocialLoginController {
 
         String code = payload.get("code");
         String state = payload.getOrDefault("state", null); // 네이버만 사용
-        SocialProviderType providerType = SocialProviderType.valueOf(provider.toUpperCase());
+        SocialProviderType providerType;
+        try {
+            providerType = SocialProviderType.valueOf(provider.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            // 사용자 입력값은 응답 메시지에 echo하지 않고 서버 로그에만 기록 (input reflection 방지).
+            log.warn("Unsupported social provider requested: {}", provider);
+            throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+        }
 
         String accessToken;
         String socialId;
@@ -65,7 +76,7 @@ public class SocialLoginController {
                 nickname = userInfo.getNickname();
                 email = userInfo.getEmail();
             }
-            default -> throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + provider);
+            default -> throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
         }
 
         // ✅ 회원가입 or 로그인 + AT Cookie + RT 바디 발급

--- a/src/test/java/com/example/thirdtool/User/application/UserServiceLoginExceptionTest.java
+++ b/src/test/java/com/example/thirdtool/User/application/UserServiceLoginExceptionTest.java
@@ -1,0 +1,140 @@
+package com.example.thirdtool.User.application;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Common.security.auth.jwt.JwtService;
+import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.User.domain.model.UserRoleType;
+import com.example.thirdtool.User.domain.repository.UserRepository;
+import com.example.thirdtool.User.dto.UserSignUpRequestDTO;
+import com.example.thirdtool.User.infrastructure.Naver.NaverMemberRepository;
+import com.example.thirdtool.User.infrastructure.kakao.KakaoMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Story-5-1: UserService 예외 통일 검증.
+ *
+ * loginLocal()의 실패 사유별 ErrorCode 분기와 addUser() 중복 가입 시
+ * USER_ALREADY_EXISTS throw를 단위로 확인한다. 단위 테스트라 Repository와
+ * PasswordEncoder만 Mock — 도메인 객체(UserEntity)는 실제 인스턴스 사용
+ * (conventions.md §4.1 Classist + Mock 외부 의존만).
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceLoginExceptionTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private TokenIssuer tokenIssuer;
+    @Mock
+    private KakaoMemberRepository kakaoMemberRepository;
+    @Mock
+    private NaverMemberRepository naverMemberRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    private UserEntity localUser;
+    private UserEntity socialUser;
+    private UserEntity lockedUser;
+
+    @BeforeEach
+    void setUp() {
+        localUser = UserEntity.ofLocal("alice", "ENCODED_PWD", "Alice", "alice@example.com");
+        socialUser = UserEntity.ofSocial("KAKAO_12345", SocialProviderType.KAKAO, "Kakao Alice", "kakao@example.com");
+        lockedUser = UserEntity.of(
+                "bob", "ENCODED_PWD",
+                true, false,
+                null, UserRoleType.USER,
+                "Bob", "bob@example.com");
+    }
+
+    @Test
+    void loginLocal_해피_정상_사용자_반환() {
+        given(userRepository.findByUsername("alice")).willReturn(Optional.of(localUser));
+        given(passwordEncoder.matches("plain", "ENCODED_PWD")).willReturn(true);
+
+        UserEntity result = userService.loginLocal("alice", "plain");
+
+        assertThat(result).isSameAs(localUser);
+    }
+
+    @Test
+    void loginLocal_사용자없음_PASSWORD_NOT_MATCHED로_통일() {
+        // 보안 정책(Critical 1 조치): 사용자 없음 / 비밀번호 불일치는 외부 응답 동일.
+        // 둘 다 PASSWORD_NOT_MATCHED(401)로 묶어 enumeration attack 차단.
+        given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.loginLocal("ghost", "pwd"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PASSWORD_NOT_MATCHED);
+    }
+
+    @Test
+    void loginLocal_소셜유저_USER_IS_SOCIAL() {
+        given(userRepository.findByUsername("KAKAO_12345")).willReturn(Optional.of(socialUser));
+
+        assertThatThrownBy(() -> userService.loginLocal("KAKAO_12345", "pwd"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_IS_SOCIAL);
+    }
+
+    @Test
+    void loginLocal_잠긴계정_USER_LOCKED() {
+        given(userRepository.findByUsername("bob")).willReturn(Optional.of(lockedUser));
+
+        assertThatThrownBy(() -> userService.loginLocal("bob", "pwd"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_LOCKED);
+    }
+
+    @Test
+    void loginLocal_비밀번호불일치_PASSWORD_NOT_MATCHED() {
+        given(userRepository.findByUsername("alice")).willReturn(Optional.of(localUser));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+        assertThatThrownBy(() -> userService.loginLocal("alice", "wrong"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PASSWORD_NOT_MATCHED);
+    }
+
+    @Test
+    void addUser_중복가입_USER_ALREADY_EXISTS() {
+        given(userRepository.existsByUsername("alice")).willReturn(true);
+
+        UserSignUpRequestDTO dto = new UserSignUpRequestDTO();
+        // dto는 getter만 사용되므로 reflection 없이 mockito BDD 스타일로 처리
+        // 다만 UserSignUpRequestDTO가 lombok @Setter라면 setter, 아니면 reflection 필요.
+        // 본 테스트는 existsByUsername 체크 단계까지만 도달하므로 username 한 필드만 채워도 OK.
+        org.springframework.test.util.ReflectionTestUtils.setField(dto, "username", "alice");
+
+        assertThatThrownBy(() -> userService.addUser(dto))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_ALREADY_EXISTS);
+    }
+}

--- a/src/test/java/com/example/thirdtool/User/presentation/SocialLoginControllerExceptionSliceTest.java
+++ b/src/test/java/com/example/thirdtool/User/presentation/SocialLoginControllerExceptionSliceTest.java
@@ -1,0 +1,70 @@
+package com.example.thirdtool.User.presentation;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Common.Exception.GlobalExceptionHandler;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-5-1 AC2 검증: User 도메인 예외가 GlobalExceptionHandler를 통해
+ * `{code, message, path, timestamp}` 형식으로 응답되는지 단위 검증.
+ *
+ * 본 테스트는 Spring 컨텍스트를 띄우지 않고 GlobalExceptionHandler를
+ * 직접 인스턴스화해 handleBusiness()를 호출 — `@WebMvcTest` Slice 보다
+ * 가볍지만 변환 흐름의 본질(ErrorCode → ResponseEntity status·body)을
+ * 동일하게 검증한다. 같은 chain을 거치는 다른 User 예외(USER_ALREADY_EXISTS
+ * 등)도 동일하게 적용된다.
+ */
+class SocialLoginControllerExceptionSliceTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleBusiness_SOCIAL_PROVIDER_NOT_SUPPORTED_400_USER007_응답() {
+        UserDomainException ex = UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+        HttpServletRequest req = new MockHttpServletRequest("POST", "/social/login/google");
+
+        ResponseEntity<?> response = handler.handleBusiness(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("USER007");
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getMessage"))
+                .isEqualTo("지원하지 않는 소셜 제공자입니다.");
+    }
+
+    @Test
+    void handleBusiness_PASSWORD_NOT_MATCHED_401_USER005_응답() {
+        // Critical 1 조치 검증: 로그인 실패 흐름이 401 + USER005 단일 응답으로 통일됨.
+        UserDomainException ex = UserDomainException.of(ErrorCode.PASSWORD_NOT_MATCHED);
+        HttpServletRequest req = new MockHttpServletRequest("POST", "/login");
+
+        ResponseEntity<?> response = handler.handleBusiness(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("USER005");
+    }
+
+    @Test
+    void handleBusiness_USER_IS_SOCIAL_400_USER006_응답() {
+        UserDomainException ex = UserDomainException.of(ErrorCode.USER_IS_SOCIAL);
+        HttpServletRequest req = new MockHttpServletRequest("POST", "/login");
+
+        ResponseEntity<?> response = handler.handleBusiness(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("USER006");
+    }
+}


### PR DESCRIPTION
## What

User BC 도메인 예외를 `BusinessException(ErrorCode)` 계층으로 통일하고, `loginLocal`의 로그인 실패 보안 누출을 차단한다.

**신규 ErrorCode 6개** (`Common/Exception/ErrorCode/ErrorCode.java` User 섹션):

| 코드 | 메시지 | HTTP |
| --- | --- | --- |
| `USER_ALREADY_EXISTS` (USER003) | 이미 가입된 사용자입니다. | 409 |
| `USER_LOCKED` (USER004) | 잠긴 계정입니다. | 403 |
| `PASSWORD_NOT_MATCHED` (USER005) | 사용자를 찾을 수 없습니다. (USER_NOT_FOUND와 동일) | 401 |
| `USER_IS_SOCIAL` (USER006) | 소셜 계정은 자체 로그인을 사용할 수 없습니다. | 400 |
| `SOCIAL_PROVIDER_NOT_SUPPORTED` (USER007) | 지원하지 않는 소셜 제공자입니다. | 400 |
| `SOCIAL_MEMBER_ALREADY_LINKED` (USER008) | 이미 연동된 소셜 계정입니다. | 409 — 후속 Story 예약 |

**`UserDomainException`** 신규 — Card BC `CardDomainException` 패턴 답습 (private constructor + static `of(ErrorCode)` / `of(ErrorCode, detail)`). detail 노출 안티패턴 경고 JavaDoc 포함.

**`UserService`** 예외 치환:
- `addUser`: `IllegalArgumentException` → `USER_ALREADY_EXISTS`
- `loginLocal`: 4단계 분기 재구성. 단 사용자 없음·비밀번호 불일치는 외부 응답을 `PASSWORD_NOT_MATCHED(401)` 단일로 통일 (보안 누출 차단).
- `updateUser`, `readUser`: `UsernameNotFoundException` → `USER_NOT_FOUND`

**`SocialLoginController`** 예외 치환:
- `SOCIAL_PROVIDER_NOT_SUPPORTED` throw. detail에 사용자 입력 echo 안 함 (input reflection 방지). `log.warn`으로 서버 로그에만 기록.

**테스트 신규 2건 / 9 케이스**:
- `UserServiceLoginExceptionTest` — Application Service 단위 6 케이스 (해피 1 / 엣지 2 / 예외 3)
- `SocialLoginControllerExceptionSliceTest` — GlobalExceptionHandler 단위 3 케이스 (AC2 직접 보장)

## Why

`workflow/product/Product.md` Product 2 — User BC 도메인 정합성 개선의 Epic 5 첫 Story.

기존 User BC는 `IllegalArgumentException` (1건) + `UsernameNotFoundException` (2건) + `BusinessException` (3건)이 혼용. `GlobalExceptionHandler`가 `BusinessException`만 `{code, message}` 형식으로 변환하므로 나머지 예외는 일관성 없는 응답으로 클라이언트 분기 부담 + 보안적 약점.

Plan(`C:\Users\user\.claude\plans\ticklish-toasting-thunder.md`) 권장 실행 순서대로 **Story 5-1을 Epic 4 앞으로 당김** — ErrorCode 계층이 먼저 준비되면 후속 Story 4-2(Parser), 4-3(Registrar)이 처음부터 `UserDomainException` 사용 가능.

## How

**Critical 결정 (Reviewer 발견 + 사용자 합의)**:

Story 5-1 원래 AC3 ("로그인 실패가 USER_NOT_FOUND와 PASSWORD_NOT_MATCHED로 구분")이 사실은 **보안 결함**임을 reviewer 세션에서 발견:
- USER_NOT_FOUND(404) / PASSWORD_NOT_MATCHED(401) — message를 같게 맞춰도 클라이언트는 HTTP status code로 "404면 사용자 없음, 401이면 사용자 있고 비밀번호만 틀림"을 식별 가능 → enumeration attack
- 사용자 합의 옵션 A: `loginLocal`에서 USER_NOT_FOUND 자체를 PASSWORD_NOT_MATCHED로 통일. status code/code/message 모두 동일.
- USER_NOT_FOUND는 `updateUser`/`readUser`에서 그대로 사용 (404 적절).
- `IS_SOCIAL` / `USER_LOCKED`은 별도 코드 유지 — 본인이 자기 계정 상태로 인지 가능한 정보라 누출 위험 낮고 UX·운영에 필요.

## Tradeoff

- AC3의 "코드로 구분" 의도 일부 포기 — `loginLocal`에서는 사용자 없음/비밀번호 불일치 응답이 외부에 동일. 서버 로그·메트릭에서는 구분 가능.
- `SOCIAL_MEMBER_ALREADY_LINKED` ErrorCode 등록만 하고 throw 사용처 0건 — 후속 Story 4-3(Registrar)에서 사용 예정 (PR 본문에 선제 등록 사유 명시).
- ADR005 Command/Query record 패턴 미적용 — Story 4-4(UserService Command/Query 분리) 범위.
- Controller→infrastructure 직접 import (`SocialLoginController` → `KakaoOAuthClient`) — 기존 패턴 유지, 후속 hygiene 후보.
- `deleteUser`의 `AccessDeniedException` 잔존 — Story 5-3 범위. AC2 "모든 User 예외가 GlobalExceptionHandler" 부분 미충족 (스프링 기본 403 처리). PR 본문에 명시.
- `@WebMvcTest` Slice 테스트는 SecurityConfig 의존성으로 컨텍스트 생성 실패 → GlobalExceptionHandler 직접 인스턴스화 단위로 대체. 같은 chain이라 본질 검증 동일.
- **PR #135 (Story-4-1) 미머지 상태에서 stacked 분기**. base가 `feat/019-custom-oauth2-user-service`. 본 PR diff에 Story-4-1 변경은 포함 안 됨 (PR #135 머지 후 본 PR rebase 또는 base 자동 변경).

## Reviewer 종합 (review.md §4 결과)

5관점 병렬 reviewer 세션:
- **Critical 1건**: PASSWORD_NOT_MATCHED 보안 누출 → **본 PR에서 조치** (사용자 합의 옵션 A)
- **Major 5건**:
  - detail input reflection (M2) → 본 PR 조치
  - AC2 응답 형식 검증 부재 (M3) → 본 PR 조치 (GlobalExceptionHandler 단위 테스트)
  - JavaDoc 누락 (M5) → 본 PR 조치
  - 분기 순서 (M4) → SKIP (Critical 1 해결 후 부차적)
  - updateUser/readUser 테스트 누락 (M6) → SKIP (Story 4-4 종료 시점 누적)
  - ADR005 Command/Query (Architecture M1) → Story 4-4 범위
  - Controller→infrastructure (Architecture M2) → 후속 Story
- **Minor / Nit**: 메서드명 패턴(나중 정리), ReflectionTestUtils DTO 사용(허용), `Boolean.TRUE.equals` 패턴(허용), `SOCIAL_MEMBER_ALREADY_LINKED` 미사용(예약), stacked 분기(인지)

사용자 의사결정: Critical 1 옵션 A + Major 2/3/5 조치 + 4/6 보류.

## Test

- [x] `./gradlew build` 그린 (1m55s, 전체 회귀 통과)
- [x] `UserServiceLoginExceptionTest` 6 케이스 그린
- [x] `SocialLoginControllerExceptionSliceTest` 3 케이스 그린
- [x] 정적: User BC 내 `IllegalArgumentException`/`UsernameNotFoundException` 직접 throw 0건 (catch 1건은 표준 라이브러리 처리 — AC1은 throw 0건이 기준)
- [ ] 로컬 부팅 + 로그인/회원가입/소셜 로그인 수동 검증 (사용자 검토)
- [ ] `updateUser`/`readUser`의 USER_NOT_FOUND 케이스 단위 테스트 — Story 4-4 종료 시점 누적 예정
- [ ] deleteUser AccessDeniedException → ErrorCode 변환 — Story 5-3 범위

## Checklist

- [x] DOMAIN.md / PACKAGE.md 변경 없음 (User BC 도메인 모델 신규 없음. `User/domain/exception/` 디렉토리는 Card BC와 동일 패턴이라 명시 불요)
- [x] BC 간 의존 방향 위반 없음 (User/domain → Common/Exception OK)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] Reviewer 세션 통과 (Critical 0건 잔존)
- [ ] ADR — 단독 ADR 부적격, "로그인 실패 응답 동일화 정책"은 PR 본문 + 코드 주석에 기록 (Epic 5 종료 시점 묶음 ADR 검토)

## Related

- `workflow/product/Product.md` — Product 2 Story 5-1 명세
- Plan: `C:\Users\user\.claude\plans\ticklish-toasting-thunder.md` (Story 5-1 권장 실행 순서 부분)
- Stacked base: PR #135 (Story-4-1)