### PR TITLE
[User] feat: Story-5-1 develop 반영 (stacked PR base 정정)

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -12,8 +12,16 @@ public enum ErrorCode {
     NOT_FOUND("C002",        "데이터를 찾을 수 없습니다.",   HttpStatus.NOT_FOUND),
 
     // ─── User ─────────────────────────────────────────────
-    USER_NOT_FOUND("USER001",  "사용자를 찾을 수 없습니다.",  HttpStatus.NOT_FOUND),
-    UNAUTHORIZED("USER002",    "인증이 필요합니다.",          HttpStatus.UNAUTHORIZED),
+    USER_NOT_FOUND("USER001",          "사용자를 찾을 수 없습니다.",       HttpStatus.NOT_FOUND),
+    UNAUTHORIZED("USER002",            "인증이 필요합니다.",               HttpStatus.UNAUTHORIZED),
+    USER_ALREADY_EXISTS("USER003",     "이미 가입된 사용자입니다.",         HttpStatus.CONFLICT),
+    USER_LOCKED("USER004",             "잠긴 계정입니다.",                  HttpStatus.FORBIDDEN),
+    // 로그인 실패는 USER_NOT_FOUND와 PASSWORD_NOT_MATCHED로 코드만 구분.
+    // 보안상 외부 응답 메시지는 USER_NOT_FOUND와 동일하게 유지한다.
+    PASSWORD_NOT_MATCHED("USER005",    "사용자를 찾을 수 없습니다.",       HttpStatus.UNAUTHORIZED),
+    USER_IS_SOCIAL("USER006",          "소셜 계정은 자체 로그인을 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    SOCIAL_PROVIDER_NOT_SUPPORTED("USER007", "지원하지 않는 소셜 제공자입니다.", HttpStatus.BAD_REQUEST),
+    SOCIAL_MEMBER_ALREADY_LINKED("USER008",  "이미 연동된 소셜 계정입니다.",     HttpStatus.CONFLICT),
 
     // ─── Refresh Token (Story 2-1) ────────────────────────
     REFRESH_TOKEN_INVALID("AUTH101",   "유효하지 않은 Refresh Token입니다.",               HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/example/thirdtool/User/application/UserService.java
+++ b/src/main/java/com/example/thirdtool/User/application/UserService.java
@@ -1,9 +1,9 @@
 package com.example.thirdtool.User.application;
 
-import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Common.security.auth.dto.TokenResponse;
 import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
 import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.User.domain.model.UserRoleType;
@@ -17,7 +17,6 @@ import com.example.thirdtool.User.infrastructure.kakao.KakaoMember;
 import com.example.thirdtool.Common.security.auth.jwt.JwtService;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +57,7 @@ public class UserService {
     public Long addUser(UserSignUpRequestDTO dto) {
 
         if (userRepository.existsByUsername(dto.getUsername())) {
-            throw new IllegalArgumentException("이미 유저가 존재합니다.");
+            throw UserDomainException.of(ErrorCode.USER_ALREADY_EXISTS);
         }
         UserEntity entity = UserEntity.ofLocal(
                 dto.getUsername(),
@@ -71,13 +70,23 @@ public class UserService {
     }
 
     // ✅ JWT 기반 자체 로그인 처리
+    // 보안: "사용자 없음"과 "비밀번호 불일치"는 외부에 동일 응답(PASSWORD_NOT_MATCHED, 401)으로 통일.
+    //       HTTP status code/code/message 모두 동일하게 노출해 enumeration attack 차단.
+    // 운영: IS_SOCIAL(소셜 계정 자체 로그인) / USER_LOCKED(잠긴 계정)은 별도 ErrorCode로 분기.
+    //       이 둘은 본인이 자기 계정 상태로 즉시 인지 가능한 정보라 누출 위험이 낮고 UX·운영에 필요.
     @Transactional
     public UserEntity loginLocal(String username, String password) {
-        UserEntity user = userRepository.findByUsernameAndIsLockAndIsSocial(username, false, false)
-                                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        UserEntity user = userRepository.findByUsername(username)
+                                        .orElseThrow(() -> UserDomainException.of(ErrorCode.PASSWORD_NOT_MATCHED));
 
+        if (Boolean.TRUE.equals(user.getIsSocial())) {
+            throw UserDomainException.of(ErrorCode.USER_IS_SOCIAL);
+        }
+        if (Boolean.TRUE.equals(user.getIsLock())) {
+            throw UserDomainException.of(ErrorCode.USER_LOCKED);
+        }
         if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+            throw UserDomainException.of(ErrorCode.PASSWORD_NOT_MATCHED);
         }
         return user;
     }
@@ -86,7 +95,7 @@ public class UserService {
     @Transactional
     public Long updateUser(String username, UserUpdateRequestDTO dto) throws AccessDeniedException {
         UserEntity entity = userRepository.findByUsernameAndIsLockAndIsSocial(username, false, false)
-                                          .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다: " + username));
+                                          .orElseThrow(() -> UserDomainException.of(ErrorCode.USER_NOT_FOUND));
 
         // 수정 권한 검증은 컨트롤러 또는 서비스 진입 전에 처리
         // if (!username.equals(entity.getUsername())) {
@@ -148,7 +157,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponseDTO readUser(String username) {
         UserEntity entity = userRepository.findByUsernameAndIsLock(username, false)
-                                          .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다: " + username));
+                                          .orElseThrow(() -> UserDomainException.of(ErrorCode.USER_NOT_FOUND));
         return new UserResponseDTO(username, entity.getIsSocial(), entity.getNickname(), entity.getEmail());
     }
 

--- a/src/main/java/com/example/thirdtool/User/domain/exception/UserDomainException.java
+++ b/src/main/java/com/example/thirdtool/User/domain/exception/UserDomainException.java
@@ -1,0 +1,32 @@
+package com.example.thirdtool.User.domain.exception;
+
+import com.example.thirdtool.Common.Exception.BusinessException;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+
+public class UserDomainException extends BusinessException {
+
+    private UserDomainException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    private UserDomainException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+
+    public static UserDomainException of(ErrorCode errorCode) {
+        return new UserDomainException(errorCode);
+    }
+
+    /**
+     * 부가 상세 메시지를 포함한 UserDomainException을 생성한다.
+     *
+     * <p>응답 body의 message: "{errorCode.message} — {detail}"
+     *
+     * <p>⚠ detail에 **사용자 입력값을 그대로 echo하지 말 것** — input reflection 패턴은
+     * 보안상 응답에 노출하지 않고 서버 로그에만 기록한다. 도메인 내부 컨텍스트
+     * (예: 자기 자신의 ID·DB식별자 등)에만 사용한다.
+     */
+    public static UserDomainException of(ErrorCode errorCode, String detail) {
+        return new UserDomainException(errorCode, detail);
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/presentation/SocialLoginController.java
+++ b/src/main/java/com/example/thirdtool/User/presentation/SocialLoginController.java
@@ -1,5 +1,7 @@
 package com.example.thirdtool.User.presentation;
 
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
 import com.example.thirdtool.User.infrastructure.Naver.NaverOAuthClient;
 import com.example.thirdtool.User.infrastructure.Naver.dto.NaverTokenResponse;
 import com.example.thirdtool.User.infrastructure.Naver.dto.NaverUserInfo;
@@ -11,12 +13,14 @@ import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.Common.security.auth.dto.TokenResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequestMapping("/social")
 @RequiredArgsConstructor
@@ -39,7 +43,14 @@ public class SocialLoginController {
 
         String code = payload.get("code");
         String state = payload.getOrDefault("state", null); // 네이버만 사용
-        SocialProviderType providerType = SocialProviderType.valueOf(provider.toUpperCase());
+        SocialProviderType providerType;
+        try {
+            providerType = SocialProviderType.valueOf(provider.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            // 사용자 입력값은 응답 메시지에 echo하지 않고 서버 로그에만 기록 (input reflection 방지).
+            log.warn("Unsupported social provider requested: {}", provider);
+            throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+        }
 
         String accessToken;
         String socialId;
@@ -65,7 +76,7 @@ public class SocialLoginController {
                 nickname = userInfo.getNickname();
                 email = userInfo.getEmail();
             }
-            default -> throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + provider);
+            default -> throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
         }
 
         // ✅ 회원가입 or 로그인 + AT Cookie + RT 바디 발급

--- a/src/test/java/com/example/thirdtool/User/application/UserServiceLoginExceptionTest.java
+++ b/src/test/java/com/example/thirdtool/User/application/UserServiceLoginExceptionTest.java
@@ -1,0 +1,140 @@
+package com.example.thirdtool.User.application;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Common.security.auth.jwt.JwtService;
+import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.User.domain.model.UserRoleType;
+import com.example.thirdtool.User.domain.repository.UserRepository;
+import com.example.thirdtool.User.dto.UserSignUpRequestDTO;
+import com.example.thirdtool.User.infrastructure.Naver.NaverMemberRepository;
+import com.example.thirdtool.User.infrastructure.kakao.KakaoMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Story-5-1: UserService 예외 통일 검증.
+ *
+ * loginLocal()의 실패 사유별 ErrorCode 분기와 addUser() 중복 가입 시
+ * USER_ALREADY_EXISTS throw를 단위로 확인한다. 단위 테스트라 Repository와
+ * PasswordEncoder만 Mock — 도메인 객체(UserEntity)는 실제 인스턴스 사용
+ * (conventions.md §4.1 Classist + Mock 외부 의존만).
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceLoginExceptionTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private TokenIssuer tokenIssuer;
+    @Mock
+    private KakaoMemberRepository kakaoMemberRepository;
+    @Mock
+    private NaverMemberRepository naverMemberRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    private UserEntity localUser;
+    private UserEntity socialUser;
+    private UserEntity lockedUser;
+
+    @BeforeEach
+    void setUp() {
+        localUser = UserEntity.ofLocal("alice", "ENCODED_PWD", "Alice", "alice@example.com");
+        socialUser = UserEntity.ofSocial("KAKAO_12345", SocialProviderType.KAKAO, "Kakao Alice", "kakao@example.com");
+        lockedUser = UserEntity.of(
+                "bob", "ENCODED_PWD",
+                true, false,
+                null, UserRoleType.USER,
+                "Bob", "bob@example.com");
+    }
+
+    @Test
+    void loginLocal_해피_정상_사용자_반환() {
+        given(userRepository.findByUsername("alice")).willReturn(Optional.of(localUser));
+        given(passwordEncoder.matches("plain", "ENCODED_PWD")).willReturn(true);
+
+        UserEntity result = userService.loginLocal("alice", "plain");
+
+        assertThat(result).isSameAs(localUser);
+    }
+
+    @Test
+    void loginLocal_사용자없음_PASSWORD_NOT_MATCHED로_통일() {
+        // 보안 정책(Critical 1 조치): 사용자 없음 / 비밀번호 불일치는 외부 응답 동일.
+        // 둘 다 PASSWORD_NOT_MATCHED(401)로 묶어 enumeration attack 차단.
+        given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.loginLocal("ghost", "pwd"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PASSWORD_NOT_MATCHED);
+    }
+
+    @Test
+    void loginLocal_소셜유저_USER_IS_SOCIAL() {
+        given(userRepository.findByUsername("KAKAO_12345")).willReturn(Optional.of(socialUser));
+
+        assertThatThrownBy(() -> userService.loginLocal("KAKAO_12345", "pwd"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_IS_SOCIAL);
+    }
+
+    @Test
+    void loginLocal_잠긴계정_USER_LOCKED() {
+        given(userRepository.findByUsername("bob")).willReturn(Optional.of(lockedUser));
+
+        assertThatThrownBy(() -> userService.loginLocal("bob", "pwd"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_LOCKED);
+    }
+
+    @Test
+    void loginLocal_비밀번호불일치_PASSWORD_NOT_MATCHED() {
+        given(userRepository.findByUsername("alice")).willReturn(Optional.of(localUser));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+        assertThatThrownBy(() -> userService.loginLocal("alice", "wrong"))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PASSWORD_NOT_MATCHED);
+    }
+
+    @Test
+    void addUser_중복가입_USER_ALREADY_EXISTS() {
+        given(userRepository.existsByUsername("alice")).willReturn(true);
+
+        UserSignUpRequestDTO dto = new UserSignUpRequestDTO();
+        // dto는 getter만 사용되므로 reflection 없이 mockito BDD 스타일로 처리
+        // 다만 UserSignUpRequestDTO가 lombok @Setter라면 setter, 아니면 reflection 필요.
+        // 본 테스트는 existsByUsername 체크 단계까지만 도달하므로 username 한 필드만 채워도 OK.
+        org.springframework.test.util.ReflectionTestUtils.setField(dto, "username", "alice");
+
+        assertThatThrownBy(() -> userService.addUser(dto))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_ALREADY_EXISTS);
+    }
+}

--- a/src/test/java/com/example/thirdtool/User/presentation/SocialLoginControllerExceptionSliceTest.java
+++ b/src/test/java/com/example/thirdtool/User/presentation/SocialLoginControllerExceptionSliceTest.java
@@ -1,0 +1,70 @@
+package com.example.thirdtool.User.presentation;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Common.Exception.GlobalExceptionHandler;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-5-1 AC2 검증: User 도메인 예외가 GlobalExceptionHandler를 통해
+ * `{code, message, path, timestamp}` 형식으로 응답되는지 단위 검증.
+ *
+ * 본 테스트는 Spring 컨텍스트를 띄우지 않고 GlobalExceptionHandler를
+ * 직접 인스턴스화해 handleBusiness()를 호출 — `@WebMvcTest` Slice 보다
+ * 가볍지만 변환 흐름의 본질(ErrorCode → ResponseEntity status·body)을
+ * 동일하게 검증한다. 같은 chain을 거치는 다른 User 예외(USER_ALREADY_EXISTS
+ * 등)도 동일하게 적용된다.
+ */
+class SocialLoginControllerExceptionSliceTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleBusiness_SOCIAL_PROVIDER_NOT_SUPPORTED_400_USER007_응답() {
+        UserDomainException ex = UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+        HttpServletRequest req = new MockHttpServletRequest("POST", "/social/login/google");
+
+        ResponseEntity<?> response = handler.handleBusiness(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("USER007");
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getMessage"))
+                .isEqualTo("지원하지 않는 소셜 제공자입니다.");
+    }
+
+    @Test
+    void handleBusiness_PASSWORD_NOT_MATCHED_401_USER005_응답() {
+        // Critical 1 조치 검증: 로그인 실패 흐름이 401 + USER005 단일 응답으로 통일됨.
+        UserDomainException ex = UserDomainException.of(ErrorCode.PASSWORD_NOT_MATCHED);
+        HttpServletRequest req = new MockHttpServletRequest("POST", "/login");
+
+        ResponseEntity<?> response = handler.handleBusiness(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("USER005");
+    }
+
+    @Test
+    void handleBusiness_USER_IS_SOCIAL_400_USER006_응답() {
+        UserDomainException ex = UserDomainException.of(ErrorCode.USER_IS_SOCIAL);
+        HttpServletRequest req = new MockHttpServletRequest("POST", "/login");
+
+        ResponseEntity<?> response = handler.handleBusiness(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("USER006");
+    }
+}


### PR DESCRIPTION
## What

PR #136 (Story-5-1)이 stacked PR 구조상 `feat/019-custom-oauth2-user-service`를 base로 머지되어 develop에 반영되지 않았다. 본 PR로 `feat/019` 브랜치 전체(PR #135 + PR #136 commit)를 develop에 반영한다.

PR #135는 이미 develop에 머지된 상태이므로 본 PR diff는 **Story-5-1 commit 2개만** 신규로 보인다:
- `b4e3d85 refactor(user): User 도메인 예외 BusinessException 계층 통일 [Story-5-1]`
- `9497a2a test(user): UserService + GlobalExceptionHandler 예외 매트릭스 검증 [Story-5-1]`

내용은 PR #136과 동일.

## Why

Stacked PR 머지 시 GitHub이 base를 자동 변경하지 않음. PR #136 머지 시 base가 여전히 `feat/019`였고, 결과 commit은 feat/019 브랜치에만 들어감. develop에는 USER ErrorCode 6개·`UserDomainException`·`UserService` 예외 치환이 미반영 상태.

이대로 Story-4-2 진입 시 develop 기점 분기에서 ErrorCode가 부족해 cascading 의존 문제 발생. 본 PR로 정정 후 4-2 진행.

## How

- `feat/019` 브랜치는 PR #135 + PR #136이 누적된 상태. 본 PR로 develop에 머지.
- 추가 코드 변경 없음 (재머지 PR).

## Reviewer 종합

Reviewer 세션은 PR #135 (Story-4-1) + PR #136 (Story-5-1)에서 이미 완료. 본 PR은 base 정정용이라 별도 Reviewer 불필요.

## Test

- [x] `./gradlew build` 그린 (PR #136 시점 1m55s 통과)
- [x] PR #136과 동일 코드 (`fe8802e` 머지 결과 = `feat/019` 현재 tip)

## Related

- PR #135 (Story-4-1, merged to develop)
- PR #136 (Story-5-1, merged to feat/019 — base 잘못 잡혔음)