### PR TITLE
[Security] refactor: SecurityContextHolder 제거 + AUTH_FORBIDDEN 응답 통일 (Story 5-3)

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     AUTH_TOKEN_EXPIRED("AUTH002",   "인증 토큰이 만료되었습니다.",                    HttpStatus.UNAUTHORIZED),
     AUTH_TOKEN_INVALID("AUTH003",   "인증 토큰이 유효하지 않습니다 (위조/서명 불일치).", HttpStatus.UNAUTHORIZED),
     AUTH_USER_NOT_FOUND("AUTH004",  "토큰의 사용자가 더 이상 존재하지 않습니다.",      HttpStatus.UNAUTHORIZED),
+    AUTH_FORBIDDEN("AUTH005",       "접근 권한이 없습니다.",                           HttpStatus.FORBIDDEN),
 
     // ─── Deck ─────────────────────────────────────────────
     DECK_NOT_FOUND("DECK001", "덱을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
@@ -115,8 +116,8 @@ public enum ErrorCode {
     FILE_DELETE_FAIL("FILE004",             "파일 삭제에 실패했습니다.",           HttpStatus.SERVICE_UNAVAILABLE),
 
     // ─── Library ──────────────────────────────────────────
-    ALREADY_EXISTS("LIBRARY001",  "이미 존재하는 리소스입니다.",  HttpStatus.CONFLICT),
-    ACCESS_DENIED("LIBRARY002",   "접근 권한이 없습니다.",        HttpStatus.FORBIDDEN);
+    // Story-5-3: ACCESS_DENIED("LIBRARY002") 제거 — 사용처 0건 + AUTH_FORBIDDEN(AUTH005)과 의미 중복.
+    ALREADY_EXISTS("LIBRARY001",  "이미 존재하는 리소스입니다.",  HttpStatus.CONFLICT);
 
     // ─── 필드 ─────────────────────────────────────────────
     private final String     code;

--- a/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -19,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -52,6 +54,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getCode(),
                                      ErrorCode.INVALID_INPUT.getMessage(), req.getRequestURI(), OffsetDateTime.now()));
