### PR TITLE
[User] feat: SocialMemberRegistrar + Strategy 패턴 도입 (Story 4-3)

### DIFF
--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -155,7 +155,9 @@ public LearningFacadeResponse.UpdateAxisName updateAxisName(
 - `infrastructure/persistence/` — Repository Port + Adapter 다수 (LearningFacade/AxisTopic/LearningMaterial/TopicMaterial/TopicRevision/RevisionReasonOption/TopicDeletionRecord 각각)
 
 ### User
-- `domain/model/` — `UserEntity`(AR), `SocialMember`(Abstract Entity), `KakaoMember`, `NaverMember`, `SocialProviderType`(E), `UserRoleType`(E)
+- `domain/model/` — `UserEntity`(AR), `SocialMember`(Abstract Entity), `KakaoMember`, `NaverMember`, `SocialProviderType`(E), `UserRoleType`(E), `SocialUserInfo`(VO, Story-4-2), `SocialMemberRegistrar`(Domain Service, Story-4-3)
+- `domain/exception/` — `UserDomainException` (Story-5-1, Card BC 패턴 답습)
+- `application/` (포트) — `SocialOAuthFlow`(Story-4-2), `SocialMemberFactory`(Story-4-3) — 인프라 어댑터 교환점
 - `domain/repository/` — `UserRepository`(Port) **← 표준은 `infrastructure/persistence/`, 레거시**
 - `application/` — `UserService`
 - `dto/` (BC 루트) — Request/Response DTO 다수 **← 표준은 `presentation/dto/`, 레거시**

--- a/src/main/java/com/example/thirdtool/User/application/SocialMemberFactory.java
+++ b/src/main/java/com/example/thirdtool/User/application/SocialMemberFactory.java
@@ -1,0 +1,35 @@
+package com.example.thirdtool.User.application;
+
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.domain.model.UserEntity;
+
+/**
+ * 제공자별 {@code SocialMember} 저장 책임을 캡슐화하는 Strategy 인터페이스.
+ *
+ * <p>Story-4-3: {@link com.example.thirdtool.User.domain.model.SocialMemberRegistrar}가
+ * {@code Map<SocialProviderType, SocialMemberFactory>}로 dispatch. 신규 제공자
+ * 추가는 본 인터페이스의 {@code @Component} 구현체 1개 추가만으로 완결
+ * (Story-4-2의 `SocialOAuthFlow` 패턴과 일관).
+ *
+ * <p>구현체는 {@code User/infrastructure/{provider}/} 패키지에 두며, 해당
+ * 제공자의 SocialMember Repository를 직접 의존한다.
+ */
+public interface SocialMemberFactory {
+
+    /**
+     * 본 Factory가 담당하는 제공자 종류. Map 분기 키.
+     */
+    SocialProviderType getProviderType();
+
+    /**
+     * 동일 {@code socialId}로 이미 등록된 SocialMember가 존재하는지 확인.
+     * Registrar가 본 메서드로 중복을 검증해 {@code SOCIAL_MEMBER_ALREADY_LINKED}를 던진다.
+     */
+    boolean existsBySocialId(String socialId);
+
+    /**
+     * UserEntity와 SocialUserInfo로부터 제공자별 구체 {@code SocialMember}를 생성·저장한다.
+     */
+    void register(UserEntity user, SocialUserInfo info);
+}

--- a/src/main/java/com/example/thirdtool/User/application/SocialOAuthFlow.java
+++ b/src/main/java/com/example/thirdtool/User/application/SocialOAuthFlow.java
@@ -9,11 +9,14 @@ import com.example.thirdtool.User.domain.model.SocialUserInfo;
  * <p>Story-4-2: SocialLoginController가 제공자별 분기(switch) 없이
  * {@code Map<SocialProviderType, SocialOAuthFlow>}로 호출.
  *
- * <p><strong>현재 한계</strong>: 신규 제공자(예: 구글) 추가 시 본 인터페이스
- * 구현체 외에도 {@link com.example.thirdtool.User.application.UserService#socialLogin}
- * 내부의 제공자별 SocialMember 저장 분기를 추가해야 한다. 본 분기는 Story 4-3
- * (`SocialMemberRegistrar` 도메인 서비스)에서 캡슐화되어 제거 예정 — 그 시점부터
- * "구현체 1개만 추가"로 완결된다.
+ * <p>Story-4-3에서 {@code SocialMemberRegistrar} + {@code SocialMemberFactory}로
+ * SocialMember 등록 분기까지 캡슐화 완료. 신규 제공자(예: 구글) 추가는 다음
+ * 두 구현체를 {@code @Component}로 등록하는 것만으로 완결된다:
+ * <ul>
+ *   <li>본 인터페이스 {@code SocialOAuthFlow} 구현 — Authorization Code → SocialUserInfo</li>
+ *   <li>{@link com.example.thirdtool.User.application.SocialMemberFactory} 구현 — SocialUserInfo → SocialMember 저장</li>
+ * </ul>
+ * UserService / SocialLoginController / Registrar는 무변경.
  *
  * <p>구현체는 {@code User/infrastructure/{provider}/} 패키지에 둔다
  * (외부 OAuth API 호출의 어댑터이므로 infrastructure 계층).

--- a/src/main/java/com/example/thirdtool/User/application/UserService.java
+++ b/src/main/java/com/example/thirdtool/User/application/UserService.java
@@ -4,15 +4,13 @@ import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Common.security.auth.dto.TokenResponse;
 import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
 import com.example.thirdtool.User.domain.exception.UserDomainException;
+import com.example.thirdtool.User.domain.model.SocialMemberRegistrar;
 import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.User.domain.model.UserRoleType;
 import com.example.thirdtool.User.dto.*;
-import com.example.thirdtool.User.infrastructure.Naver.NaverMember;
-import com.example.thirdtool.User.infrastructure.Naver.NaverMemberRepository;
-import com.example.thirdtool.User.infrastructure.kakao.KakaoMemberRepository;
 import com.example.thirdtool.User.domain.repository.UserRepository;
-import com.example.thirdtool.User.infrastructure.kakao.KakaoMember;
 
 import com.example.thirdtool.Common.security.auth.jwt.JwtService;
 import org.springframework.security.access.AccessDeniedException;
@@ -28,21 +26,18 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtService jwtService;
     private final TokenIssuer tokenIssuer;
-    private final KakaoMemberRepository kakaoMemberRepository;
-    private final NaverMemberRepository naverMemberRepository;
+    private final SocialMemberRegistrar socialMemberRegistrar;
 
     public UserService(PasswordEncoder passwordEncoder,
                        UserRepository userRepository,
                        JwtService jwtService,
                        TokenIssuer tokenIssuer,
-                       KakaoMemberRepository kakaoMemberRepository,
-                       NaverMemberRepository naverMemberRepository) {
+                       SocialMemberRegistrar socialMemberRegistrar) {
         this.passwordEncoder = passwordEncoder;
         this.userRepository = userRepository;
         this.jwtService = jwtService;
         this.tokenIssuer = tokenIssuer;
-        this.kakaoMemberRepository = kakaoMemberRepository;
-        this.naverMemberRepository = naverMemberRepository;
+        this.socialMemberRegistrar = socialMemberRegistrar;
     }
 
 
@@ -124,6 +119,13 @@ public class UserService {
 
 
     // ✅ JWT 기반 소셜 로그인 처리 및 토큰 발급
+    // Story-4-3: KakaoMemberRepository / NaverMemberRepository 직접 의존 제거.
+    // 제공자별 SocialMember 저장은 SocialMemberRegistrar 도메인 서비스에 위임.
+    //
+    // 트랜잭션 보존 (AC3): @Transactional이 본 메서드를 감싼다. orElseGet 내부에서
+    // userRepository.save → socialMemberRegistrar.register 순으로 진행하는데, Registrar가
+    // SOCIAL_MEMBER_ALREADY_LINKED 또는 DB 예외(DataIntegrityViolationException 등) RuntimeException을
+    // 던지면 Spring이 본 트랜잭션 전체를 자동 롤백 → UserEntity 저장도 함께 무효화된다.
     @Transactional
     public TokenResponse socialLogin(SocialProviderType socialType,
                                      String socialId,
@@ -139,12 +141,12 @@ public class UserService {
                                             UserEntity newUser = UserEntity.ofSocial(username, socialType, nickname, email);
                                             UserEntity savedUser = userRepository.save(newUser);
 
-                                            // 소셜 멤버 정보 저장
-                                            if (socialType == SocialProviderType.KAKAO) {
-                                                kakaoMemberRepository.save(KakaoMember.builder().user(savedUser).kakaoId(socialId).build());
-                                            } else if (socialType == SocialProviderType.NAVER) {
-                                                naverMemberRepository.save(NaverMember.builder().user(savedUser).naverId(socialId).build());
-                                            }
+                                            // 제공자별 SocialMember 등록은 Registrar에 위임 (Story-4-3).
+                                            // 중복 socialId면 SOCIAL_MEMBER_ALREADY_LINKED throw → 단일 트랜잭션 롤백.
+                                            socialMemberRegistrar.register(
+                                                    savedUser,
+                                                    new SocialUserInfo(socialId, nickname, email, socialType)
+                                            );
                                             return savedUser;
                                         });
 

--- a/src/main/java/com/example/thirdtool/User/domain/model/SocialMemberRegistrar.java
+++ b/src/main/java/com/example/thirdtool/User/domain/model/SocialMemberRegistrar.java
@@ -1,0 +1,61 @@
+package com.example.thirdtool.User.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.User.application.SocialMemberFactory;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 소셜 회원 등록 도메인 서비스.
+ *
+ * <p>Story-4-3: {@code UserService}가 카카오·네이버 Repository를 직접 알지 않도록
+ * 제공자별 {@link SocialMemberFactory} 호출을 캡슐화. {@code Map<SocialProviderType,
+ * SocialMemberFactory>} 자동 dispatch 패턴은 Story-4-2의 {@code SocialOAuthFlow}와 동일.
+ *
+ * <p>도메인 서비스 위치 근거: Card BC의 {@code CardStatusHistoryAppender} 패턴 답습.
+ * Aggregate가 직접 Repository를 호출하지 않고, 다중 협력이 필요한 영속 책임을
+ * 도메인 서비스로 위임 (CLAUDE.md §1.7 — "Domain Service 호출은 Application Service가 한다").
+ *
+ * <p>중복 검증: {@code SocialMember.socialId}는 DB 레벨 unique 제약 + 본 서비스의
+ * 사전 검증으로 이중 방어 (conventions.md §1.6).
+ */
+@Component
+public class SocialMemberRegistrar {
+
+    private final Map<SocialProviderType, SocialMemberFactory> factories;
+
+    public SocialMemberRegistrar(List<SocialMemberFactory> factories) {
+        this.factories = factories.stream()
+                                  .collect(Collectors.toMap(
+                                          SocialMemberFactory::getProviderType,
+                                          Function.identity(),
+                                          (a, b) -> {
+                                              throw new IllegalStateException(
+                                                      "Duplicate SocialMemberFactory for provider: " + a.getProviderType());
+                                          }
+                                  ));
+    }
+
+    /**
+     * 제공자별 SocialMember를 등록한다. 이미 같은 {@code socialId}로 등록된
+     * 회원이 있으면 {@code SOCIAL_MEMBER_ALREADY_LINKED}를 던진다 (AC4).
+     *
+     * @throws UserDomainException {@code SOCIAL_PROVIDER_NOT_SUPPORTED} — 등록된 Factory 없음
+     * @throws UserDomainException {@code SOCIAL_MEMBER_ALREADY_LINKED} — 동일 socialId 중복
+     */
+    public void register(UserEntity user, SocialUserInfo info) {
+        SocialMemberFactory factory = factories.get(info.provider());
+        if (factory == null) {
+            throw UserDomainException.of(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+        }
+        if (factory.existsBySocialId(info.socialId())) {
+            throw UserDomainException.of(ErrorCode.SOCIAL_MEMBER_ALREADY_LINKED);
+        }
+        factory.register(user, info);
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/infrastructure/Naver/NaverMemberFactory.java
+++ b/src/main/java/com/example/thirdtool/User/infrastructure/Naver/NaverMemberFactory.java
@@ -1,0 +1,38 @@
+package com.example.thirdtool.User.infrastructure.Naver;
+
+import com.example.thirdtool.User.application.SocialMemberFactory;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 네이버 SocialMember 저장 어댑터. {@link NaverMemberRepository}에 영속을 위임.
+ */
+@Component
+@RequiredArgsConstructor
+public class NaverMemberFactory implements SocialMemberFactory {
+
+    private final NaverMemberRepository naverMemberRepository;
+
+    @Override
+    public SocialProviderType getProviderType() {
+        return SocialProviderType.NAVER;
+    }
+
+    @Override
+    public boolean existsBySocialId(String socialId) {
+        return naverMemberRepository.findBySocialId(socialId).isPresent();
+    }
+
+    @Override
+    public void register(UserEntity user, SocialUserInfo info) {
+        naverMemberRepository.save(
+                NaverMember.builder()
+                           .user(user)
+                           .naverId(info.socialId())
+                           .build()
+        );
+    }
+}

--- a/src/main/java/com/example/thirdtool/User/infrastructure/kakao/KakaoMemberFactory.java
+++ b/src/main/java/com/example/thirdtool/User/infrastructure/kakao/KakaoMemberFactory.java
@@ -1,0 +1,38 @@
+package com.example.thirdtool.User.infrastructure.kakao;
+
+import com.example.thirdtool.User.application.SocialMemberFactory;
+import com.example.thirdtool.User.domain.model.SocialProviderType;
+import com.example.thirdtool.User.domain.model.SocialUserInfo;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 카카오 SocialMember 저장 어댑터. {@link KakaoMemberRepository}에 영속을 위임.
+ */
+@Component
+@RequiredArgsConstructor
+public class KakaoMemberFactory implements SocialMemberFactory {
+
+    private final KakaoMemberRepository kakaoMemberRepository;
+
+    @Override
+    public SocialProviderType getProviderType() {
+        return SocialProviderType.KAKAO;
+    }
+
+    @Override
+    public boolean existsBySocialId(String socialId) {
+        return kakaoMemberRepository.findBySocialId(socialId).isPresent();
+    }
+
+    @Override
+    public void register(UserEntity user, SocialUserInfo info) {
+        kakaoMemberRepository.save(
+                KakaoMember.builder()
+                           .user(user)
+                           .kakaoId(info.socialId())
+                           .build()
+        );
+    }
+}

--- a/src/test/java/com/example/thirdtool/User/application/UserServiceLoginExceptionTest.java
+++ b/src/test/java/com/example/thirdtool/User/application/UserServiceLoginExceptionTest.java
@@ -4,13 +4,12 @@ import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Common.security.auth.jwt.JwtService;
 import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
 import com.example.thirdtool.User.domain.exception.UserDomainException;
+import com.example.thirdtool.User.domain.model.SocialMemberRegistrar;
 import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.User.domain.model.UserRoleType;
 import com.example.thirdtool.User.domain.repository.UserRepository;
 import com.example.thirdtool.User.dto.UserSignUpRequestDTO;
-import com.example.thirdtool.User.infrastructure.Naver.NaverMemberRepository;
-import com.example.thirdtool.User.infrastructure.kakao.KakaoMemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,9 +46,7 @@ class UserServiceLoginExceptionTest {
     @Mock
     private TokenIssuer tokenIssuer;
     @Mock
-    private KakaoMemberRepository kakaoMemberRepository;
-    @Mock
-    private NaverMemberRepository naverMemberRepository;
+    private SocialMemberRegistrar socialMemberRegistrar;
 
     @InjectMocks
     private UserService userService;

--- a/src/test/java/com/example/thirdtool/User/domain/model/SocialMemberRegistrarTest.java
+++ b/src/test/java/com/example/thirdtool/User/domain/model/SocialMemberRegistrarTest.java
@@ -1,0 +1,106 @@
+package com.example.thirdtool.User.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.User.application.SocialMemberFactory;
+import com.example.thirdtool.User.domain.exception.UserDomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Story-4-3: SocialMemberRegistrar 도메인 서비스 — 제공자별 Factory dispatch +
+ * 중복 검증(SOCIAL_MEMBER_ALREADY_LINKED).
+ *
+ * Classist 전략 (도메인 서비스 본체는 실제 인스턴스) + Factory만 Mock.
+ */
+class SocialMemberRegistrarTest {
+
+    private SocialMemberFactory kakaoFactory;
+    private SocialMemberFactory naverFactory;
+    private SocialMemberRegistrar registrar;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        kakaoFactory = Mockito.mock(SocialMemberFactory.class);
+        naverFactory = Mockito.mock(SocialMemberFactory.class);
+        // getProviderType은 Registrar 생성자에서만 호출 — lenient로 unused stub 경고 회피
+        // (partial registrar 케이스에서 naverFactory가 사용 안 됨)
+        lenient().when(kakaoFactory.getProviderType()).thenReturn(SocialProviderType.KAKAO);
+        lenient().when(naverFactory.getProviderType()).thenReturn(SocialProviderType.NAVER);
+
+        registrar = new SocialMemberRegistrar(List.of(kakaoFactory, naverFactory));
+
+        user = UserEntity.ofSocial("KAKAO_12345", SocialProviderType.KAKAO, "Alice", "a@k.test");
+    }
+
+    @Test
+    void register_KAKAO_정상_KakaoFactory_위임() {
+        given(kakaoFactory.existsBySocialId("12345")).willReturn(false);
+        SocialUserInfo info = new SocialUserInfo("12345", "Alice", "a@k.test", SocialProviderType.KAKAO);
+
+        registrar.register(user, info);
+
+        verify(kakaoFactory).register(user, info);
+        verify(naverFactory, never()).register(any(), any());
+    }
+
+    @Test
+    void register_NAVER_정상_NaverFactory_위임() {
+        given(naverFactory.existsBySocialId("naver-999")).willReturn(false);
+        SocialUserInfo info = new SocialUserInfo("naver-999", "Bob", "b@n.test", SocialProviderType.NAVER);
+
+        registrar.register(user, info);
+
+        verify(naverFactory).register(user, info);
+        verify(kakaoFactory, never()).register(any(), any());
+    }
+
+    @Test
+    void register_중복socialId_SOCIAL_MEMBER_ALREADY_LINKED() {
+        given(kakaoFactory.existsBySocialId("12345")).willReturn(true);
+        SocialUserInfo info = new SocialUserInfo("12345", "Alice", "a@k.test", SocialProviderType.KAKAO);
+
+        assertThatThrownBy(() -> registrar.register(user, info))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SOCIAL_MEMBER_ALREADY_LINKED);
+
+        // 중복 시 실제 저장은 호출되지 않음
+        verify(kakaoFactory, never()).register(any(), any());
+    }
+
+    @Test
+    void constructor_같은Provider_Factory_중복등록시_부팅실패() {
+        SocialMemberFactory duplicateKakao = Mockito.mock(SocialMemberFactory.class);
+        given(duplicateKakao.getProviderType()).willReturn(SocialProviderType.KAKAO);
+
+        assertThatThrownBy(() -> new SocialMemberRegistrar(List.of(kakaoFactory, duplicateKakao)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Duplicate SocialMemberFactory");
+    }
+
+    @Test
+    void register_등록안된Provider_SOCIAL_PROVIDER_NOT_SUPPORTED() {
+        // KAKAO Factory만 등록한 상태에서 NAVER 요청이 들어오는 시나리오.
+        // 향후 SocialProviderType enum에 새 값을 추가했는데 SocialMemberFactory 구현체를
+        // @Component로 등록하지 않은 회귀 케이스를 재현.
+        SocialMemberRegistrar partialRegistrar = new SocialMemberRegistrar(List.of(kakaoFactory));
+        SocialUserInfo info = new SocialUserInfo("naver-999", "Bob", "b@n.test", SocialProviderType.NAVER);
+
+        assertThatThrownBy(() -> partialRegistrar.register(user, info))
+                .isInstanceOf(UserDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SOCIAL_PROVIDER_NOT_SUPPORTED);
+    }
+}


### PR DESCRIPTION
## What

`UserService.socialLogin()` 내부의 `if (KAKAO)/else if (NAVER)` SocialMember 저장 분기를 도메인 서비스로 캡슐화한다. Story 4-2 `SocialOAuthFlow` 패턴과 일관된 Strategy + Map dispatch 채택.

**신규 4 파일**:
- `User/application/SocialMemberFactory.java` — Strategy 포트. `getProviderType` + `existsBySocialId` + `register`
- `User/infrastructure/kakao/KakaoMemberFactory.java` + `Naver/NaverMemberFactory.java` — `@Component`. 기존 Repository 위임 + 중복 검증
- `User/domain/model/SocialMemberRegistrar.java` — `@Component` 도메인 서비스 (Card BC `CardStatusHistoryAppender` 패턴). `Map<SocialProviderType, Factory>` dispatch. `Collectors.toMap` 명시 merger (중복 Factory 시 부팅 실패). `SOCIAL_MEMBER_ALREADY_LINKED` 사전 검증

**수정**:
- `User/application/UserService.java` — `KakaoMemberRepository`/`NaverMemberRepository` 의존 제거 (6→5개). `SocialMemberRegistrar` 단일 의존. `socialLogin()` 분기 제거. `@Transactional` 동작 주석 보강 (AC3 명시)
- `User/application/SocialOAuthFlow.java` — Javadoc "Story 4-3 완료 예정" 잔존 문구 정정. 본 Story로 완결됨을 반영
- `docs/PACKAGE.md` — User BC §domain/model 갱신 (SocialUserInfo·SocialMemberRegistrar·UserDomainException 추가 + application 포트 명시)
- `workflow/product/Product.md` Story 4-3 절 — 명세 변경 이력 + Strategy 패턴 채택 사유 명시 (`.gitignore` 대상이라 PR diff 외)

**테스트 신규 1 파일 / 5 케이스**:
- `SocialMemberRegistrarTest` — KAKAO/NAVER dispatch (해피) + 중복 socialId (예외) + Factory 중복 등록 부팅 실패 (방어) + 미등록 Provider (예외)

**테스트 수정**:
- `UserServiceLoginExceptionTest` — Mock 의존 정정 (Kakao/NaverMemberRepository → SocialMemberRegistrar)

## Why

`workflow/product/Product.md` Product 2 Epic 4 세 번째 Story. Story 4-2 한계("신규 제공자 = 단일 클래스 미달성") 해소.

**명세 변경** (사용자 합의 옵션 B, 2026-05-28):
- 원 명세: "Registrar 내부 switch에만 분기 추가"
- 채택: Strategy + Map dispatch (Story 4-2 `SocialOAuthFlow`와 패턴 일관)
- 사유: 신규 제공자 추가 시 Registrar 자체 무변경 + `@Component` 1개 추가만으로 자동 합류

## How

**Strategy 패턴**:
- `SocialMemberFactory` 인터페이스 → `KakaoMemberFactory`/`NaverMemberFactory` 구현체
- `SocialMemberRegistrar`가 `List<SocialMemberFactory>` 주입 → `Collectors.toMap` 변환 (명시 merger로 중복 부팅 실패)
- 신규 제공자 추가 비용:
  - `SocialProviderType.GOOGLE` enum 1줄
  - `GoogleOAuthFlow @Component` (Story 4-2)
  - `GoogleMember` Entity + `GoogleMemberRepository`
  - `GoogleMemberFactory @Component`
  - `UserService`/`SocialLoginController`/`SocialMemberRegistrar` 무변경 ✅

**중복 검증 (AC4)**:
- Registrar 사전 검증 (`Factory.existsBySocialId`) + DB unique 제약 → 이중 방어 (conventions.md §1.6)
- 같은 socialId 중복 시 `SOCIAL_MEMBER_ALREADY_LINKED (USER008, HTTP 409)` throw

**트랜잭션 (AC3)**:
- `UserService.socialLogin()`의 `@Transactional` 그대로 보존
- `SocialMemberRegistrar`는 별도 `@Transactional` 없음 → 호출자 트랜잭션 참여
- Registrar에서 RuntimeException(UserDomainException · DataIntegrityViolationException) 시 Spring 자동 롤백 → `UserEntity` 저장도 함께 무효화

## Tradeoff

**알려진 한계** (본 Story 외 처리, PR 본문·코드 주석에 명시):
- **TOCTOU race condition**: 두 동시 요청이 같은 socialId로 진입 시 `existsBySocialId` 두 번 통과 → DB unique 제약이 막지만 `DataIntegrityViolationException`은 현재 `GlobalExceptionHandler`에 명시 매핑 없음 → 500 노출 가능성. 별도 hygiene Story (`@ExceptionHandler(DataIntegrityViolationException.class)` 추가)로 분리.
- **Architecture: domain → application 역방향 의존**: `SocialMemberRegistrar (domain)` → `SocialMemberFactory (application)`. PACKAGE.md에 Port 위치 규칙 명시 또는 Port 이동 필요. 본 Story는 Card BC `CardStatusHistoryAppender` 패턴 답습으로 정당화 + PACKAGE.md 갱신으로 의도 기록. 명시적 ADR은 후속.
- **Naver 대문자 패키지명** 답습 (Story 4-2와 동일) — 별도 hygiene Story
- **ADR005 Command/Query record** 미적용 — Story 4-4 범위
- **`UserServiceLoginExceptionTest`에 `socialLogin()` 동작 테스트 누락** — Story 4-4 종료 시점 누적

## Reviewer 종합 (review.md §4 결과)

5관점 병렬 reviewer 세션:
- **Critical 1건**: UserService 트랜잭션 동작 주석 부재 → **본 PR 조치** (Javadoc 보강)
- **Major 9건**:
  - [Sceptical] SocialOAuthFlow Javadoc 정정 → **본 PR 조치**
  - [Sceptical] Product.md Story 4-3 명세 갱신 → **본 PR 조치**
  - [Sceptical] PACKAGE.md `SocialMemberRegistrar` 추가 → **본 PR 조치**
  - [Test] `SOCIAL_PROVIDER_NOT_SUPPORTED` 단위 케이스 누락 → **본 PR 조치**
  - 나머지(역방향 의존·Naver 패키지명·TOCTOU·socialLogin() 테스트·SocialUserInfo trim) → 후속

사용자 의사결정: 옵션 1 (Sceptical 1·2·3 + Test 4 + Critical 조치).

## Test

- [x] `./gradlew build` 그린 (회귀 통과)
- [x] `SocialMemberRegistrarTest` 5 케이스 그린 (해피 2 / 엣지 0 / 예외 2 / 방어 1)
- [x] `UserServiceLoginExceptionTest` 갱신 후 그린 (6 케이스)
- [x] 정적 검증: `UserService.java`에 `KakaoMemberRepository`/`NaverMemberRepository` import 0건
- [ ] 로컬 부팅 + 카카오/네이버 소셜 로그인 수동 검증 (사용자 검토)
- [ ] DataIntegrityViolationException → 409 매핑 — 후속

## Checklist

- [x] DOMAIN.md / PACKAGE.md 반영 (PACKAGE.md 갱신 포함)
- [x] BC 의존 방향 (Card BC 동일 패턴, 단 PACKAGE.md Port 규칙 명시 후속 필요)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 (변경 없음)
- [x] Reviewer 세션 통과 (Critical 0건 잔존)
- [ ] ADR — 단독 ADR 부적격. Epic 4 종료 시점(Story 4-4 완료 후) 묶음 ADR 검토 ("OAuth 통합 아키텍처 — Flow + Registrar + Command/Query 분리").

## Related

- `workflow/product/Product.md` — Product 2 Story 4-3 명세 (본 PR로 갱신)
- Plan: `C:\Users\user\.claude\plans\ticklish-toasting-thunder.md`
- 선행: Story 4-2 (PR #138, merged)