### PR TITLE
feat(card): Story 1-1 후속 — archive / return-to-field 엔드포인트

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/application/service/CardCommandService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardCommandService.java
@@ -1,7 +1,10 @@
 package com.example.thirdtool.Card.application.service;
 
 import com.example.thirdtool.Card.domain.exception.CardDomainException;
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
 import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
 import com.example.thirdtool.Card.domain.model.MainNote;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.domain.model.Tag;
@@ -28,6 +31,7 @@ public class CardCommandService {
     private final CardRepository cardRepository;
     private final TagRepository tagRepository;
     private final DeckRepository deckRepository;
+    private final CardStatusHistoryAppender cardStatusHistoryAppender;
 
     // ─── 카드 생성 ─────────────────────────────────────
 
@@ -118,6 +122,44 @@ public class CardCommandService {
         List<Tag>  newTags = resolveTags(request.tags());
         card.replaceTags(newTags);
         return CardResponse.Tags.of(card);
+    }
+
+    // ─── 카드 ARCHIVE 전환 ────────────────────────────────
+    // product-card.md Epic 1 Story 1-1 — 사용자가 카드를 "보관"하는 운영 위치 전환.
+    // 멱등: 이미 ARCHIVE면 도메인 no-op + 이력 미생성 + Deck 재계산 미호출.
+
+    public CardResponse.Detail archive(Long cardId, ArchiveReason reason) {
+        if (reason == null) {
+            throw CardDomainException.of(
+                    ErrorCode.INVALID_INPUT, "archive: reason은 null일 수 없습니다.");
+        }
+        Card       card       = findActiveCard(cardId);
+        CardStatus fromStatus = card.getStatus();
+
+        card.archive();
+
+        if (fromStatus != card.getStatus()) {
+            cardStatusHistoryAppender.append(card, fromStatus, card.getStatus(), reason);
+            card.getDeck().recalculateProgressStatus();
+        }
+        return CardResponse.Detail.of(card);
+    }
+
+    // ─── 카드 ON_FIELD 복귀 ───────────────────────────────
+    // product-card.md Epic 7 — 새 사이클 시작. enteredFieldAt/viewCount/lastViewedAt은 도메인에서 재초기화.
+    // 멱등: 이미 ON_FIELD면 도메인 no-op + 이력 미생성 + Deck 재계산 미호출.
+
+    public CardResponse.Detail returnToField(Long cardId) {
+        Card       card       = findActiveCard(cardId);
+        CardStatus fromStatus = card.getStatus();
+
+        card.returnToField();
+
+        if (fromStatus != card.getStatus()) {
+            cardStatusHistoryAppender.append(card, fromStatus, card.getStatus(), null);
+            card.getDeck().recalculateProgressStatus();
+        }
+        return CardResponse.Detail.of(card);
     }
 
     // ─── 13. 카드 삭제 (Soft Delete) ──────────────────────

--- a/src/main/java/com/example/thirdtool/Card/presentation/CardController.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/CardController.java
@@ -140,4 +140,23 @@ public class CardController {
         cardCommandService.softDelete(cardId);
         return ResponseEntity.noContent().build();
     }
+
+    // ─── 14. 카드 ARCHIVE 전환 ────────────────────────────
+    // product-card.md Epic 1 Story 1-1 — 사용자 명시 보관. 멱등.
+    @PostMapping("/api/v1/cards/{cardId}/archive")
+    public ResponseEntity<CardResponse.Detail> archive(
+            @PathVariable Long cardId,
+            @Valid @RequestBody CardRequest.Archive request
+                                                      ) {
+        return ResponseEntity.ok(cardCommandService.archive(cardId, request.reason()));
+    }
+
+    // ─── 15. 카드 ON_FIELD 복귀 ───────────────────────────
+    // product-card.md Epic 7 — 새 사이클 시작. 멱등.
+    @PostMapping("/api/v1/cards/{cardId}/return-to-field")
+    public ResponseEntity<CardResponse.Detail> returnToField(
+            @PathVariable Long cardId
+                                                            ) {
+        return ResponseEntity.ok(cardCommandService.returnToField(cardId));
+    }
 }

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/CardRequest.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/CardRequest.java
@@ -1,7 +1,9 @@
 package com.example.thirdtool.Card.presentation.dto;
 
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -56,6 +58,14 @@ public class CardRequest {
     public record ReplaceTags(
             @NotEmpty
             List<String> tags
+    ) {}
+
+    // ─── 카드 ARCHIVE 전환 요청 ───────────────────────────
+    // 사용자 명시 액션의 reason은 MANUAL로 고정 (Service에서 강제) — 본 DTO는 향후
+    // 관리자/시스템 호출(MAX_VIEW·MAX_DURATION)을 위한 확장 여지를 위해 enum을 받는다.
+    public record Archive(
+            @NotNull
+            ArchiveReason reason
     ) {}
 
     // ─── 중첩 DTO ─────────────────────────────────────────

--- a/src/test/java/com/example/thirdtool/Card/application/service/CardCommandServiceArchiveTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/CardCommandServiceArchiveTest.java
@@ -1,0 +1,202 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.domain.exception.CardDomainException;
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Card.infrastructure.persistence.TagRepository;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.model.DeckProgressStatus;
+import com.example.thirdtool.Deck.infrastructure.repository.DeckRepository;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * CardCommandService archive / returnToField 조율 검증 (Story-1-1 후속).
+ *
+ * - 도메인 멱등성(이미 같은 상태)에서 Appender·Deck 재계산이 호출되지 않는지
+ * - 실제 전이가 발생한 경우 Appender(올바른 from/to/reason) + Deck 재계산이 호출되는지
+ */
+@DisplayName("CardCommandService — archive / returnToField (Story-1-1 후속)")
+class CardCommandServiceArchiveTest {
+
+    private CardRepository cardRepository;
+    private TagRepository tagRepository;
+    private DeckRepository deckRepository;
+    private CardStatusHistoryAppender appender;
+    private CardCommandService service;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        cardRepository = mock(CardRepository.class);
+        tagRepository = mock(TagRepository.class);
+        deckRepository = mock(DeckRepository.class);
+        appender = mock(CardStatusHistoryAppender.class);
+        service = new CardCommandService(cardRepository, tagRepository, deckRepository, appender);
+
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        deck = Deck.createFromLearningMaterial(user, 10L, 200L, "DDD");
+        ReflectionTestUtils.setField(deck, "id", 500L);
+    }
+
+    private Card persistedCard() {
+        Card card = Card.create(
+                deck,
+                MainNote.of("본문", null),
+                Summary.of("한 문장."),
+                List.of("키워드")
+        );
+        ReflectionTestUtils.setField(card, "id", 1000L);
+        when(cardRepository.findById(1000L)).thenReturn(Optional.of(card));
+        return card;
+    }
+
+    // ─── archive() ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("archive()")
+    class Archive {
+
+        @Test
+        @DisplayName("ON_FIELD → ARCHIVE 정상 전이 시 Appender 1회 + Deck 재계산 호출")
+        void archive_onField_appendsHistory_recalculatesDeck() {
+            Card card = persistedCard();
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+            ReflectionTestUtils.setField(deck, "progressStatus", DeckProgressStatus.IN_PROGRESS);
+
+            service.archive(1000L, ArchiveReason.MANUAL);
+
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+            verify(appender, times(1))
+                    .append(eq(card), eq(CardStatus.ON_FIELD), eq(CardStatus.ARCHIVE), eq(ArchiveReason.MANUAL));
+            // deck.cards는 단위 테스트에서 빈 컬렉션 (JPA cascade 미적용) → recalculate 호출되면 NOT_STARTED로 회귀
+            assertThat(deck.getProgressStatus()).isEqualTo(DeckProgressStatus.NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("이미 ARCHIVE면 도메인 no-op + Appender 미호출 + Deck 재계산 미호출 (멱등)")
+        void archive_alreadyArchive_noOp() {
+            Card card = persistedCard();
+            card.archive();
+            ReflectionTestUtils.setField(deck, "progressStatus", DeckProgressStatus.IN_PROGRESS);
+
+            service.archive(1000L, ArchiveReason.MANUAL);
+
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+            verify(appender, never()).append(any(), any(), any(), any());
+            // recalculate 미호출 → IN_PROGRESS 보존
+            assertThat(deck.getProgressStatus()).isEqualTo(DeckProgressStatus.IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("reason이 null이면 INVALID_INPUT 예외")
+        void archive_nullReason_throws() {
+            persistedCard();
+
+            assertThatThrownBy(() -> service.archive(1000L, null))
+                    .isInstanceOf(CardDomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+            verify(appender, never()).append(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 cardId면 CARD_NOT_FOUND 예외")
+        void archive_notFound_throws() {
+            when(cardRepository.findById(9999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.archive(9999L, ArchiveReason.MANUAL))
+                    .isInstanceOf(CardDomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+            verify(appender, never()).append(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("soft delete된 카드는 CARD_NOT_FOUND 예외")
+        void archive_softDeleted_throws() {
+            Card card = persistedCard();
+            card.softDelete();
+
+            assertThatThrownBy(() -> service.archive(1000L, ArchiveReason.MANUAL))
+                    .isInstanceOf(CardDomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+            verify(appender, never()).append(any(), any(), any(), any());
+        }
+    }
+
+    // ─── returnToField() ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("returnToField()")
+    class ReturnToField {
+
+        @Test
+        @DisplayName("ARCHIVE → ON_FIELD 복귀 시 reason 없이 Appender 1회 + Deck 재계산 호출 + 도메인 재초기화")
+        void returnToField_archive_appendsHistory_resetsFields() {
+            Card card = persistedCard();
+            card.recordView();
+            card.archive();
+
+            service.returnToField(1000L);
+
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+            assertThat(card.getViewCount()).isZero();
+            assertThat(card.getLastViewedAt()).isNull();
+            verify(appender, times(1))
+                    .append(eq(card), eq(CardStatus.ARCHIVE), eq(CardStatus.ON_FIELD), eq((ArchiveReason) null));
+        }
+
+        @Test
+        @DisplayName("이미 ON_FIELD면 도메인 no-op + Appender 미호출 + Deck 재계산 미호출 (멱등)")
+        void returnToField_alreadyOnField_noOp() {
+            Card card = persistedCard();
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+            ReflectionTestUtils.setField(deck, "progressStatus", DeckProgressStatus.COMPLETED);
+
+            service.returnToField(1000L);
+
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+            verify(appender, never()).append(any(), any(), any(), any());
+            assertThat(deck.getProgressStatus()).isEqualTo(DeckProgressStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 cardId면 CARD_NOT_FOUND 예외")
+        void returnToField_notFound_throws() {
+            when(cardRepository.findById(9999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.returnToField(9999L))
+                    .isInstanceOf(CardDomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/application/service/CardCommandServiceDeckProgressTriggerTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/CardCommandServiceDeckProgressTriggerTest.java
@@ -1,6 +1,7 @@
 package com.example.thirdtool.Card.application.service;
 
 import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Card.infrastructure.persistence.TagRepository;
 import com.example.thirdtool.Card.presentation.dto.CardRequest;
@@ -32,6 +33,7 @@ class CardCommandServiceDeckProgressTriggerTest {
     private CardRepository cardRepository;
     private TagRepository tagRepository;
     private DeckRepository deckRepository;
+    private CardStatusHistoryAppender cardStatusHistoryAppender;
     private CardCommandService service;
 
     private UserEntity user;
@@ -42,7 +44,8 @@ class CardCommandServiceDeckProgressTriggerTest {
         cardRepository = mock(CardRepository.class);
         tagRepository = mock(TagRepository.class);
         deckRepository = mock(DeckRepository.class);
-        service = new CardCommandService(cardRepository, tagRepository, deckRepository);
+        cardStatusHistoryAppender = mock(CardStatusHistoryAppender.class);
+        service = new CardCommandService(cardRepository, tagRepository, deckRepository, cardStatusHistoryAppender);
 
         user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositorySliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositorySliceTest.java
@@ -16,11 +16,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * CardRepository slice 테스트 (@DataJpaTest + H2).
@@ -103,8 +104,7 @@ class CardRepositorySliceTest {
     void archive_persistsStatus_preservesEnteredFieldAt() {
         // given
         Card card = persistCard();
-        // DATETIME(6)는 microsecond 정밀도 — Java LocalDateTime(nanosecond)와 비교 시 마이크로초 단위 절단.
-        LocalDateTime originalEnteredFieldAt = card.getEnteredFieldAt().truncatedTo(ChronoUnit.MICROS);
+        LocalDateTime originalEnteredFieldAt = card.getEnteredFieldAt();
 
         // when
         card.archive();
@@ -113,10 +113,10 @@ class CardRepositorySliceTest {
 
         Card found = cardJpaRepository.findById(card.getId()).orElseThrow();
 
-        // then
+        // then — DATETIME(6) microsecond 정밀도 + DB 측 반올림 가능성으로 1μs 허용 오차.
         assertThat(found.getStatus()).isEqualTo(CardStatus.ARCHIVE);
-        assertThat(found.getEnteredFieldAt().truncatedTo(ChronoUnit.MICROS))
-                .isEqualTo(originalEnteredFieldAt);
+        assertThat(found.getEnteredFieldAt())
+                .isCloseTo(originalEnteredFieldAt, within(Duration.ofNanos(1_000)));
     }
 
     @Test


### PR DESCRIPTION
## 개요

`workflow/product/pes/ready/product-card.md` Epic 1 Story 1-1 후속. Card 운영 위치 전환을 사용자가 명시 호출하는 두 엔드포인트(POST `/cards/{id}/archive`, `/return-to-field`)를 추가하고, `CardCommandService`가 도메인 멱등성을 활용해 이력 append·Deck 재계산을 조율한다.

## 왜 / 설계 결정

- 직전 PR(#143)에서 DB 정합·응답 노출은 끝났지만, 사용자가 ARCHIVE/ON_FIELD 전환을 호출할 수 있는 진입점이 없었다 — Story 1-1 인수 시나리오의 핵심 액션 누락.
- **fromStatus 캡처 + 멱등 활용** — `Card.archive()`/`returnToField()`가 같은 상태에서 no-op이므로, Service는 호출 전 status를 캡처해 실제 전이가 발생한 경우에만 `CardStatusHistoryAppender.append()`와 `deck.recalculateProgressStatus()`를 호출한다. 기각: 매번 append 시도(Appender가 내부에서 한 번 더 멱등 체크하지만 Deck 재계산 비용이 무의미하게 발생).
- **reason 처리** — `archive(cardId, ArchiveReason)`는 reason을 Service 인자로 받아 향후 MAX_VIEW(Story 2-1)·MAX_DURATION(Story 2-2) 호출 경로와 동일한 시그니처를 공유한다. Controller는 현 단계에서 사용자 명시 호출만 받지만 DTO에 ArchiveReason enum을 직접 노출해 추후 확장 여지 확보.

## 작업 내용

- feat(card): `CardCommandService` — `archive(Long, ArchiveReason)`, `returnToField(Long)` 메서드 + `CardStatusHistoryAppender` 의존 추가. reason null 거부, soft-deleted 카드 CARD_NOT_FOUND.
- feat(card): `CardRequest.Archive` record — `@NotNull ArchiveReason reason`.
- feat(card): `CardController` — POST `/api/v1/cards/{cardId}/archive` (body `Archive`), `/api/v1/cards/{cardId}/return-to-field` (body 없음). 양쪽 200 + `CardResponse.Detail`.
- test(card): `CardCommandServiceArchiveTest` (`@Nested Archive` 5건 + `@Nested ReturnToField` 3건 = 9 케이스) — 정상 전이·멱등·예외(NULL/NOT_FOUND/soft-deleted)·Deck 재계산 트리거 검증.
- test(card): `CardCommandServiceDeckProgressTriggerTest` — 신규 의존 추가에 따른 생성자 인자 정합.
- fix(test): `CardRepositorySliceTest.archive_persistsStatus_preservesEnteredFieldAt` — DB DATETIME(6) 반올림 1μs 오차로 `isEqualTo(truncated)` 비교가 흔들려 `isCloseTo(within Duration.ofNanos(1_000))` 허용 오차로 교체.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test` → BUILD SUCCESSFUL (58s, 전체 통과)
- `./gradlew test --tests "com.example.thirdtool.Card.application.service.*"` → BUILD SUCCESSFUL (11/11)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (기존 `CardResponse.Detail` 직접 반환 형식 유지, 래퍼 도입은 본 PR 범위 밖)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인 행위·BC 의존 변경 없음, Service 조율 한정)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Card BC 내부 + 기존 Deck 호출 경로(`deck.recalculateProgressStatus()`)만
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 1 (Card 상태 도메인 재정의) / Story 1-1 (후속) — Card ON_FIELD/Archive 상태 정의 및 DB 반영

## Commits in this PR

- `2c07881` feat(card): CardCommandService.archive / returnToField + 이력·Deck 재계산 조율
- `15d9456` feat(card): POST /cards/{id}/archive·/return-to-field 엔드포인트
- `1972e24` test(card): CardCommandServiceArchiveTest 매트릭스 + 슬라이스 시각 비교 허용 오차