+    }
+
+    /**
+     * Story-5-3: Controller에서 throw한 {@link AccessDeniedException}을 ErrorCode 기반 JSON 응답으로 변환.
+     *
+     * <p><strong>주의 — 처리 범위 분리</strong>:
+     * <ul>
+     *   <li>Controller throw → 본 핸들러가 {code:"AUTH005", message, path, timestamp} JSON 응답</li>
+     *   <li>Spring Security 필터 체인 throw (예: SecurityConfig의 `hasRole(...)` 미충족)
+     *       → {@code SecurityConfig.accessDeniedHandler}가 처리 (현재는 빈 body 403,
+     *       후속 Story에서 본 핸들러 응답 형식과 통일 예정)</li>
+     * </ul>
+     *
+     * <p>응답 메시지는 보안상 ErrorCode enum 메시지("접근 권한이 없습니다.")로 통일하며,
+     * Controller에서 던진 구체 메시지는 서버 로그에만 기록.
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest req) {
+        log.warn("[AccessDenied] {} {} - {}", req.getMethod(), req.getRequestURI(), ex.getMessage());
+        ErrorCode ec = ErrorCode.AUTH_FORBIDDEN;
+        return ResponseEntity.status(ec.getStatus())
+                             .body(new ErrorResponse(ec.getCode(), ec.getMessage(),
+                                                     req.getRequestURI(), OffsetDateTime.now()));
     }
 
     @Getter

--- a/src/main/java/com/example/thirdtool/User/application/UserCommandService.java
+++ b/src/main/java/com/example/thirdtool/User/application/UserCommandService.java
@@ -9,12 +9,10 @@ import com.example.thirdtool.User.domain.model.SocialMemberRegistrar;
 import com.example.thirdtool.User.domain.model.SocialProviderType;
 import com.example.thirdtool.User.domain.model.SocialUserInfo;
 import com.example.thirdtool.User.domain.model.UserEntity;
-import com.example.thirdtool.User.domain.model.UserRoleType;
 import com.example.thirdtool.User.domain.repository.UserRepository;
 import com.example.thirdtool.User.dto.UserDeleteRequestDTO;
 import com.example.thirdtool.User.dto.UserSignUpRequestDTO;
 import com.example.thirdtool.User.dto.UserUpdateRequestDTO;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,14 +97,8 @@ public class UserCommandService {
     }
 
     @Transactional
-    public Long updateUser(UserEntity currentUser, UserUpdateRequestDTO dto) throws AccessDeniedException {
-        // Story-5-2 본인 검증: 요청 바디의 username이 currentUser와 다르면 타 계정 수정 시도로 차단.
-        // (UserUpdateRequestDTO.username 자체 제거는 Story-5-4 범위)
-        if (dto.getUsername() != null && !currentUser.getUsername().equals(dto.getUsername())) {
-            throw new AccessDeniedException("본인 계정만 수정할 수 있습니다.");
-        }
-
-        // currentUser 정보로 자체 로그인·non-lock 조건을 만족하는 사용자를 찾아 수정.
+    public Long updateUser(UserEntity currentUser, UserUpdateRequestDTO dto) {
+        // Story-5-3: 권한·본인 검증은 Controller에서 처리. Service는 순수 비즈니스 로직만.
         UserEntity entity = userRepository.findByUsernameAndIsLockAndIsSocial(currentUser.getUsername(), false, false)
                                           .orElseThrow(() -> UserDomainException.of(ErrorCode.USER_NOT_FOUND));
         entity.updateUser(dto);
@@ -114,21 +106,10 @@ public class UserCommandService {
     }
 
     @Transactional
-    public void deleteUser(UserEntity currentUser, UserDeleteRequestDTO dto) throws AccessDeniedException {
-        // Story-5-2: SecurityContextHolder 직접 호출 제거 → currentUser.getRoleType() 활용.
-        // 권한 검증을 @PreAuthorize로 이관하는 것은 Story-5-3 범위 (현재는 Service에서 처리).
-        boolean isAdmin = currentUser.getRoleType() == UserRoleType.ADMIN;
-        boolean isSelfDelete = currentUser.getUsername().equals(dto.getUsername());
-
-        if (!isSelfDelete && !isAdmin) {
-            throw new AccessDeniedException("본인 혹은 관리자만 삭제할 수 있습니다.");
-        }
-
-        // 본인 삭제는 currentUser 기반, admin 삭제는 dto.username 기반 (admin이 다른 계정 삭제).
-        // 두 케이스 모두 결과 username은 dto.username과 동일 (isSelfDelete=true일 때 currentUser.username == dto.username).
-        String targetUsername = isSelfDelete ? currentUser.getUsername() : dto.getUsername();
-        userRepository.deleteByUsername(targetUsername);
-        jwtService.removeRefreshUser(targetUsername);
+    public void deleteUser(UserDeleteRequestDTO dto) {
+        // Story-5-3: 권한 검증(본인/관리자)은 Controller에서 처리. Service는 dto.username 기반 단순 삭제만.
+        userRepository.deleteByUsername(dto.getUsername());
+        jwtService.removeRefreshUser(dto.getUsername());
     }
 
     /**

--- a/src/main/java/com/example/thirdtool/User/presentation/UserController.java
+++ b/src/main/java/com/example/thirdtool/User/presentation/UserController.java
@@ -5,6 +5,7 @@ import com.example.thirdtool.Common.security.auth.token.TokenIssuer;
 import com.example.thirdtool.User.application.UserCommandService;
 import com.example.thirdtool.User.application.UserQueryService;
 import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.User.domain.model.UserRoleType;
 import com.example.thirdtool.User.dto.*;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -12,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,11 +35,10 @@ public class UserController {
     }
 
     // ✅ 자체 로그인 (AT Cookie + RT Body 발급)
+    // Story-5-3: 인증 컨텍스트 명시 청소 코드 제거 — STATELESS 세션이라 불필요.
     @PostMapping(value = "/login")
     public ResponseEntity<TokenResponse> loginLocal(@RequestBody LoginRequestDTO dto,
                                                     HttpServletResponse response) {
-
-        SecurityContextHolder.clearContext();
         UserEntity user = userCommandService.loginLocal(dto.getUsername(), dto.getPassword());
         String refreshToken = tokenIssuer.issue(user, response);
         return ResponseEntity.ok(new TokenResponse(refreshToken));
@@ -71,22 +70,33 @@ public class UserController {
 
     // ✅ 유저 수정 (자체 로그인 유저만) (Command)
     // Story-5-2: @AuthenticationPrincipal을 UserEntity 단일 타입으로 통일.
-    // 인증 주체 주입은 Spring Security가 JWTFilter에서 설정한 Principal을 그대로 활용.
+    // Story-5-3: 본인 검증을 Controller에서 수행. Service는 순수 비즈니스 로직만.
     @PutMapping(value = "/user", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Long> updateUserApi(
             @AuthenticationPrincipal UserEntity currentUser,
             @Validated @RequestBody UserUpdateRequestDTO dto
                                              ) throws AccessDeniedException {
+        // 본인 검증: dto에 username이 있으면 currentUser와 일치해야 함 (Story-5-4에서 dto.username 제거 예정).
+        if (dto.getUsername() != null && !currentUser.getUsername().equals(dto.getUsername())) {
+            throw new AccessDeniedException("본인 계정만 수정할 수 있습니다.");
+        }
         return ResponseEntity.status(200).body(userCommandService.updateUser(currentUser, dto));
     }
 
     // ✅ 유저 제거 (자체/소셜) (Command)
+    // Story-5-3: 본인 / 관리자 권한 검증을 Controller에서 수행. Service는 순수 삭제만.
     @DeleteMapping(value = "/user")
     public ResponseEntity<Boolean> deleteUserApi(
             @AuthenticationPrincipal UserEntity currentUser,
             @Validated @RequestBody UserDeleteRequestDTO dto
                                                 ) throws AccessDeniedException {
-        userCommandService.deleteUser(currentUser, dto);
+        boolean isAdmin = currentUser.getRoleType() == UserRoleType.ADMIN;
+        boolean isSelfDelete = currentUser.getUsername().equals(dto.getUsername());
+        if (!isSelfDelete && !isAdmin) {
+            throw new AccessDeniedException("본인 혹은 관리자만 삭제할 수 있습니다.");
+        }
+
+        userCommandService.deleteUser(dto);
         return ResponseEntity.status(200).body(true);
     }
 }

--- a/src/test/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandlerAccessDeniedTest.java
+++ b/src/test/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandlerAccessDeniedTest.java
@@ -1,0 +1,55 @@
+package com.example.thirdtool.Common.Exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-5-3: GlobalExceptionHandler.handleAccessDenied() 단위 검증.
+ *
+ * <p>Spring Security의 {@link AccessDeniedException}이 Controller에서 throw됐을 때
+ * AUTH_FORBIDDEN(AUTH005, FORBIDDEN) ErrorCode 응답으로 변환되는지 확인. 기존
+ * SocialLoginControllerExceptionSliceTest의 패턴(handler 직접 인스턴스화 +
+ * MockHttpServletRequest)을 답습.
+ */
+class GlobalExceptionHandlerAccessDeniedTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleAccessDenied_403_AUTH005_응답() {
+        AccessDeniedException ex = new AccessDeniedException("본인 혹은 관리자만 삭제할 수 있습니다.");
+        HttpServletRequest req = new MockHttpServletRequest("DELETE", "/user");
+
+        ResponseEntity<?> response = handler.handleAccessDenied(ex, req);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        Object body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getCode")).isEqualTo("AUTH005");
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getMessage"))
+                .isEqualTo("접근 권한이 없습니다.");
+        assertThat((String) ReflectionTestUtils.invokeMethod(body, "getPath")).isEqualTo("/user");
+    }
+
+    @Test
+    void handleAccessDenied_응답메시지가_ErrorCode_enum값으로_통일() {
+        // 보안 정책: Controller에서 던진 구체 메시지는 응답에 echo하지 않고 enum 메시지로 통일.
+        AccessDeniedException ex = new AccessDeniedException("매우 구체적인 거부 사유 (서버 로그에만 기록)");
+        HttpServletRequest req = new MockHttpServletRequest("PUT", "/user");
+
+        ResponseEntity<?> response = handler.handleAccessDenied(ex, req);
+
+        Object body = response.getBody();
+        String message = (String) ReflectionTestUtils.invokeMethod(body, "getMessage");
+        assertThat(message)
+                .isEqualTo("접근 권한이 없습니다.")
+                .doesNotContain("구체적인 거부 사유");
+    }
+}


