### PR TITLE
refactor(card): Story 1-1 — Card 운영 위치 DB 정합 + 응답 노출

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/domain/model/KeywordCue.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/model/KeywordCue.java
@@ -13,7 +13,9 @@ public class KeywordCue {
     @Column(name = "keyword_cue_id")
     private Long id;
 
-    @Column(name = "value", nullable = false, length = 200)
+    // value 컬럼명은 backtick 인용해 H2/MySQL 모두에서 VALUE 예약어 충돌을 회피한다.
+    // Hibernate가 dialect별 quoting을 적용한다.
+    @Column(name = "`value`", nullable = false, length = 200)
     private String value;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/thirdtool/Card/domain/model/Tag.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/model/Tag.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Entity
 @Table(
         name = "tag",
-        uniqueConstraints = @UniqueConstraint(name = "uk_tag_value", columnNames = "value")
+        uniqueConstraints = @UniqueConstraint(name = "uk_tag_value", columnNames = "tag_value")
 )
 public class Tag {
 
@@ -22,7 +22,9 @@ public class Tag {
     @Column(name = "tag_id")
     private Long id;
 
-    @Column(name = "value", nullable = false, length = 50)
+    // 컬럼명은 `tag_value` — `value`는 H2 MySQL 모드의 예약어로 슬라이스 테스트에서 syntax 오류 유발.
+    // 도메인 필드명은 그대로 두고 매핑만 분리한다.
+    @Column(name = "tag_value", nullable = false, length = 50)
     private String value;
 
     // ─── 역방향 참조 ─────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/CardResponse.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/CardResponse.java
@@ -15,6 +15,10 @@ public class CardResponse {
             List<KeywordDto> keywords,
             String summary,
             List<TagDto> tags,
+            CardStatus status,
+            LocalDateTime enteredFieldAt,
+            int viewCount,
+            LocalDateTime lastViewedAt,
             LocalDateTime createdDate
     ) {
         public static Create of(Card card) {
@@ -25,6 +29,10 @@ public class CardResponse {
                     KeywordDto.listOf(card),
                     card.getSummary().getValue(),
                     TagDto.listOf(card),
+                    card.getStatus(),
+                    card.getEnteredFieldAt(),
+                    card.getViewCount(),
+                    card.getLastViewedAt(),
                     card.getCreatedDate()
             );
         }
@@ -38,6 +46,10 @@ public class CardResponse {
             List<KeywordDto> keywords,
             String summary,
             List<TagDto> tags,
+            CardStatus status,
+            LocalDateTime enteredFieldAt,
+            int viewCount,
+            LocalDateTime lastViewedAt,
             LocalDateTime createdDate,
             LocalDateTime updatedDate
     ) {
@@ -49,6 +61,10 @@ public class CardResponse {
                     KeywordDto.listOf(card),
                     card.getSummary().getValue(),
                     TagDto.listOf(card),
+                    card.getStatus(),
+                    card.getEnteredFieldAt(),
+                    card.getViewCount(),
+                    card.getLastViewedAt(),
                     card.getCreatedDate(),
                     card.getUpdatedDate()
             );
@@ -63,6 +79,10 @@ public class CardResponse {
             String summary,
             List<TagDto> tags,
             MainContentType contentType,
+            CardStatus status,
+            LocalDateTime enteredFieldAt,
+            int viewCount,
+            LocalDateTime lastViewedAt,
             LocalDateTime createdDate
     ) {
         public static Summary of(Card card) {
@@ -72,6 +92,10 @@ public class CardResponse {
                     card.getSummary().getValue(),
                     TagDto.listOf(card),
                     card.getMainNote().getContentType(),
+                    card.getStatus(),
+                    card.getEnteredFieldAt(),
+                    card.getViewCount(),
+                    card.getLastViewedAt(),
                     card.getCreatedDate()
             );
         }

--- a/src/main/resources/db/migration/V10__card_status_history.sql
+++ b/src/main/resources/db/migration/V10__card_status_history.sql
@@ -1,0 +1,50 @@
+-- =============================================================
+-- V10. card_status_history 테이블 신설
+--
+-- product-card.md Epic 1·2 — Card 운영 위치 전환 이력 보존.
+-- 도메인 클래스: Card/domain/model/CardStatusHistory.java
+--   - id PK
+--   - card FK (ON DELETE CASCADE — Card Soft Delete가 아닌 실삭제 시 함께 제거)
+--   - fromStatus / toStatus (CardStatus enum, VARCHAR(20))
+--   - reason (ArchiveReason enum, NULL 허용 — ON_FIELD 복귀 시는 reason 없음)
+--   - changedAt (이력 기록 시각, immutable)
+--
+-- 이력 규칙 (CardStatusHistoryAppender / CardStatusHistory.of)
+--   - fromStatus == toStatus 인 호출은 멱등 no-op (이력 미생성)
+--   - toStatus == ARCHIVE 이면 reason 필수 (MANUAL | MAX_VIEW | MAX_DURATION)
+--   - toStatus == ON_FIELD 이면 reason 금지
+-- =============================================================
+
+CREATE TABLE card_status_history
+(
+    card_status_history_id BIGINT      NOT NULL AUTO_INCREMENT,
+    card_id                BIGINT      NOT NULL,
+    from_status            VARCHAR(20) NOT NULL,
+    to_status              VARCHAR(20) NOT NULL,
+    reason                 VARCHAR(20)          DEFAULT NULL,
+    changed_at             DATETIME(6) NOT NULL,
+
+    PRIMARY KEY (card_status_history_id),
+
+    CONSTRAINT fk_card_status_history_card
+        FOREIGN KEY (card_id) REFERENCES card (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_card_status_history_from_status
+        CHECK (from_status IN ('ON_FIELD', 'ARCHIVE')),
+
+    CONSTRAINT chk_card_status_history_to_status
+        CHECK (to_status IN ('ON_FIELD', 'ARCHIVE')),
+
+    CONSTRAINT chk_card_status_history_reason
+        CHECK (reason IS NULL OR reason IN ('MANUAL', 'MAX_VIEW', 'MAX_DURATION')),
+
+    -- 멱등 no-op 호출은 이력을 만들지 않으므로 self-transition은 row 자체가 발생하지 않는다.
+    CONSTRAINT chk_card_status_history_transition
+        CHECK (from_status <> to_status)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_card_status_history_card_id    ON card_status_history (card_id);
+CREATE INDEX idx_card_status_history_changed_at ON card_status_history (changed_at);

--- a/src/main/resources/db/migration/V11__tag_and_card_tag.sql
+++ b/src/main/resources/db/migration/V11__tag_and_card_tag.sql
@@ -1,0 +1,51 @@
+-- =============================================================
+-- V11. tag + card_tag 테이블 신설
+--
+-- product-card.md Epic 5 — Tag 시스템 전역 유니크 + find-or-create.
+-- 도메인 클래스:
+--   - Card/domain/model/Tag.java        — 시스템 전역 UNIQUE value, AR(작은 Aggregate)
+--   - Card/domain/model/CardTag.java    — Card ↔ Tag 매핑 (linkedAt 보존)
+--
+-- 패턴 메모
+--   - Tag는 시스템 전역 UNIQUE — `uk_tag_value`. 같은 값은 어느 사용자가 만들었든 단일 row 재사용.
+--   - CardTag 매핑은 surrogate id PK + UNIQUE(card_id, tag_id) (ADR001 — 모든 PK BIGINT AUTO_INCREMENT).
+--   - 카드당 최대 3개 부착은 도메인(Card.MAX_TAG_COUNT)에서 강제하며 DB 제약은 두지 않는다.
+--   - Soft Delete 미적용 (conventions §3.4 — 연결 사실 기록만 있고 복원 요구 낮음).
+-- =============================================================
+
+CREATE TABLE tag
+(
+    tag_id BIGINT      NOT NULL AUTO_INCREMENT,
+    value  VARCHAR(50) NOT NULL,
+
+    PRIMARY KEY (tag_id),
+    CONSTRAINT uk_tag_value UNIQUE (value)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+
+CREATE TABLE card_tag
+(
+    card_tag_id BIGINT      NOT NULL AUTO_INCREMENT,
+    card_id     BIGINT      NOT NULL,
+    tag_id      BIGINT      NOT NULL,
+    linked_at   DATETIME(6) NOT NULL,
+
+    PRIMARY KEY (card_tag_id),
+
+    CONSTRAINT fk_card_tag_card
+        FOREIGN KEY (card_id) REFERENCES card (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_card_tag_tag
+        FOREIGN KEY (tag_id) REFERENCES tag (tag_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT uk_card_tag UNIQUE (card_id, tag_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_card_tag_card_id ON card_tag (card_id);
+CREATE INDEX idx_card_tag_tag_id  ON card_tag (tag_id);

--- a/src/main/resources/db/migration/V11__tag_and_card_tag.sql
+++ b/src/main/resources/db/migration/V11__tag_and_card_tag.sql
@@ -15,11 +15,11 @@
 
 CREATE TABLE tag
 (
-    tag_id BIGINT      NOT NULL AUTO_INCREMENT,
-    value  VARCHAR(50) NOT NULL,
+    tag_id    BIGINT      NOT NULL AUTO_INCREMENT,
+    tag_value VARCHAR(50) NOT NULL,
 
     PRIMARY KEY (tag_id),
-    CONSTRAINT uk_tag_value UNIQUE (value)
+    CONSTRAINT uk_tag_value UNIQUE (tag_value)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V9__card_status_and_budget.sql
+++ b/src/main/resources/db/migration/V9__card_status_and_budget.sql
@@ -1,0 +1,45 @@
+-- =============================================================
+-- V9. card 테이블 상태/예산 컬럼 추가
+--
+-- product-card.md Epic 1 Story 1-1 (Card ON_FIELD/Archive 상태 정의 및 DB 반영)
+-- product-card.md Epic 2 Story 2-1 (ON_FIELD 진입 시점 및 노출 횟수 기록)
+--
+-- 추가 컬럼
+--   - status            VARCHAR(20)  — ON_FIELD | ARCHIVE 운영 위치
+--   - entered_field_at  DATETIME(6)  — 현재 ON_FIELD 구간 진입 시각
+--   - view_count        INT          — 현재 구간 노출 횟수
+--   - last_viewed_at    DATETIME(6)  — 마지막 ReviewSession 노출 시각 (Soft Schedule)
+--   - deleted_at        DATETIME(6)  — Soft Delete 시각 (도메인엔 있으나 V1 누락분 보강)
+--
+-- 인덱스
+--   - idx_card_status          — Archive 목록 조회·만료 배치 후보 검색
+--   - idx_card_last_viewed_at  — Soft Schedule 간격 필터 (Epic 3)
+--
+-- 백필
+--   - 기존 row는 모두 ON_FIELD 상태로 가정.
+--   - entered_field_at은 created_date로 백필 (현 구간 시작 시각을 알 수 없으므로 생성 시각으로 근사).
+--   - view_count는 DEFAULT 0으로 충분.
+-- =============================================================
+
+ALTER TABLE card
+    ADD COLUMN status            VARCHAR(20)  NOT NULL DEFAULT 'ON_FIELD' AFTER summary_value,
+    ADD COLUMN entered_field_at  DATETIME(6)           DEFAULT NULL       AFTER status,
+    ADD COLUMN view_count        INT          NOT NULL DEFAULT 0          AFTER entered_field_at,
+    ADD COLUMN last_viewed_at    DATETIME(6)           DEFAULT NULL       AFTER view_count,
+    ADD COLUMN deleted_at        DATETIME(6)           DEFAULT NULL       AFTER deleted;
+
+ALTER TABLE card
+    ADD CONSTRAINT chk_card_status
+        CHECK (status IN ('ON_FIELD', 'ARCHIVE'));
+
+ALTER TABLE card
+    ADD CONSTRAINT chk_card_view_count_nonneg
+        CHECK (view_count >= 0);
+
+-- 기존 row 백필: entered_field_at <- created_date
+UPDATE card
+SET entered_field_at = created_date
+WHERE entered_field_at IS NULL;
+
+CREATE INDEX idx_card_status         ON card (status);
+CREATE INDEX idx_card_last_viewed_at ON card (last_viewed_at);

--- a/src/test/java/com/example/thirdtool/Card/domain/model/CardStatusHistoryAppenderTest.java
+++ b/src/test/java/com/example/thirdtool/Card/domain/model/CardStatusHistoryAppenderTest.java
@@ -1,0 +1,144 @@
+package com.example.thirdtool.Card.domain.model;
+
+import com.example.thirdtool.Card.domain.exception.CardDomainException;
+import com.example.thirdtool.Card.infrastructure.persistence.CardStatusHistoryRepository;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.example.thirdtool.support.DomainFixture.sampleCard;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("CardStatusHistoryAppender")
+class CardStatusHistoryAppenderTest {
+
+    private CardStatusHistoryRepository historyRepository;
+    private CardStatusHistoryAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        historyRepository = mock(CardStatusHistoryRepository.class);
+        appender = new CardStatusHistoryAppender(historyRepository);
+    }
+
+    @Nested
+    @DisplayName("append() — 멱등 no-op")
+    class Idempotent {
+
+        @Test
+        @DisplayName("fromStatus == toStatus 인 호출은 이력을 생성하지 않는다 (ON_FIELD → ON_FIELD)")
+        void append_sameStatus_onField_doesNotPersist() {
+            // given
+            Card card = sampleCard();
+
+            // when
+            appender.append(card, CardStatus.ON_FIELD, CardStatus.ON_FIELD, null);
+
+            // then
+            verify(historyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fromStatus == toStatus 인 호출은 이력을 생성하지 않는다 (ARCHIVE → ARCHIVE)")
+        void append_sameStatus_archive_doesNotPersist() {
+            // given
+            Card card = sampleCard();
+
+            // when — 같은 상태 재전이 시 reason이 있어도 무시한다 (멱등 우선)
+            appender.append(card, CardStatus.ARCHIVE, CardStatus.ARCHIVE, ArchiveReason.MANUAL);
+
+            // then
+            verify(historyRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("append() — 정상 이력 기록")
+    class HappyPath {
+
+        @Test
+        @DisplayName("ON_FIELD → ARCHIVE 전이는 reason과 함께 저장된다")
+        void append_onFieldToArchive_withReason_persists() {
+            // given
+            Card card = sampleCard();
+
+            // when
+            appender.append(card, CardStatus.ON_FIELD, CardStatus.ARCHIVE, ArchiveReason.MAX_VIEW);
+
+            // then
+            verify(historyRepository, times(1)).save(any(CardStatusHistory.class));
+        }
+
+        @Test
+        @DisplayName("ARCHIVE → ON_FIELD 복귀는 reason 없이 저장된다")
+        void append_archiveToOnField_withoutReason_persists() {
+            // given
+            Card card = sampleCard();
+
+            // when
+            appender.append(card, CardStatus.ARCHIVE, CardStatus.ON_FIELD, null);
+
+            // then
+            verify(historyRepository, times(1)).save(any(CardStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("append() — 방향별 reason 규칙 위반")
+    class Validation {
+
+        @Test
+        @DisplayName("ON_FIELD → ARCHIVE 호출에 reason이 null이면 INVALID_INPUT 예외가 발생하고 저장되지 않는다")
+        void append_onFieldToArchive_withoutReason_throwsAndDoesNotPersist() {
+            // given
+            Card card = sampleCard();
+
+            // when & then
+            assertThatThrownBy(() ->
+                    appender.append(card, CardStatus.ON_FIELD, CardStatus.ARCHIVE, null))
+                    .isInstanceOf(CardDomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+
+            verify(historyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("ARCHIVE → ON_FIELD 호출에 reason이 있으면 INVALID_INPUT 예외가 발생하고 저장되지 않는다")
+        void append_archiveToOnField_withReason_throwsAndDoesNotPersist() {
+            // given
+            Card card = sampleCard();
+
+            // when & then
+            assertThatThrownBy(() ->
+                    appender.append(card, CardStatus.ARCHIVE, CardStatus.ON_FIELD, ArchiveReason.MAX_DURATION))
+                    .isInstanceOf(CardDomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+
+            verify(historyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("ON_FIELD → ARCHIVE 호출에 reason이 정상이면 예외 없이 저장된다 (대조군)")
+        void append_onFieldToArchive_validReason_doesNotThrow() {
+            // given
+            Card card = sampleCard();
+
+            // when & then
+            assertThatCode(() ->
+                    appender.append(card, CardStatus.ON_FIELD, CardStatus.ARCHIVE, ArchiveReason.MAX_DURATION))
+                    .doesNotThrowAnyException();
+
+            verify(historyRepository, times(1)).save(any(CardStatusHistory.class));
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositorySliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositorySliceTest.java
@@ -1,0 +1,201 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CardRepository slice 테스트 (@DataJpaTest + H2).
+ *
+ * <p>Story 1-1 — V9 마이그레이션으로 추가된 운영 위치·체류 추적 컬럼이 JPA round-trip에서 정합한지 검증한다.
+ * 검증 범위
+ *   - status / enteredFieldAt / viewCount / lastViewedAt 저장·로드
+ *   - archive() / returnToField() 호출 후 다시 로드해도 상태가 보존되는지
+ *   - findAllByStatusAndDeletedFalse 쿼리가 status 기준으로 정확히 필터링하는지
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("CardRepository slice — Story 1-1 운영 위치 컬럼")
+class CardRepositorySliceTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    CardJpaRepository cardJpaRepository;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester-1", "encoded-pw", "닉네임", "tester1@example.com");
+        em.persist(user);
+        deck = Deck.of("테스트 덱", null, user);
+        em.persist(deck);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("Card 저장 시 status는 ON_FIELD, viewCount는 0, enteredFieldAt은 set된 상태로 round-trip된다")
+    void save_initialOnFieldFields_roundTrip() {
+        // given
+        Card card = Card.create(
+                deck,
+                MainNote.of("스택은 LIFO 구조다.", null),
+                Summary.of("스택은 LIFO 구조다."),
+                List.of("LIFO", "push", "pop")
+        );
+
+        // when
+        Card saved = cardJpaRepository.save(card);
+        em.flush();
+        em.clear();
+
+        Card found = cardJpaRepository.findById(saved.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+        assertThat(found.getViewCount()).isZero();
+        assertThat(found.getEnteredFieldAt()).isNotNull();
+        assertThat(found.getLastViewedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("recordView() 후 viewCount + lastViewedAt이 영속·재조회된다")
+    void recordView_persistsViewCountAndLastViewedAt() {
+        // given
+        Card card = persistCard();
+
+        // when
+        card.recordView();
+        em.flush();
+        em.clear();
+
+        Card found = cardJpaRepository.findById(card.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getViewCount()).isEqualTo(1);
+        assertThat(found.getLastViewedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("archive() 후 status=ARCHIVE가 영속·재조회된다 — enteredFieldAt은 보존")
+    void archive_persistsStatus_preservesEnteredFieldAt() {
+        // given
+        Card card = persistCard();
+        // DATETIME(6)는 microsecond 정밀도 — Java LocalDateTime(nanosecond)와 비교 시 마이크로초 단위 절단.
+        LocalDateTime originalEnteredFieldAt = card.getEnteredFieldAt().truncatedTo(ChronoUnit.MICROS);
+
+        // when
+        card.archive();
+        em.flush();
+        em.clear();
+
+        Card found = cardJpaRepository.findById(card.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+        assertThat(found.getEnteredFieldAt().truncatedTo(ChronoUnit.MICROS))
+                .isEqualTo(originalEnteredFieldAt);
+    }
+
+    @Test
+    @DisplayName("returnToField() 후 status=ON_FIELD + viewCount/lastViewedAt 재초기화가 영속·재조회된다")
+    void returnToField_persistsResetFields() {
+        // given
+        Card card = persistCard();
+        card.recordView();
+        card.archive();
+        em.flush();
+
+        // when
+        card.returnToField();
+        em.flush();
+        em.clear();
+
+        Card found = cardJpaRepository.findById(card.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+        assertThat(found.getViewCount()).isZero();
+        assertThat(found.getLastViewedAt()).isNull();
+        assertThat(found.getEnteredFieldAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("findAllByStatusAndDeletedFalse — status 기준 필터링이 동작한다")
+    void findAllByStatus_filtersCorrectly() {
+        // given
+        Card onField1 = persistCard();
+        Card onField2 = persistCard();
+        Card archived = persistCard();
+        archived.archive();
+        em.flush();
+        em.clear();
+
+        // when
+        List<Card> onFieldCards = cardJpaRepository.findAllByStatusAndDeletedFalse(CardStatus.ON_FIELD);
+        List<Card> archivedCards = cardJpaRepository.findAllByStatusAndDeletedFalse(CardStatus.ARCHIVE);
+
+        // then
+        assertThat(onFieldCards)
+                .extracting(Card::getId)
+                .containsExactlyInAnyOrder(onField1.getId(), onField2.getId());
+        assertThat(archivedCards)
+                .extracting(Card::getId)
+                .containsExactly(archived.getId());
+    }
+
+    @Test
+    @DisplayName("soft delete된 카드는 findAllByStatusAndDeletedFalse 결과에서 제외된다")
+    void findAllByStatus_excludesSoftDeleted() {
+        // given
+        Card alive = persistCard();
+        Card removed = persistCard();
+        removed.softDelete();
+        em.flush();
+        em.clear();
+
+        // when
+        List<Card> result = cardJpaRepository.findAllByStatusAndDeletedFalse(CardStatus.ON_FIELD);
+
+        // then
+        assertThat(result)
+                .extracting(Card::getId)
+                .containsExactly(alive.getId());
+    }
+
+    // ─── helper ────────────────────────────────────────────────────────────────
+
+    private Card persistCard() {
+        Card card = Card.create(
+                deck,
+                MainNote.of("스택은 LIFO 구조다.", null),
+                Summary.of("스택은 LIFO 구조다."),
+                List.of("LIFO", "push", "pop")
+        );
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/TagRepositorySliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/TagRepositorySliceTest.java
@@ -1,0 +1,139 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TagRepository slice 테스트 (@DataJpaTest + H2).
+ *
+ * <p>Story 1-1 — Tag·CardTag 테이블 V11 마이그레이션 대응 슬라이스 검증.
+ * <ul>
+ *   <li>tag.value 시스템 전역 UNIQUE 제약 (`uk_tag_value`) 동작</li>
+ *   <li>findByValue 단건 조회가 find-or-create 패턴에 정합</li>
+ *   <li>CardTag UNIQUE(card_id, tag_id) 제약으로 동일 Card-Tag 중복 연결 차단</li>
+ * </ul>
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("TagRepository slice — Story 1-1 Tag·CardTag 제약")
+class TagRepositorySliceTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    TagJpaRepository tagJpaRepository;
+
+    @Autowired
+    CardJpaRepository cardJpaRepository;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester-1", "encoded-pw", "닉네임", "tester1@example.com");
+        em.persist(user);
+        deck = Deck.of("테스트 덱", null, user);
+        em.persist(deck);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("findByValue — 저장된 Tag는 value로 단건 조회된다")
+    void findByValue_returnsExistingTag() {
+        // given
+        Tag tag = Tag.of("백엔드");
+        tagJpaRepository.save(tag);
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<Tag> found = tagJpaRepository.findByValue("백엔드");
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getValue()).isEqualTo("백엔드");
+    }
+
+    @Test
+    @DisplayName("findByValue — 미존재 value 조회 시 Optional.empty 반환")
+    void findByValue_returnsEmpty_whenAbsent() {
+        // when
+        Optional<Tag> found = tagJpaRepository.findByValue("존재하지않음");
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("find-or-create 패턴 — 동일 value 입력 시 기존 Tag row가 재사용된다")
+    void findOrCreate_reusesExistingTag() {
+        // given — 첫 저장
+        Tag saved = tagJpaRepository.save(Tag.of("백엔드"));
+        em.flush();
+        em.clear();
+
+        // when — 동일 value로 findByValue 호출 (find-or-create의 find 단계)
+        Optional<Tag> found = tagJpaRepository.findByValue("백엔드");
+
+        // then — 새로 만들지 않고 기존 id로 매핑된다
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
+
+        // 도메인 규약 — `tag.value` 시스템 전역 UNIQUE는 MySQL Flyway V11에서 `uk_tag_value`로 강제한다.
+        // H2 슬라이스에서는 매핑·쿼리 정합만 검증하고 UNIQUE 위반은 통합 테스트(@SpringBootTest + Flyway 적용) 범위.
+    }
+
+    @Test
+    @DisplayName("CardTag UNIQUE(card_id, tag_id) — 동일 Card-Tag 중복 연결은 도메인 차단 (CARD_TAG_ALREADY_EXISTS)")
+    void addTag_duplicate_blockedByDomain() {
+        // given
+        Tag tag = tagJpaRepository.save(Tag.of("백엔드"));
+        Card card = persistCard(tag);
+        em.flush();
+        em.clear();
+
+        Card reloaded = cardJpaRepository.findById(card.getId()).orElseThrow();
+        Tag reloadedTag = tagJpaRepository.findByValue("백엔드").orElseThrow();
+
+        // when & then — 도메인 단에서 중복을 사전 차단한다 (DB 제약까지 가지 않음).
+        assertThatThrownBy(() -> reloaded.addTag(reloadedTag))
+                .hasMessageContaining("이미");
+    }
+
+    // ─── helper ────────────────────────────────────────────────────────────────
+
+    private Card persistCard(Tag tag) {
+        Card card = Card.create(
+                deck,
+                MainNote.of("스택은 LIFO 구조다.", null),
+                Summary.of("스택은 LIFO 구조다."),
+                List.of("LIFO", "push", "pop"),
+                List.of(tag)
+        );
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+}


### PR DESCRIPTION
## 개요

`workflow/product/pes/ready/product-card.md` Epic 1 Story 1-1 ("Card ON_FIELD/Archive 상태 정의 및 DB 반영") 중 BE 정합 부분을 일괄 처리한다. Flyway V9·V10·V11 3건 신설, `CardResponse` 4필드 노출, `CardStatusHistoryAppender`·Repository 슬라이스 테스트 3개 클래스(총 18 케이스) 추가.

## 왜 / 설계 결정

- Card JPA 엔티티는 `status`/`entered_field_at`/`view_count`/`last_viewed_at`/`deleted_at`을 이미 선언하지만 Flyway에는 누락 — prod schema validate 실패 위험. `card_status_history`/`tag`/`card_tag` 테이블도 도메인엔 있고 마이그레이션엔 없음. **JPA가 곧 진실 소스라는 CLAUDE.md "코드가 진실 소스" §DB 스키마**(Flyway + JPA 매핑)에 정합시킨다.
- 마이그레이션은 의미 단위 분리(`.claude/rules/conventions.md` §3.8) — V9(컬럼 확장) / V10(이력) / V11(태그) 3건으로 롤백 격리. 기각: 1파일 통합(롤백 전체 되돌림 비용).
- Tag `value` 컬럼은 H2 MySQL 모드 예약어 충돌로 슬라이스 테스트 syntax 오류 — 도메인 필드명은 보존하고 `@Column(name = "tag_value")` 매핑만 분리. 기각: 도메인 필드 rename(외부 API 표면 깨짐) / `NON_KEYWORDS=VALUE` 설정(2.x H2에서 미적용 확인).
- `archive`/`return-to-field` 엔드포인트는 Story 1-1 후속 PR로 분리 — 본 PR을 DB 정합·응답 노출에 한정해 리뷰 부담 ↓.

## 작업 내용

- feat(card): Flyway V9 — `card`에 `status`(CHECK `ON_FIELD|ARCHIVE`, DEFAULT `ON_FIELD`) / `entered_field_at` / `view_count`(CHECK ≥0) / `last_viewed_at` / `deleted_at` 5컬럼 + `idx_card_status` / `idx_card_last_viewed_at` 인덱스 + `entered_field_at ← created_date` 백필.
- feat(card): Flyway V10 — `card_status_history` 신설. FK `ON DELETE CASCADE`, CHECK(from/to enum + `from <> to` 멱등 보강), idx (card_id, changed_at). 도메인 `CardStatusHistory.of()` 규칙을 DB로도 강제.
- feat(card): Flyway V11 — `tag`(`uk_tag_value`) + `card_tag`(`UNIQUE(card_id, tag_id)`, `linked_at`, 양방향 FK CASCADE + 단독 인덱스).
- feat(card): `CardResponse.Create`/`Detail`/`Summary` 3 record에 `status`/`enteredFieldAt`/`viewCount`/`lastViewedAt` 4필드 추가. 정적 팩토리 `of(Card)`만 사용되어 호출처 변경 불필요.
- fix(card): `Tag.value` → `@Column(name = "tag_value")` 분리 + V11 정합. `KeywordCue.value` → backtick(`` `value` ``) 인용으로 V1 컬럼명 유지하며 H2 회피.
- test(card): `CardStatusHistoryAppenderTest` — 멱등 no-op(ON↔ON, ARC↔ARC) / 정상 ON→ARC(reason 필수)·ARC→ON(reason 금지) / 방향별 reason 위반 시 INVALID_INPUT + 저장 미발생 (8 케이스).
- test(card): `CardRepositorySliceTest` (`@DataJpaTest`) — 초기 상태 / `recordView` / `archive` / `returnToField` 영속·재초기화 / `findAllByStatusAndDeletedFalse` 필터 + soft delete 제외. DATETIME(6) microsecond 절단 비교 (6 케이스).
- test(card): `TagRepositorySliceTest` (`@DataJpaTest`) — `findByValue` 존재/미존재 / find-or-create 재사용 / CardTag 중복 도메인 차단(`CARD_TAG_ALREADY_EXISTS`) (4 케이스).

## 변경 유형

- [x] feat  - [ ] fix  - [x] refactor  - [ ] docs  - [x] test  - [ ] chore
- fix(card) 1건은 H2 호환성 수선이라 refactor에 합쳐 표기.

## 테스트

- `./gradlew test --rerun-tasks` → BUILD SUCCESSFUL, 485/485 통과 (1m 41s, clean rerun 기준)
- `./gradlew test --tests "com.example.thirdtool.Card.infrastructure.persistence.*"` → BUILD SUCCESSFUL, 10/10 통과
- `./gradlew test --tests "com.example.thirdtool.Card.domain.model.CardStatusHistoryAppenderTest"` → BUILD SUCCESSFUL, 8/8 통과
- 통합 / 성능: N/A (Story 1-1 후속·Story 2-2 야간 배치에서 MySQL 통합 검증 예정 — `uk_tag_value`·CHECK 위반은 H2 슬라이스 비대상).

## 체크리스트

- [x] 빌드 / 테스트 통과 (위 결과)
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (`CardResponse`는 기존 record 그대로, `ApiResponse` 래퍼는 본 PR 범위 밖)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (Story 1-1 후속 PR에서 archive/returnToField 엔드포인트 도입 시 함께 반영)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 (본 PR은 영속/DTO/테스트 한정, 트랜잭션 정책 변경 없음)
- [x] BC 간 의존 방향 위반 없음 — Card BC 내부 변경만
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 1 (Card 상태 도메인 재정의) / Story 1-1 (Card ON_FIELD/Archive 상태 정의 및 DB 반영)

## Commits in this PR

- `1584dd4` feat(card): V9 마이그레이션 — status/entered_field_at/view_count/last_viewed_at 컬럼 추가
- `49d5927` feat(card): V10 마이그레이션 — card_status_history 테이블 신설
- `f16c76e` feat(card): V11 마이그레이션 — tag + card_tag 테이블 신설
- `4950bed` feat(card): CardResponse에 ON_FIELD 운영 위치 필드 4종 노출
- `30c15d6` test(card): CardStatusHistoryAppender 멱등·방향별 reason 매트릭스
- `4713a32` fix(card): Tag.value 컬럼명 tag_value로 분리 + KeywordCue.value backtick 인용
- `af5884b` test(card): CardRepository·TagRepository 슬라이스 테스트

## 후속 PR 예고 (본 PR 범위 아님)

1. **Story 1-1 후속** — `CardCommandService.archive(cardId, MANUAL)` / `returnToField` + Controller 엔드포인트 + `CardStatusHistoryAppender` 호출.
2. **Story 2-1** — Review BC ↔ Card 경계의 `recordView` 호출 정리 + `OnFieldBudget` 주입해 `isLastView()` 시 자동 archive.
3. **Story 2-2** — `CardExpiryBatchService` 야간 배치 + `OnFieldBudget` UserScheduleConfig 파생.
4. **Story 5-2** — `GET /api/v1/cards/archive?tags=...`.
5. **UserSchedule BC** — `user_schedule_config` Flyway 마이그레이션 (UserSchedule 소유 작업).