### PR TITLE
[User] feat: SocialOAuthFlow 추상화 + Controller switch 제거 (Story 4-2)

### DIFF
--- a/src/main/java/com/example/thirdtool/User/application/SocialOAuthFlow.java
+++ b/src/main/java/com/example/thirdtool/User/application/SocialOAuthFlow.java
@@ -1,0 +1,37 @@
+package com.example.thirdtool.User.application;
+
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+
+/**
+ * 소셜 OAuth 인증 흐름의 application 포트.
+ *
+ * <p>Story-4-2: SocialLoginController가 제공자별 분기(switch) 없이
+ * {@code Map<SocialProviderType, SocialOAuthFlow>}로 호출.
+ *
+ * <p><strong>현재 한계</strong>: 신규 제공자(예: 구글) 추가 시 본 인터페이스
+ * 구현체 외에도 {@link com.example.thirdtool.User.application.UserService#socialLogin}
+ * 내부의 제공자별 SocialMember 저장 분기를 추가해야 한다. 본 분기는 Story 4-3
+ * (`SocialMemberRegistrar` 도메인 서비스)에서 캡슐화되어 제거 예정 — 그 시점부터
+ * "구현체 1개만 추가"로 완결된다.
+ *
+ * <p>구현체는 {@code User/infrastructure/{provider}/} 패키지에 둔다
+ * (외부 OAuth API 호출의 어댑터이므로 infrastructure 계층).
+ */
+public interface SocialOAuthFlow {
+
+    /**
+     * 본 흐름이 담당하는 제공자 종류. Map 분기 키로 사용.
+     */
+    SocialProviderType getProviderType();
+
+    /**
+     * Authorization Code로 소셜 제공자에 인증을 수행하고 통일된
+     * {@link SocialUserInfo}로 반환한다.
+     *
+     * @param code  Authorization Code (필수)
+     * @param state OAuth state 파라미터 (네이버 등 필요 시. 카카오는 무시 가능)
+     * @return 제공자 의존 없는 사용자 정보
+     */
+    SocialUserInfo authenticate(String code, String state);
+}