### PR DESCRIPTION
## What

Service 레이어의 `SecurityContextHolder` 직접 참조를 제거하고 권한 검증을 Controller로 이관. `AccessDeniedException`은 `GlobalExceptionHandler`가 새 `AUTH_FORBIDDEN(AUTH005)` ErrorCode로 변환해 일관된 `{code, message, path, timestamp}` JSON 응답으로 통일.

**신규 ErrorCode**:
- `AUTH_FORBIDDEN("AUTH005", "접근 권한이 없습니다.", FORBIDDEN)`

**제거** (Reviewer Critical 1):
- `ACCESS_DENIED("LIBRARY002")` — 사용처 0건 dead code, `AUTH_FORBIDDEN`과 의미 중복

**GlobalExceptionHandler**:
- `@ExceptionHandler(AccessDeniedException.class)` 추가 → `AUTH_FORBIDDEN` 응답으로 변환
- `log.warn`으로 호출 측 메시지 + URI 서버 로그 기록 (응답에는 enum 메시지로 통일)
- Filter 단계(`SecurityConfig.accessDeniedHandler`) vs Controller throw 분리 명시 Javadoc

**UserController**:
- `updateUserApi`: `dto.username != null && != currentUser.username` → `AccessDenied` (본인 검증)
- `deleteUserApi`: `!(isSelfDelete || isAdmin)` → `AccessDenied` (본인/관리자 권한 검증)
- `loginLocal`: `SecurityContextHolder.clearContext()` 제거 (STATELESS 세션 불필요)

