### PR TITLE
[Security] refactor: @AuthenticationPrincipal UserEntity 통일 (Story 5-2)

### DIFF
--- a/src/main/java/com/example/thirdtool/Review/application/ReviewCommandService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewCommandService.java
@@ -12,7 +12,6 @@ import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
 import com.example.thirdtool.Review.presentation.dto.ReviewRequest;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
 import com.example.thirdtool.User.domain.model.UserEntity;
-import com.example.thirdtool.User.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +26,6 @@ public class ReviewCommandService {
     private final ReviewSessionRepository reviewSessionRepository;
     private final ReviewQueryService      reviewQueryService;
     private final DeckQueryService        deckQueryService;
-    private final UserRepository          userRepository;
 
     // Card BC 의존 — port interface를 통한 접근 (ADR-006)
     private final CardRepository cardRepository;
@@ -38,16 +36,14 @@ public class ReviewCommandService {
 
     // ─── 1. 리뷰 세션 시작 ───────────────────────────────
 
-    public ReviewResponse.StartSession startReview(ReviewRequest.StartSession request, Long userId) {
+    // Story-5-2: Long userId → UserEntity user 시그니처 통일. JWTFilter가 Principal에 UserEntity를
+    // 주입하므로 userRepository 재조회 제거 (불필요한 DB I/O 절감).
+    public ReviewResponse.StartSession startReview(ReviewRequest.StartSession request, UserEntity user) {
         Deck deck = deckQueryService.getActiveDeck(request.deckId());
 
-        if (!deck.getUser().getId().equals(userId)) {
+        if (!deck.getUser().getId().equals(user.getId())) {
             throw ReviewSessionException.of(ErrorCode.REVIEW_SESSION_FORBIDDEN);
         }
-
-        UserEntity user = userRepository.findById(userId)
-                                        .orElseThrow(() -> new IllegalStateException(
-                                                "인증된 사용자를 찾을 수 없습니다: " + userId));
 
         // 카드 목록을 Application Service에서 조회해 ReviewSession에 전달한다.
         // ReviewSession이 deck.getCards()를 직접 호출하지 않도록 해 N+1 제어권을 유지한다.
@@ -65,8 +61,8 @@ public class ReviewCommandService {
 
     // ─── 2. 현재 카드 COMPARING 전환 ─────────────────────
 
-    public ReviewResponse.CardReviewDto startComparing(Long sessionId, Long userId) {
-        ReviewSession session = reviewQueryService.getSessionByOwner(sessionId, userId);
+    public ReviewResponse.CardReviewDto startComparing(Long sessionId, UserEntity user) {
+        ReviewSession session = reviewQueryService.getSessionByOwner(sessionId, user);
         session.startComparingCurrentCard();
 
         // isLastView는 카드 진입 시 이미 결정된 viewCount 상태를 그대로 읽는다.
@@ -76,8 +72,8 @@ public class ReviewCommandService {
 
     // ─── 3. 다음 카드로 이동 ──────────────────────────────
 
-    public ReviewResponse.NextCard moveToNext(Long sessionId, Long userId) {
-        ReviewSession session = reviewQueryService.getSessionByOwner(sessionId, userId);
+    public ReviewResponse.NextCard moveToNext(Long sessionId, UserEntity user) {
+        ReviewSession session = reviewQueryService.getSessionByOwner(sessionId, user);
 
         // 종료 여부 + COMPARING 검증은 도메인 내부에서 처리
         session.moveToNext();

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -7,6 +7,7 @@ import com.example.thirdtool.Review.domain.model.ReviewSession;
 import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
 import com.example.thirdtool.Review.infrastructure.dto.ReviewSessionSearchCondition;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,9 +22,11 @@ public class ReviewQueryService {
     private final ReviewSessionRepository reviewSessionRepository;
     private final OnFieldBudget systemBudget;
 
+    // Story-5-2: Long userId → UserEntity user 시그니처 통일.
+
     // ─── 1. 세션 단건 조회 ────────────────────────────────
-    public ReviewResponse.SessionDetail findById(Long sessionId, Long userId) {
-        ReviewSession session = getSessionByOwner(sessionId, userId);
+    public ReviewResponse.SessionDetail findById(Long sessionId, UserEntity user) {
+        ReviewSession session = getSessionByOwner(sessionId, user);
         boolean isLastView = resolveIsLastView(session);
         return ReviewResponse.SessionDetail.of(session, isLastView);
     }
@@ -35,9 +38,9 @@ public class ReviewQueryService {
      * deckId 지정 시 해당 덱의 세션만 반환, 미지정 시 전체 반환.
      * startedAt 내림차순 정렬은 QueryDSL에서 처리한다.
      */
-    public List<ReviewResponse.SessionSummary> searchSessions(Long deckId, Long userId) {
+    public List<ReviewResponse.SessionSummary> searchSessions(Long deckId, UserEntity user) {
         ReviewSessionSearchCondition condition = ReviewSessionSearchCondition.builder()
-                                                                             .userId(userId)
+                                                                             .userId(user.getId())
                                                                              .deckId(deckId)
                                                                              .build();
 
@@ -48,13 +51,13 @@ public class ReviewQueryService {
     }
 
     // ─── 내부 공용 메서드 ─────────────────────────────────
-    public ReviewSession getSessionByOwner(Long sessionId, Long userId) {
+    public ReviewSession getSessionByOwner(Long sessionId, UserEntity user) {
         // 세션 존재 여부: 없으면 REVIEW001
         ReviewSession session = reviewSessionRepository.findById(sessionId)
                                                        .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_SESSION_NOT_FOUND));
 
         // 소유자 검증: 본인 세션이 아니면 REVIEW005
-        if (!session.isOwner(userId)) {
+        if (!session.isOwner(user.getId())) {
             throw new BusinessException(ErrorCode.REVIEW_SESSION_FORBIDDEN);
         }
 

--- a/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
@@ -4,6 +4,7 @@ import com.example.thirdtool.Review.application.ReviewCommandService;
 import com.example.thirdtool.Review.application.ReviewQueryService;
 import com.example.thirdtool.Review.presentation.dto.ReviewRequest;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,47 +25,46 @@ public class ReviewController {
     @PostMapping("/api/v1/reviews")
     public ResponseEntity<ReviewResponse.StartSession> startReview(
             @Valid @RequestBody ReviewRequest.StartSession request,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal UserEntity currentUser
                                                                   ) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(reviewCommandService.startReview(request, userId));
+                .body(reviewCommandService.startReview(request, currentUser));
     }
 
     // ─── 2. 세션 단건 조회 ────────────────────────────────
     @GetMapping("/api/v1/reviews/{sessionId}")
     public ResponseEntity<ReviewResponse.SessionDetail> findById(
             @PathVariable Long sessionId,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal UserEntity currentUser
                                                                 ) {
-        return ResponseEntity.ok(reviewQueryService.findById(sessionId, userId));
+        return ResponseEntity.ok(reviewQueryService.findById(sessionId, currentUser));
     }
 
     // ─── 3. 현재 카드 COMPARING 전환 ─────────────────────
     @PatchMapping("/api/v1/reviews/{sessionId}/comparing")
     public ResponseEntity<ReviewResponse.CardReviewDto> startComparing(
             @PathVariable Long sessionId,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal UserEntity currentUser
                                                                       ) {
-        return ResponseEntity.ok(reviewCommandService.startComparing(sessionId, userId));
+        return ResponseEntity.ok(reviewCommandService.startComparing(sessionId, currentUser));
     }
 
     // ─── 4. 다음 카드로 이동 ──────────────────────────────
     @PatchMapping("/api/v1/reviews/{sessionId}/next")
     public ResponseEntity<ReviewResponse.NextCard> moveToNext(
             @PathVariable Long sessionId,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal UserEntity currentUser
                                                              ) {
-        return ResponseEntity.ok(reviewCommandService.moveToNext(sessionId, userId));
+        return ResponseEntity.ok(reviewCommandService.moveToNext(sessionId, currentUser));
     }
 
     // ─── 5. 세션 목록 조회 ────────────────────────────────
     @GetMapping("/api/v1/reviews")
     public ResponseEntity<List<ReviewResponse.SessionSummary>> searchSessions(
             @RequestParam(required = false) Long deckId,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal UserEntity currentUser
                                                                              ) {
-        return ResponseEntity.ok(reviewQueryService.searchSessions(deckId, userId));
+        return ResponseEntity.ok(reviewQueryService.searchSessions(deckId, currentUser));
     }
 }
-

--- a/src/main/java/com/example/thirdtool/User/application/UserCommandService.java
+++ b/src/main/java/com/example/thirdtool/User/application/UserCommandService.java
@@ -15,7 +15,6 @@ import com.example.thirdtool.User.dto.UserDeleteRequestDTO;
 import com.example.thirdtool.User.dto.UserSignUpRequestDTO;
 import com.example.thirdtool.User.dto.UserUpdateRequestDTO;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -100,26 +99,36 @@ public class UserCommandService {
     }
 
     @Transactional
-    public Long updateUser(String username, UserUpdateRequestDTO dto) throws AccessDeniedException {
-        UserEntity entity = userRepository.findByUsernameAndIsLockAndIsSocial(username, false, false)
+    public Long updateUser(UserEntity currentUser, UserUpdateRequestDTO dto) throws AccessDeniedException {
+        // Story-5-2 본인 검증: 요청 바디의 username이 currentUser와 다르면 타 계정 수정 시도로 차단.
+        // (UserUpdateRequestDTO.username 자체 제거는 Story-5-4 범위)
+        if (dto.getUsername() != null && !currentUser.getUsername().equals(dto.getUsername())) {
+            throw new AccessDeniedException("본인 계정만 수정할 수 있습니다.");
+        }
+
+        // currentUser 정보로 자체 로그인·non-lock 조건을 만족하는 사용자를 찾아 수정.
+        UserEntity entity = userRepository.findByUsernameAndIsLockAndIsSocial(currentUser.getUsername(), false, false)
                                           .orElseThrow(() -> UserDomainException.of(ErrorCode.USER_NOT_FOUND));
         entity.updateUser(dto);
         return userRepository.save(entity).getId();
     }
 
     @Transactional
-    public void deleteUser(String username, UserDeleteRequestDTO dto) throws AccessDeniedException {
-        // 권한 검증 로직은 컨트롤러나 별도의 서비스에서 처리하는 것이 좋으나 Story-5-3 범위.
-        // 본 Story 4-4는 Command/Query 분리만 — SecurityContextHolder 호출은 그대로 유지.
-        String sessionRole = SecurityContextHolder.getContext().getAuthentication().getAuthorities().iterator().next().getAuthority();
-        boolean isAdmin = sessionRole.equals("ROLE_" + UserRoleType.ADMIN.name());
+    public void deleteUser(UserEntity currentUser, UserDeleteRequestDTO dto) throws AccessDeniedException {
+        // Story-5-2: SecurityContextHolder 직접 호출 제거 → currentUser.getRoleType() 활용.
+        // 권한 검증을 @PreAuthorize로 이관하는 것은 Story-5-3 범위 (현재는 Service에서 처리).
+        boolean isAdmin = currentUser.getRoleType() == UserRoleType.ADMIN;
+        boolean isSelfDelete = currentUser.getUsername().equals(dto.getUsername());
 
-        if (!username.equals(dto.getUsername()) && !isAdmin) {
+        if (!isSelfDelete && !isAdmin) {
             throw new AccessDeniedException("본인 혹은 관리자만 삭제할 수 있습니다.");
         }
 
-        userRepository.deleteByUsername(dto.getUsername());
-        jwtService.removeRefreshUser(dto.getUsername());
+        // 본인 삭제는 currentUser 기반, admin 삭제는 dto.username 기반 (admin이 다른 계정 삭제).
+        // 두 케이스 모두 결과 username은 dto.username과 동일 (isSelfDelete=true일 때 currentUser.username == dto.username).
+        String targetUsername = isSelfDelete ? currentUser.getUsername() : dto.getUsername();
+        userRepository.deleteByUsername(targetUsername);
+        jwtService.removeRefreshUser(targetUsername);
     }
 
     /**

--- a/src/main/java/com/example/thirdtool/User/presentation/UserController.java
+++ b/src/main/java/com/example/thirdtool/User/presentation/UserController.java
@@ -70,21 +70,23 @@ public class UserController {
     }
 
     // ✅ 유저 수정 (자체 로그인 유저만) (Command)
+    // Story-5-2: @AuthenticationPrincipal을 UserEntity 단일 타입으로 통일.
+    // 인증 주체 주입은 Spring Security가 JWTFilter에서 설정한 Principal을 그대로 활용.
     @PutMapping(value = "/user", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> updateUserApi(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal UserEntity currentUser,
             @Validated @RequestBody UserUpdateRequestDTO dto
                                              ) throws AccessDeniedException {
-        return ResponseEntity.status(200).body(userCommandService.updateUser(username, dto));
+        return ResponseEntity.status(200).body(userCommandService.updateUser(currentUser, dto));
     }
 
     // ✅ 유저 제거 (자체/소셜) (Command)
     @DeleteMapping(value = "/user")
     public ResponseEntity<Boolean> deleteUserApi(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal UserEntity currentUser,
             @Validated @RequestBody UserDeleteRequestDTO dto
                                                 ) throws AccessDeniedException {
-        userCommandService.deleteUser(username, dto);
+        userCommandService.deleteUser(currentUser, dto);
         return ResponseEntity.status(200).body(true);
     }
 }

--- a/src/test/java/com/example/thirdtool/User/application/UserCommandServiceLoginExceptionTest.java
+++ b/src/test/java/com/example/thirdtool/User/application/UserCommandServiceLoginExceptionTest.java
@@ -27,15 +27,17 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 /**
- * Story-5-1: UserService 예외 통일 검증.
+ * Story-5-1·4-4: UserCommandService 예외 통일 검증.
  *
  * loginLocal()의 실패 사유별 ErrorCode 분기와 addUser() 중복 가입 시
  * USER_ALREADY_EXISTS throw를 단위로 확인한다. 단위 테스트라 Repository와
  * PasswordEncoder만 Mock — 도메인 객체(UserEntity)는 실제 인스턴스 사용
  * (conventions.md §4.1 Classist + Mock 외부 의존만).
+ *
+ * Story-4-4: UserService → UserCommandService 분리에 따라 본 테스트도 rename.
  */
 @ExtendWith(MockitoExtension.class)
-class UserServiceLoginExceptionTest {
+class UserCommandServiceLoginExceptionTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -49,7 +51,7 @@ class UserServiceLoginExceptionTest {
     private SocialMemberRegistrar socialMemberRegistrar;
 
     @InjectMocks
-    private UserService userService;
+    private UserCommandService userCommandService;
 
     private UserEntity localUser;
     private UserEntity socialUser;
@@ -71,7 +73,7 @@ class UserServiceLoginExceptionTest {
         given(userRepository.findByUsername("alice")).willReturn(Optional.of(localUser));
         given(passwordEncoder.matches("plain", "ENCODED_PWD")).willReturn(true);
 
-        UserEntity result = userService.loginLocal("alice", "plain");
+        UserEntity result = userCommandService.loginLocal("alice", "plain");
 
         assertThat(result).isSameAs(localUser);
     }
@@ -82,7 +84,7 @@ class UserServiceLoginExceptionTest {
         // 둘 다 PASSWORD_NOT_MATCHED(401)로 묶어 enumeration attack 차단.
         given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> userService.loginLocal("ghost", "pwd"))
+        assertThatThrownBy(() -> userCommandService.loginLocal("ghost", "pwd"))
                 .isInstanceOf(UserDomainException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PASSWORD_NOT_MATCHED);
@@ -92,7 +94,7 @@ class UserServiceLoginExceptionTest {
     void loginLocal_소셜유저_USER_IS_SOCIAL() {
         given(userRepository.findByUsername("KAKAO_12345")).willReturn(Optional.of(socialUser));
 
-        assertThatThrownBy(() -> userService.loginLocal("KAKAO_12345", "pwd"))
+        assertThatThrownBy(() -> userCommandService.loginLocal("KAKAO_12345", "pwd"))
                 .isInstanceOf(UserDomainException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_IS_SOCIAL);
@@ -102,7 +104,7 @@ class UserServiceLoginExceptionTest {
     void loginLocal_잠긴계정_USER_LOCKED() {
         given(userRepository.findByUsername("bob")).willReturn(Optional.of(lockedUser));
 
-        assertThatThrownBy(() -> userService.loginLocal("bob", "pwd"))
+        assertThatThrownBy(() -> userCommandService.loginLocal("bob", "pwd"))
                 .isInstanceOf(UserDomainException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_LOCKED);
@@ -113,7 +115,7 @@ class UserServiceLoginExceptionTest {
         given(userRepository.findByUsername("alice")).willReturn(Optional.of(localUser));
         given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
 
-        assertThatThrownBy(() -> userService.loginLocal("alice", "wrong"))
+        assertThatThrownBy(() -> userCommandService.loginLocal("alice", "wrong"))
                 .isInstanceOf(UserDomainException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PASSWORD_NOT_MATCHED);
@@ -129,7 +131,7 @@ class UserServiceLoginExceptionTest {
         // 본 테스트는 existsByUsername 체크 단계까지만 도달하므로 username 한 필드만 채워도 OK.
         org.springframework.test.util.ReflectionTestUtils.setField(dto, "username", "alice");
 
-        assertThatThrownBy(() -> userService.addUser(dto))
+        assertThatThrownBy(() -> userCommandService.addUser(dto))
                 .isInstanceOf(UserDomainException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_ALREADY_EXISTS);


### PR DESCRIPTION
## What

`@AuthenticationPrincipal`을 모든 Controller·Service에서 `UserEntity` 단일 타입으로 통일.

**UserController**:
- `updateUserApi` / `deleteUserApi`: `@AuthenticationPrincipal String username` → `UserEntity currentUser`
- `userMeApi`는 이전부터 UserEntity 사용 (그대로)

**UserCommandService**:
- `updateUser(String, dto)` → `updateUser(UserEntity, dto)` + **본인 검증 추가** (dto.username ≠ currentUser면 AccessDenied)
- `deleteUser(String, dto)` → `deleteUser(UserEntity, dto)` + **SecurityContextHolder 제거** (`currentUser.getRoleType()` 활용)
- 본인 삭제는 `currentUser.getUsername()` 기반, admin 삭제는 `dto.getUsername()` 기반으로 명시 분기

**ReviewController + ReviewCommandService + ReviewQueryService** (Sceptical Critical 1 조치):
- 5개 엔드포인트 모두 `@AuthenticationPrincipal Long userId` → `UserEntity currentUser`
- Service 3+3 메서드 시그니처 `Long userId` → `UserEntity user`
- `startReview`의 `userRepository.findById(userId)` 재조회 제거 → currentUser 직접 사용. `UserRepository` 의존성 제거

**chore (PR #140 fixup)**: PR #140 머지 누락분(`UserCommandServiceLoginExceptionTest` 클래스명·Javadoc) 정리. 별도 commit으로 분리.

## Why

`workflow/product/Product.md` Product 2 Epic 5 두 번째 Story. 인증 주체 주입 타입 일관성 확보.

**Sceptical Reviewer Critical 발견**: ReviewController 5개 엔드포인트가 `@AuthenticationPrincipal Long userId`를 받고 있었으나, JWTFilter는 Principal에 `UserEntity`를 주입 → Spring의 `AuthenticationPrincipalArgumentResolver`가 타입 불일치 시 null 주입(errorOnInvalidType=false 기본값) → **현재 모든 인증된 Review API 호출이 null userId로 진행 → NPE/권한 우회 위험**. 본 PR로 정정.

## How

**Controller→Service 시그니처 변경 패턴**:
```java
// Before
@AuthenticationPrincipal Long userId
service.method(arg, userId);

// After
@AuthenticationPrincipal UserEntity currentUser
service.method(arg, currentUser);
```

내부에서 `user.getId()` / `user.getUsername()` / `user.getRoleType()` 추출 사용.

**본인 검증 (updateUser)**:
```java
if (dto.getUsername() != null && !currentUser.getUsername().equals(dto.getUsername())) {
    throw new AccessDeniedException("본인 계정만 수정할 수 있습니다.");
}
```

**SecurityContextHolder 제거 (deleteUser)**:
```java
// Before: SecurityContextHolder.getContext().getAuthentication().getAuthorities()...
// After:
boolean isAdmin = currentUser.getRoleType() == UserRoleType.ADMIN;
boolean isSelfDelete = currentUser.getUsername().equals(dto.getUsername());
```

## Tradeoff

**알려진 한계** (후속 Story):
- **`UserUpdateRequestDTO.username` 자체 제거**: Story-5-4 범위. 본 PR은 본인 검증만 추가
- **권한 검증 `@PreAuthorize` 이관**: Story-5-3 범위. 본 PR은 Service 내부에 isAdmin 분기 유지
- **ADR005 Command/Query record 미적용**: 후속 hygiene Story. Service 시그니처가 raw 인자(UserEntity + DTO 2개)
- **회귀 테스트 부족**: ReviewController/Service 단위 테스트 부재 — 후속 누적 (LearningFacade BC 패턴 따라 Slice/통합)
- **UserEntity가 UserDetails 미구현**: Spring Security 어댑터 계층 부재. 도메인 객체와 인증 계약 혼재 — 별도 refactor Story
- **`UserController.updateUserApi`/`deleteUserApi` Slice 테스트 부재**: `@AuthenticationPrincipal UserEntity` 주입 흐름 동작 검증 누락 — 후속

## Reviewer 종합 (review.md §4 결과)

5관점 병렬 reviewer 세션:
- **Critical 3건**:
  - [Sceptical] ReviewController 5개 `@AuthenticationPrincipal Long userId` → 런타임 null 위험 → **본 PR 조치 (옵션 A)**
  - [Test] 시그니처 변경 회귀 테스트 0건 → 후속
  - [API/Exception] updateUser 본인 검증 누락 → **본 PR 조치 (본인 검증 추가)**
- **Major**:
  - deleteUser dto.username 잔존 + SecurityContextHolder → **본 PR 조치 (currentUser 기반 + getRoleType)**
  - UserEntity Principal이 UserDetails 미구현 → 후속 refactor
  - ADR005 미적용 / updateUser DB 재조회 / Comment Javadoc 격상 → 후속

사용자 의사결정: 옵션 A (ReviewController 포함 + 본인 검증 + currentUser 정리).

## Test

- [x] `./gradlew build` 전체 회귀 그린 (1m59s)
- [x] 정적 검증: `grep "@AuthenticationPrincipal String|Long" src/main` 0건 — AC1 통과
- [x] UserController + ReviewController + 기존 LearningFacade/Deck 모두 UserEntity 통일 — AC2 통과
- [ ] UserController slice 테스트 (`@WebMvcTest`) — 후속
- [ ] ReviewController slice + Review Service 단위 테스트 — 후속
- [ ] 로컬 부팅 + 인증 흐름 수동 검증 (사용자 검토)

## Checklist

- [x] BC 의존 방향 (presentation → application → {domain, infrastructure})
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] Reviewer 세션 통과 (Critical 0건 잔존)
- [ ] ADR — 단독 ADR 부적격. Epic 5 종료 시점 묶음 ADR 검토 후보 ("User BC 인증 주체 일원화")

## Related

- `workflow/product/Product.md` Story 5-2 명세
- Plan: `C:\Users\user\.claude\plans\ticklish-toasting-thunder.md`
- 선행: PR #135/#137/#138/#139/#140 (Epic 4 완료, Story 5-1)
- 다음: Story 5-3 (SecurityContextHolder 완전 제거 + @PreAuthorize), Story 5-4 (UserUpdateRequestDTO.username 제거)