--- a/src/main/java/com/example/thirdtool/User/domain/model/SocialUserInfo.java
+++ b/src/main/java/com/example/thirdtool/User/domain/model/SocialUserInfo.java
@@ -1,0 +1,36 @@
+package com.example.thirdtool.User.domain.model;
+
+/**
+ * 소셜 제공자(카카오·네이버 등)로부터 받은 사용자 식별·프로필 정보를
+ * 제공자 의존 없는 표준 VO로 표현한다.
+ *
+ * <p>Story-4-2에서 도입. {@link SocialOAuthFlow} 구현체가 제공자별
+ * 응답(예: {@code KakaoUserInfo}, {@code NaverUserInfo})을 본 VO로 변환해
+ * 반환한다. 호출자({@code SocialLoginController})는 본 VO만 알면 된다.
+ *
+ * <p>불변식:
+ * <ul>
+ *   <li>{@code socialId}, {@code provider}는 null/blank 금지.
+ *   <li>{@code nickname}, {@code email}은 nullable — 제공자별 미제공 가능.
+ * </ul>
+ *
+ * @param socialId 소셜 제공자 측의 고유 사용자 ID
+ * @param nickname 표시 닉네임 (nullable)
+ * @param email    이메일 (nullable, 제공자별 동의 항목에 따라 누락 가능)
+ * @param provider 제공자 종류
+ */
+public record SocialUserInfo(
+        String socialId,
+        String nickname,
+        String email,
+        SocialProviderType provider
+) {
+    public SocialUserInfo {
+        if (socialId == null || socialId.isBlank()) {
+            throw new IllegalArgumentException("socialId must not be blank");
+        }
+        if (provider == null) {
+            throw new IllegalArgumentException("provider must not be null");
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/infrastructure/Naver/NaverOAuthFlow.java
+++ b/src/main/java/com/example/thirdtool/User/infrastructure/Naver/NaverOAuthFlow.java
@@ -1,0 +1,37 @@
+package com.example.thirdtool.User.infrastructure.Naver;
+
+import com.example.thirdtool.User.application.SocialOAuthFlow;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.infrastructure.Naver.dto.NaverTokenResponse;
+import com.example.thirdtool.User.infrastructure.Naver.dto.NaverUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 네이버 OAuth 인증 흐름. {@link NaverOAuthClient}에 외부 API 호출을 위임하고
+ * 응답을 표준 {@link SocialUserInfo}로 변환한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class NaverOAuthFlow implements SocialOAuthFlow {
+
+    private final NaverOAuthClient naverOAuthClient;
+
+    @Override
+    public SocialProviderType getProviderType() {
+        return SocialProviderType.NAVER;
+    }
+
+    @Override
+    public SocialUserInfo authenticate(String code, String state) {
+        NaverTokenResponse tokenResponse = naverOAuthClient.getAccessToken(code, state);
+        NaverUserInfo userInfo = naverOAuthClient.getUserInfo(tokenResponse.getAccess_token());
+        return new SocialUserInfo(
+                userInfo.getId(),
+                userInfo.getNickname(),
+                userInfo.getEmail(),
+                SocialProviderType.NAVER
+        );
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/infrastructure/kakao/KakaoOAuthFlow.java
+++ b/src/main/java/com/example/thirdtool/User/infrastructure/kakao/KakaoOAuthFlow.java
@@ -1,0 +1,38 @@
+package com.example.thirdtool.User.infrastructure.kakao;
+
+import com.example.thirdtool.User.application.SocialOAuthFlow;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoTokenResponse;
+import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 카카오 OAuth 인증 흐름. {@link KakaoOAuthClient}에 외부 API 호출을 위임하고
+ * 응답을 표준 {@link SocialUserInfo}로 변환한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthFlow implements SocialOAuthFlow {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+
+    @Override
+    public SocialProviderType getProviderType() {
+        return SocialProviderType.KAKAO;
+    }
+
+    @Override
+    public SocialUserInfo authenticate(String code, String state) {
+        // 카카오는 state를 사용하지 않음.
+        KakaoTokenResponse tokenResponse = kakaoOAuthClient.getAccessToken(code);
+        KakaoUserInfo userInfo = kakaoOAuthClient.getUserInfo(tokenResponse.getAccess_token());
+        return new SocialUserInfo(
+                userInfo.getId(),
+                userInfo.getNickname(),
+                userInfo.getEmail(),
+                SocialProviderType.KAKAO
+        );
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/presentation/SocialLoginController.java
+++ b/src/main/java/com/example/thirdtool/User/presentation/SocialLoginController.java
@@ -1,37 +1,48 @@
 package com.example.thirdtool.User.presentation;
 
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
-import com.example.thirdtool.User.domain.exception.UserDomainException;
-import com.example.thirdtool.User.infrastructure.Naver.NaverOAuthClient;
-import com.example.thirdtool.User.infrastructure.Naver.dto.NaverTokenResponse;
-import com.example.thirdtool.User.infrastructure.Naver.dto.NaverUserInfo;
-import com.example.thirdtool.User.infrastructure.kakao.KakaoOAuthClient;
-import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoTokenResponse;
-import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoUserInfo;
-import com.example.thirdtool.User.application.UserService;
-import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.Common.security.auth.dto.TokenResponse;
+import com.example.thirdtool.User.application.SocialOAuthFlow;
+import com.example.thirdtool.User.application.UserService;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+/**
+ * 소셜 로그인 통합 엔드포인트.
+ *
+ * <p>Story-4-2: 제공자별 분기({@code switch(providerType)})를 제거하고
+ * {@link SocialOAuthFlow} 구현체를 {@code Map<SocialProviderType, SocialOAuthFlow>}로
+ * 주입받아 단일 호출로 처리. 신규 제공자 추가는 {@link SocialOAuthFlow} 구현체
+ * 1개를 {@link org.springframework.stereotype.Component @Component} 등록만 하면
+ * 자동으로 Map에 합류.
+ */
 @Slf4j
 @RestController
 @RequestMapping("/social")
-@RequiredArgsConstructor
 public class SocialLoginController {
 
     private final UserService userService;
-    private final KakaoOAuthClient kakaoOauthClient;
-    private final NaverOAuthClient naverOauthClient;
+    private final Map<SocialProviderType, SocialOAuthFlow> oauthFlows;
+
+    public SocialLoginController(UserService userService, List<SocialOAuthFlow> flows) {
+        this.userService = userService;
+        this.oauthFlows = flows.stream()
+                               .collect(Collectors.toMap(SocialOAuthFlow::getProviderType, Function.identity()));
+    }
 
     /**
-     * 소셜 로그인 통합 엔드포인트
+     * 소셜 로그인 통합 엔드포인트.
      * - provider: "kakao" or "naver"
      * - code, state (네이버용)
      */
@@ -42,52 +53,35 @@ public class SocialLoginController {
             HttpServletResponse response) {
 
         String code = payload.get("code");
-        String state = payload.getOrDefault("state", null); // 네이버만 사용
-        SocialProviderType providerType;
+        String state = payload.getOrDefault("state", null);
+        SocialProviderType providerType = resolveProvider(provider);
+
+        SocialOAuthFlow flow = oauthFlows.get(providerType);
+        if (flow == null) {
+            // 등록된 SocialOAuthFlow 구현체가 없는 경우 — 신규 제공자 enum이
+            // 추가됐는데 구현체가 누락된 상황. 운영자에게 빠른 감지를 위해 경고 로그.
+            log.warn("No SocialOAuthFlow registered for provider: {}", providerType);
+            throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+        }
+
+        SocialUserInfo info = flow.authenticate(code, state);
+        TokenResponse tokens = userService.socialLogin(
+                info.provider(),
+                info.socialId(),
+                info.nickname(),
+                info.email(),
+                response
+        );
+        return ResponseEntity.ok(tokens);
+    }
+
+    private SocialProviderType resolveProvider(String provider) {
         try {
-            providerType = SocialProviderType.valueOf(provider.toUpperCase());
+            return SocialProviderType.valueOf(provider.toUpperCase());
         } catch (IllegalArgumentException ex) {
             // 사용자 입력값은 응답 메시지에 echo하지 않고 서버 로그에만 기록 (input reflection 방지).
             log.warn("Unsupported social provider requested: {}", provider);
             throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
         }
-
-        String accessToken;
-        String socialId;
-        String nickname;
-        String email;
-
-        switch (providerType) {
-            case KAKAO -> {
-                KakaoTokenResponse tokenResponse = kakaoOauthClient.getAccessToken(code);
-                accessToken = tokenResponse.getAccess_token();
-                KakaoUserInfo userInfo = kakaoOauthClient.getUserInfo(accessToken);
-
-                socialId = userInfo.getId();
-                nickname = userInfo.getNickname();
-                email = userInfo.getEmail();
-            }
-            case NAVER -> {
-                NaverTokenResponse tokenResponse = naverOauthClient.getAccessToken(code, state);
-                accessToken = tokenResponse.getAccess_token();
-                NaverUserInfo userInfo = naverOauthClient.getUserInfo(accessToken);
-
-                socialId = userInfo.getId();
-                nickname = userInfo.getNickname();
-                email = userInfo.getEmail();
-            }
-            default -> throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
-        }
-
-        // ✅ 회원가입 or 로그인 + AT Cookie + RT 바디 발급
-        TokenResponse tokens = userService.socialLogin(
-                providerType,
-                socialId,
-                nickname,
-                email,
-                response
-                                                      );
-
-        return ResponseEntity.ok(tokens);
     }
 }

--- a/src/test/java/com/example/thirdtool/User/domain/model/SocialUserInfoTest.java
+++ b/src/test/java/com/example/thirdtool/User/domain/model/SocialUserInfoTest.java
@@ -1,0 +1,54 @@
+package com.example.thirdtool.User.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SocialUserInfoTest {
+
+    @Test
+    void create_valid_생성성공() {
+        SocialUserInfo info = new SocialUserInfo("12345", "Alice", "a@test", SocialProviderType.KAKAO);
+
+        assertThat(info.socialId()).isEqualTo("12345");
+        assertThat(info.nickname()).isEqualTo("Alice");
+        assertThat(info.email()).isEqualTo("a@test");
+        assertThat(info.provider()).isEqualTo(SocialProviderType.KAKAO);
+    }
+
+    @Test
+    void create_nickname_null_허용() {
+        // 제공자별 닉네임 미동의 케이스
+        SocialUserInfo info = new SocialUserInfo("12345", null, "a@test", SocialProviderType.NAVER);
+        assertThat(info.nickname()).isNull();
+    }
+
+    @Test
+    void create_email_null_허용() {
+        // 제공자별 이메일 미동의 케이스
+        SocialUserInfo info = new SocialUserInfo("12345", "Alice", null, SocialProviderType.KAKAO);
+        assertThat(info.email()).isNull();
+    }
+
+    @Test
+    void create_socialId_null_예외() {
+        assertThatThrownBy(() -> new SocialUserInfo(null, "Alice", "a@test", SocialProviderType.KAKAO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("socialId");
+    }
+
+    @Test
+    void create_socialId_blank_예외() {
+        assertThatThrownBy(() -> new SocialUserInfo("  ", "Alice", "a@test", SocialProviderType.KAKAO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("socialId");
+    }
+
+    @Test
+    void create_provider_null_예외() {
+        assertThatThrownBy(() -> new SocialUserInfo("12345", "Alice", "a@test", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("provider");
+    }
+}

--- a/src/test/java/com/example/thirdtool/User/infrastructure/Naver/NaverOAuthFlowTest.java
+++ b/src/test/java/com/example/thirdtool/User/infrastructure/Naver/NaverOAuthFlowTest.java
@@ -1,0 +1,70 @@
+package com.example.thirdtool.User.infrastructure.Naver;
+
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.infrastructure.Naver.dto.NaverTokenResponse;
+import com.example.thirdtool.User.infrastructure.Naver.dto.NaverUserInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NaverOAuthFlowTest {
+
+    @Mock
+    private NaverOAuthClient naverOAuthClient;
+
+    @InjectMocks
+    private NaverOAuthFlow flow;
+
+    @Test
+    void getProviderType_NAVER_반환() {
+        assertThat(flow.getProviderType()).isEqualTo(SocialProviderType.NAVER);
+    }
+
+    @Test
+    void authenticate_정상응답_SocialUserInfo로_변환() {
+        NaverTokenResponse token = new NaverTokenResponse();
+        token.setAccess_token("AT_NAVER");
+
+        NaverUserInfo userInfo = new NaverUserInfo();
+        NaverUserInfo.NaverResponse response = new NaverUserInfo.NaverResponse();
+        response.setId("naver-999");
+        response.setNickname("NaverUser");
+        response.setEmail("user@naver.test");
+        userInfo.setResponse(response);
+
+        given(naverOAuthClient.getAccessToken("CODE", "STATE")).willReturn(token);
+        given(naverOAuthClient.getUserInfo("AT_NAVER")).willReturn(userInfo);
+
+        SocialUserInfo result = flow.authenticate("CODE", "STATE");
+
+        assertThat(result.socialId()).isEqualTo("naver-999");
+        assertThat(result.nickname()).isEqualTo("NaverUser");
+        assertThat(result.email()).isEqualTo("user@naver.test");
+        assertThat(result.provider()).isEqualTo(SocialProviderType.NAVER);
+    }
+
+    @Test
+    void authenticate_state가_NaverOAuthClient에_그대로_전달됨() {
+        NaverTokenResponse token = new NaverTokenResponse();
+        token.setAccess_token("AT");
+        NaverUserInfo userInfo = new NaverUserInfo();
+        NaverUserInfo.NaverResponse response = new NaverUserInfo.NaverResponse();
+        response.setId("naver-1");
+        userInfo.setResponse(response);
+
+        given(naverOAuthClient.getAccessToken("CODE", "STATE_X")).willReturn(token);
+        given(naverOAuthClient.getUserInfo("AT")).willReturn(userInfo);
+
+        SocialUserInfo result = flow.authenticate("CODE", "STATE_X");
+
+        assertThat(result.socialId()).isEqualTo("naver-1");
+        // Mockito stubbing이 정확한 인자(CODE, STATE_X)로 매치돼야 호출 성공
+    }
+}

--- a/src/test/java/com/example/thirdtool/User/infrastructure/kakao/KakaoOAuthFlowTest.java
+++ b/src/test/java/com/example/thirdtool/User/infrastructure/kakao/KakaoOAuthFlowTest.java
@@ -1,0 +1,77 @@
+package com.example.thirdtool.User.infrastructure.kakao;
+
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoTokenResponse;
+import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoUserInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoOAuthFlowTest {
+
+    @Mock
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @InjectMocks
+    private KakaoOAuthFlow flow;
+
+    @Test
+    void getProviderType_KAKAO_반환() {
+        assertThat(flow.getProviderType()).isEqualTo(SocialProviderType.KAKAO);
+    }
+
+    @Test
+    void authenticate_정상응답_SocialUserInfo로_변환() {
+        KakaoTokenResponse token = new KakaoTokenResponse();
+        token.setAccess_token("AT123");
+
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo();
+        kakaoUserInfo.setId("12345");
+        // KakaoUserInfo.getNickname/getEmail은 내부 kakao_account/profile 객체 경유.
+        // 본 단위 테스트는 변환 매핑만 검증하므로 setter로 직접 채워 넣음.
+        KakaoUserInfo.KakaoAccount account = new KakaoUserInfo.KakaoAccount();
+        account.setEmail("user@kakao.test");
+        KakaoUserInfo.KakaoProfile profile = new KakaoUserInfo.KakaoProfile();
+        profile.setNickname("KakaoUser");
+        account.setProfile(profile);
+        ReflectionTestUtils.setField(kakaoUserInfo, "kakao_account", account);
+
+        given(kakaoOAuthClient.getAccessToken("CODE")).willReturn(token);
+        given(kakaoOAuthClient.getUserInfo("AT123")).willReturn(kakaoUserInfo);
+
+        SocialUserInfo result = flow.authenticate("CODE", null);
+
+        assertThat(result.socialId()).isEqualTo("12345");
+        assertThat(result.nickname()).isEqualTo("KakaoUser");
+        assertThat(result.email()).isEqualTo("user@kakao.test");
+        assertThat(result.provider()).isEqualTo(SocialProviderType.KAKAO);
+    }
+
+    @Test
+    void authenticate_state는_무시되고_getAccessToken_code_단일인자만_호출() {
+        // state 인자가 와도 무시되고 KakaoOAuthClient.getAccessToken(code) 단일 인자만 호출됨을 verify로 명시 검증.
+        KakaoTokenResponse token = new KakaoTokenResponse();
+        token.setAccess_token("AT");
+        KakaoUserInfo userInfo = new KakaoUserInfo();
+        userInfo.setId("99");
+
+        given(kakaoOAuthClient.getAccessToken("CODE")).willReturn(token);
+        given(kakaoOAuthClient.getUserInfo("AT")).willReturn(userInfo);
+
+        SocialUserInfo result = flow.authenticate("CODE", "RANDOM_STATE_IGNORED");
+
+        assertThat(result.socialId()).isEqualTo("99");
+        // KakaoOAuthClient.getAccessToken은 정확히 "CODE" 인자로 1회 호출 — state는 어디에도 전달되지 않음.
+        verify(kakaoOAuthClient).getAccessToken("CODE");
+        verify(kakaoOAuthClient).getUserInfo("AT");
+    }
+}


### PR DESCRIPTION
## What

소셜 로그인 흐름을 제공자별 `SocialOAuthFlow` 구현체로 분리하고, `SocialLoginController`의 `switch(providerType)` 분기를 Map 자동 dispatch로 대체한다.

**신규 4 파일**:
- `User/domain/model/SocialUserInfo.java` — VO record (`socialId`, `nickname`, `email`, `provider`). socialId/provider null·blank 금지, nickname/email nullable.
- `User/application/SocialOAuthFlow.java` — port 인터페이스. `getProviderType()` + `authenticate(code, state) → SocialUserInfo`.
- `User/infrastructure/kakao/KakaoOAuthFlow.java` — `KakaoOAuthClient` 위임 + `SocialUserInfo` 변환. state 무시.
- `User/infrastructure/Naver/NaverOAuthFlow.java` — `NaverOAuthClient` 위임 + state 전달.

**수정**:
- `User/presentation/SocialLoginController.java` — switch 제거. `List<SocialOAuthFlow>` 생성자 주입 → `Map<SocialProviderType, SocialOAuthFlow>` 변환. `flow.authenticate(code, state)` 단일 호출. infrastructure 직접 import 제거.

**테스트 신규 3 파일 / 12 케이스**:
- `KakaoOAuthFlowTest` (3): 해피 2 + 엣지 1 (state 무시를 Mockito `verify`로 명시 검증)
- `NaverOAuthFlowTest` (3): 해피 2 + 엣지 1 (state 전달)
- `SocialUserInfoTest` (6): 해피 1 / 엣지 2 / 예외 3

## Why

`workflow/product/Product.md` Product 2 — User BC 도메인 정합성 개선의 Epic 4 두 번째 Story.

**명세 변경 이력** (Product.md Story 4-2 절 갱신 포함 — `/workflow/`는 .gitignore라 본 PR diff엔 안 들어가지만 로컬 자료 정확화):
- 원 명세: `CustomOAuth2UserService`에 `SocialUserInfoParser` 주입 (`parse(Map<String,Object>)`)
- 실제 채택: Story 4-1에서 `CustomOAuth2UserService` 폐기됨 → 적용 위치를 `SocialLoginController`로 조정. 책임 단위도 "OAuth2User attributes 파싱"에서 "Authorization Code부터 SocialUserInfo까지 전체 인증 흐름"으로 격상 (사용자 합의 옵션 A, 2026-05-28).

`SocialLoginController`가 인프라(`KakaoOAuthClient`·`NaverOAuthClient` 등)를 직접 의존하던 PR #136 Architecture Major 지적도 해소 — 이제 application port만 의존.

## How

- `SocialOAuthFlow` 구현체는 `@Component` 등록 → Spring이 `List<SocialOAuthFlow>`로 자동 수집 → Controller 생성자에서 `Collectors.toMap`으로 Map 변환
- 신규 제공자(구글) 추가 비용: `SocialOAuthFlow` 구현체 1개 신규 + (Story 4-3 완료 후) Story 4-3의 Registrar 분기 1줄 추가만 필요
- Spring DI 패턴 trade-off:
  - 장점: Open/Closed — Controller 변경 없이 새 제공자 추가. `@Bean` 명시 등록 불요
  - 단점: List → Map 변환을 생성자에서 매번 수행. 같은 ProviderType 중복 시 `IllegalStateException`로 부팅 실패 (의도된 fail-fast이지만 진단 메시지 약함 — 후속 hygiene 후보)

## Tradeoff

**알려진 한계** (본 Story 외 처리, PR 본문·코드 주석에 명시):
- **"신규 제공자 = 단일 클래스"가 본 Story 단독으로 미달성**: `UserService.socialLogin()` 내부의 KAKAO/NAVER 분기 잔존. Story 4-3 (`SocialMemberRegistrar`)에서 해소. `SocialOAuthFlow.java:11` Javadoc에 명시.
- **ADR005 Command/Query record 미적용**: `authenticate(String code, String state)`가 raw 인자. Story 4-4 범위.
- **`Naver` 패키지명 (대문자) — Java 컨벤션 위반**: 기존 코드 잔존, 본 Story가 만든 게 아님. 별도 hygiene Story.
- **WebClient `.block()` 동기 호출** (`KakaoOAuthClient`·`NaverOAuthClient`): Reactor 스레드 풀 차단 안티패턴. 별도 hygiene/리팩토링 Story.
- **`SOCIAL_PROVIDER_NOT_SUPPORTED` 두 곳 throw — 의미 차이**: (a) 입력 enum 미존재 vs (b) enum 있지만 구현체 누락. 별도 ErrorCode 분리는 후속.
- **Spring 직접 `Map<SocialProviderType, SocialOAuthFlow>` 주입 대안**: 현재 List→Map 변환 패턴 유지. Map 직접 주입 또는 `SocialOAuthFlowRegistry` 빈 추출은 후속.

## Reviewer 종합 (review.md §4 결과)

5관점 병렬 reviewer 세션:
- **Critical 3건**:
  - [Architecture] ADR005 미적용 → Story 4-4 명시 (본 PR 보류, Tradeoff에 명시)
  - [Domain] UserEntity 불변식 검증 부재 → 본 Story 범위 외 (기존 결함)
  - [Test] state 무시 verify 부재 → **본 PR 조치 (Mockito verify 명시화)**
- **Major 9건**:
  - [Sceptical] Product.md 명세 갱신 → **본 PR 조치**
  - [Sceptical] SocialOAuthFlow Javadoc "단일 클래스" 정정 → **본 PR 조치**
  - 나머지(toMap merger, Port 위치, SocialUserInfo 위치, ErrorCode 분리, 패키지명, 슬라이스 테스트) → 후속
- **Minor / Nit**: DOMAIN.md 미반영, .block() 안티패턴, 죽은 코드 위험 등 — 후속

사용자 의사결정: 옵션 1 (Sceptical 1·2 + Test Critical 조치, 나머지 다음 Story로).

## Test

- [x] `./gradlew build` 그린 (전체 회귀 통과)
- [x] `KakaoOAuthFlowTest` 3 케이스 그린 (state 무시를 `verify(client).getAccessToken("CODE")`로 명시)
- [x] `NaverOAuthFlowTest` 3 케이스 그린
- [x] `SocialUserInfoTest` 6 케이스 그린 (해피 1 / 엣지 2 / 예외 3)
- [x] API 동작 100% 호환: `/social/login/{provider}` 요청·응답 형식 무변
- [ ] 로컬 부팅 + 카카오/네이버 소셜 로그인 수동 검증 (사용자 검토)
- [ ] Controller 슬라이스 통합 테스트 — 후속 누적

## Checklist

- [x] BC 간 의존 방향 준수 (presentation → application port → infrastructure adapter)
- [x] Reviewer 세션 통과 (Critical 잔존 항목은 Story 4-3/4-4/별도 명시)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 (변경 없음)
- [ ] DOMAIN.md §2.5 `SocialUserInfo` VO + `SocialOAuthFlow` 포트 항목 추가 — 후속 docs commit (Story 4-3 종료 시점 묶음)
- [ ] ADR — 단독 ADR 부적격 (Strategy 패턴 표준 적용). Epic 4 종료 시점 묶음 ADR 검토.

## Related

- `workflow/product/Product.md` — Product 2 Story 4-2 명세 (본 PR로 SocialOAuthFlow 명세 갱신, 단 `/workflow/`는 .gitignore라 PR diff 외)
- Plan: `C:\Users\user\.claude\plans\ticklish-toasting-thunder.md`
- 선행: PR #135 (Story-4-1, merged) + PR #137 (Story-5-1 base 정정, merged)