**UserCommandService 순수화**:
- `updateUser`: `throws AccessDeniedException` 제거, 본인 검증 분기 제거
- `deleteUser(UserEntity, dto)` → `deleteUser(UserDeleteRequestDTO dto)` 시그니처 단순화

**신규 테스트**:
- `GlobalExceptionHandlerAccessDeniedTest` 2 케이스 (403 + AUTH005 응답 + 호출 측 메시지 미echo)

**명세 갱신** (`workflow/product/Product.md` Story 5-3):
- 권한 검증 이관 방식 = 옵션 B (Controller 분기). `@PreAuthorize` 보류
- `UserCommandService.deleteUser` 시그니처 단순화 명시
- AC 4건 모두 체크 완료

## Why

`workflow/product/Product.md` Product 2 Epic 5 세 번째 Story. Story 5-2에서 이미 `UserCommandService`의 `SecurityContextHolder` 직접 호출은 제거됨. 본 Story는 권한 검증 책임을 Controller로 이관하고 응답 형식을 통일.

## How

**3가지 사용자 결정** (2026-05-29):
- **권한 검증 이관 방식 = 옵션 B (Controller 분기)**: `@PreAuthorize` 미도입 (`@EnableMethodSecurity` + SpEL 테스트 복잡도 회피)
- **ErrorCode 전략 = AUTH_FORBIDDEN 신규 등록** (AUTH 시리즈 일관)
- **`clearContext()` 제거**: STATELESS 세션이라 불필요

**처리 흐름 분리**:
| 발생 위치 | 처리자 | 응답 |
| --- | --- | --- |
| Controller throw | GlobalExceptionHandler.handleAccessDenied | 403 + JSON `{code:AUTH005, message, path, timestamp}` |
| Spring Security 필터 체인 (`hasRole`) | SecurityConfig.accessDeniedHandler | 403 + 빈 body (후속 통일) |

## Tradeoff

**알려진 한계** (후속 Story):
- **SecurityConfig.accessDeniedHandler 미통일**: `res.sendError(403)`로 응답 형식이 GlobalExceptionHandler와 다름. 후속 hygiene Story에서 ObjectMapper 주입으로 JSON 응답 통일
- **UserController slice 테스트 + UserCommandService 시그니처 변경 회귀 테스트 누락** — 후속 누적
- **본인 검증 로직 중복**: `currentUser.getUsername().equals(dto.username)`이 update/delete 양쪽. `UserEntity.isSelf(String)` 도메인 메서드 추출 후보
- **updateUser 본인 검증이 dto.username != null 조건부** — Story-5-4 dto.username 제거 시 무조건 검증으로 정리
- **Service 직접 호출 시 권한 우회 위험**: `UserCommandService.deleteUser(dto)`가 currentUser 안 받음. Javadoc에 "권한 검증 미수행, 호출 측 책임" 명시. 다른 Service/Batch가 직접 호출하면 권한 우회 가능 — `@Deprecated` 후속 명시 검토

## Reviewer 종합 (review.md §4 결과)

5관점 병렬 reviewer 세션:
- **Critical 2건**:
  - [Sceptical] ACCESS_DENIED dead code → **본 PR 제거**
  - [Sceptical·API] SecurityConfig.accessDeniedHandler 통일 → 후속 Story 분리
- **Major 6건**:
  - [Sceptical] Product.md AC 갱신 → **본 PR 조치**
  - [Test] AUTH_FORBIDDEN 응답 검증 단위 테스트 → **본 PR 추가**
  - [Domain] 도메인 규칙 Controller 노출 → 후속 (`UserEntity.isSelf`)
  - [Architecture] deleteUser currentUser 안 받음 → Javadoc + 후속 `@Deprecated`
  - [Test] UserController slice + UserCommandService 회귀 → 후속
  - [API] updateUser dto.username 조건부 검증 → Story-5-4 정렬
- **Minor / Nit**:
  - handleAccessDenied log.warn 추가 → **본 PR 조치**
  - 핸들러 Javadoc 보강 → **본 PR 조치**
  - 본인 검증 중복 (헬퍼 추출) / clearContext 제거 근거 / 메서드명 일관성 → 후속

사용자 의사결정: 옵션 b (Critical 1 + Product.md + Major 일부 + log/주석 보강).

## Test

- [x] `./gradlew build` 그린 (1m44s, 전체 회귀)
- [x] `GlobalExceptionHandlerAccessDeniedTest` 2 케이스 그린
- [x] 정적 검증: `grep "SecurityContextHolder" src/main` → `Common/security` 내 2건만 (JWTFilter, TestController) — AC1 통과
- [ ] UserController slice (`@WebMvcTest`) — 후속
- [ ] UserCommandService.updateUser/deleteUser 회귀 — 후속
- [ ] 로컬 부팅 + 권한 거부 시나리오 수동 검증 (사용자 검토)

## Checklist

- [x] BC 의존 방향 (presentation → application → {domain, infrastructure})
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] Reviewer 세션 통과 (Critical 1 조치, Critical 2는 후속 명시)
- [ ] ADR — Epic 5 종료 시점 묶음 ADR 검토 후보 ("User BC 인증·인가 일원화 + ErrorCode 매핑 통일")

## Related

- `workflow/product/Product.md` Story 5-3 명세 (본 PR로 갱신)
- Plan: `C:\Users\user\.claude\plans\ticklish-toasting-thunder.md`
- 선행: PR #141 (Story 5-2)
- 다음: Story 5-4 (`UserUpdateRequestDTO.username` / `UserRequestDTO` 제거)
- 후속 정리 Story: SecurityConfig.accessDeniedHandler JSON 통일