### PR TITLE
feat(user-schedule): Story 4-2 — user_schedule_config Flyway 정합 + 슬라이스

### DIFF
--- a/src/main/resources/db/migration/V12__user_schedule_config.sql
+++ b/src/main/resources/db/migration/V12__user_schedule_config.sql
@@ -1,0 +1,77 @@
+-- =============================================================
+-- V12. user_schedule_config + user_schedule_config_history 신설
+--
+-- product-card.md Epic 4 Story 4-2 — 사용자별 설정값 독립 저장 및 조회.
+-- 도메인 클래스:
+--   - UserSchedule/domain/model/UserScheduleConfig.java
+--   - UserSchedule/domain/model/UserScheduleConfigHistory.java
+--
+-- 의미
+--   - user_schedule_config: 유저 1명당 1행. raw_input_days(사용자 입력 일수) + mapped_mode(매핑 결과 enum).
+--   - user_schedule_config_history: 모드 변경 이력 append-only. 최초 생성 시 from_mode=NULL.
+--
+-- 도메인 규약
+--   - 유저당 1개 강제 (UNIQUE(user_id))
+--   - mapped_mode CHECK: MODE_10D | MODE_20D | MODE_30D (LearningMode enum)
+--   - raw_input_days >= 1 (도메인 검증)
+--   - history.from_mode NULL 허용 (createDefault/처음 생성 시) — to_mode는 NOT NULL
+-- =============================================================
+
+CREATE TABLE user_schedule_config
+(
+    user_schedule_config_id BIGINT      NOT NULL AUTO_INCREMENT,
+    user_id                 BIGINT      NOT NULL,
+    raw_input_days          INT         NOT NULL,
+    mapped_mode             VARCHAR(20) NOT NULL,
+    created_at              DATETIME(6) NOT NULL,
+    updated_at              DATETIME(6) NOT NULL,
+
+    PRIMARY KEY (user_schedule_config_id),
+
+    CONSTRAINT uk_user_schedule_config_user_id UNIQUE (user_id),
+
+    CONSTRAINT fk_user_schedule_config_user
+        FOREIGN KEY (user_id) REFERENCES user_entity (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_user_schedule_config_mapped_mode
+        CHECK (mapped_mode IN ('MODE_10D', 'MODE_20D', 'MODE_30D')),
+
+    CONSTRAINT chk_user_schedule_config_raw_input_days
+        CHECK (raw_input_days >= 1)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+
+CREATE TABLE user_schedule_config_history
+(
+    user_schedule_config_history_id BIGINT      NOT NULL AUTO_INCREMENT,
+    user_schedule_config_id         BIGINT      NOT NULL,
+    from_mode                       VARCHAR(20)          DEFAULT NULL,
+    to_mode                         VARCHAR(20) NOT NULL,
+    raw_input_days                  INT         NOT NULL,
+    changed_at                      DATETIME(6) NOT NULL,
+
+    PRIMARY KEY (user_schedule_config_history_id),
+
+    CONSTRAINT fk_user_schedule_config_history_config
+        FOREIGN KEY (user_schedule_config_id) REFERENCES user_schedule_config (user_schedule_config_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_user_schedule_config_history_from_mode
+        CHECK (from_mode IS NULL OR from_mode IN ('MODE_10D', 'MODE_20D', 'MODE_30D')),
+
+    CONSTRAINT chk_user_schedule_config_history_to_mode
+        CHECK (to_mode IN ('MODE_10D', 'MODE_20D', 'MODE_30D')),
+
+    CONSTRAINT chk_user_schedule_config_history_raw_input_days
+        CHECK (raw_input_days >= 1)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_user_schedule_config_history_config_id
+    ON user_schedule_config_history (user_schedule_config_id);
+CREATE INDEX idx_user_schedule_config_history_changed_at
+    ON user_schedule_config_history (changed_at);

--- a/src/test/java/com/example/thirdtool/UserSchedule/infrastructure/persistence/UserScheduleConfigRepositorySliceTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/infrastructure/persistence/UserScheduleConfigRepositorySliceTest.java
@@ -1,0 +1,132 @@
+package com.example.thirdtool.UserSchedule.infrastructure.persistence;
+
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import com.example.thirdtool.UserSchedule.domain.model.LearningModeMappingPolicy;
+import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfig;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * UserScheduleConfigRepository slice 테스트 (@DataJpaTest + H2).
+ *
+ * <p>Story-4-2 V12 마이그레이션 정합 검증:
+ * <ul>
+ *   <li>findByUserId / existsByUserId 정상·미존재</li>
+ *   <li>LearningMode enum 영속 round-trip (MODE_10D/20D/30D)</li>
+ *   <li>updateMode 후 mapped_mode·raw_input_days 갱신 영속</li>
+ * </ul>
+ *
+ * <p>user_id UNIQUE 위반은 DB 제약 동작이 H2/MySQL에서 다를 수 있어 통합 테스트 범위로 위임.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("UserScheduleConfigRepository slice — Story-4-2")
+class UserScheduleConfigRepositorySliceTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    UserScheduleConfigRepository repository;
+
+    private LearningModeMappingPolicy policy;
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        policy = new LearningModeMappingPolicy();
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
+        em.persist(user);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("findByUserId — 저장된 config는 userId로 단건 조회된다")
+    void findByUserId_returnsExisting() {
+        // given
+        UserScheduleConfig config = UserScheduleConfig.create(user.getId(), 13, policy);
+        repository.save(config);
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<UserScheduleConfig> found = repository.findByUserId(user.getId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getRawInputDays()).isEqualTo(13);
+        assertThat(found.get().getMappedMode()).isEqualTo(LearningMode.MODE_10D);
+    }
+
+    @Test
+    @DisplayName("findByUserId — 미존재 userId는 Optional.empty")
+    void findByUserId_empty() {
+        assertThat(repository.findByUserId(999_999L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("existsByUserId — 저장 여부 boolean으로 반환")
+    void existsByUserId_returnsBoolean() {
+        assertThat(repository.existsByUserId(user.getId())).isFalse();
+
+        repository.save(UserScheduleConfig.createDefault(user.getId(), policy));
+        em.flush();
+
+        assertThat(repository.existsByUserId(user.getId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("LearningMode enum — MODE_20D / MODE_30D round-trip")
+    void enumRoundTrip_20D_and_30D() {
+        // MODE_20D (15~24)
+        UserEntity user2 = UserEntity.ofLocal("u2", "pw", "n2", "u2@e.com");
+        em.persist(user2);
+        repository.save(UserScheduleConfig.create(user2.getId(), 20, policy));
+
+        // MODE_30D (25+)
+        UserEntity user3 = UserEntity.ofLocal("u3", "pw", "n3", "u3@e.com");
+        em.persist(user3);
+        repository.save(UserScheduleConfig.create(user3.getId(), 30, policy));
+        em.flush();
+        em.clear();
+
+        assertThat(repository.findByUserId(user2.getId()).orElseThrow().getMappedMode())
+                .isEqualTo(LearningMode.MODE_20D);
+        assertThat(repository.findByUserId(user3.getId()).orElseThrow().getMappedMode())
+                .isEqualTo(LearningMode.MODE_30D);
+    }
+
+    @Test
+    @DisplayName("updateMode — raw_input_days와 mapped_mode가 함께 갱신·영속된다")
+    void updateMode_persistsBothFields() {
+        // given — 10D 모드로 시작
+        UserScheduleConfig config = UserScheduleConfig.create(user.getId(), 10, policy);
+        repository.save(config);
+        em.flush();
+        em.clear();
+
+        // when — 25로 수정 → MODE_30D
+        UserScheduleConfig loaded = repository.findByUserId(user.getId()).orElseThrow();
+        loaded.updateMode(25, policy);
+        em.flush();
+        em.clear();
+
+        // then
+        UserScheduleConfig reloaded = repository.findByUserId(user.getId()).orElseThrow();
+        assertThat(reloaded.getRawInputDays()).isEqualTo(25);
+        assertThat(reloaded.getMappedMode()).isEqualTo(LearningMode.MODE_30D);
+    }
+}


### PR DESCRIPTION
## 개요

UserSchedule BC의 도메인 엔티티(`UserScheduleConfig` / `UserScheduleConfigHistory`)는 이미 구현되어 있으나 **Flyway 마이그레이션이 누락**되어 prod에서 schema validate 실패 위험. Story 4-2의 BE 정합 부분(V12 마이그레이션 + Repository 슬라이스)을 보강한다.

## 왜 / 설계 결정

- 직전 audit에서 UserSchedule BC가 도메인·Repository·Service·Controller 모두 구현되어 있으나 Flyway만 빠진 상태였다. 이대로 prod 배포 시 `user_schedule_config` / `user_schedule_config_history` 테이블 미생성으로 모든 UserSchedule API 즉시 실패.
- 다음 단계인 **Review BC가 사용자별 OnFieldBudget을 주입하도록 전환**(Story 2-1/2-3 마무리, 별도 PR 예정)이 이 BC에 의존하므로 마이그레이션 정합화가 선행 조건.
- 도메인 검증과 DB CHECK를 **이중 방어**(`conventions.md` §1.6)로 둔다 — `mapped_mode` enum 값, `raw_input_days >= 1`, `from_mode` NULL 허용(최초 생성) 등.

## 작업 내용

- feat(user-schedule): Flyway V12 — `user_schedule_config` 테이블 신설.
  - `user_id` UNIQUE (유저당 1개 강제) + FK `user_entity(id)` ON DELETE CASCADE.
  - `mapped_mode` CHECK(`MODE_10D` | `MODE_20D` | `MODE_30D`).
  - `raw_input_days` CHECK >= 1.
- feat(user-schedule): Flyway V12 — `user_schedule_config_history` 테이블 신설.
  - append-only. `from_mode` NULL 허용(최초 생성/`createDefault`), `to_mode` NOT NULL.
  - `user_schedule_config_id` FK CASCADE.
  - idx (config_id, changed_at).
- test(user-schedule): `UserScheduleConfigRepositorySliceTest` (`@DataJpaTest`, 5건) — `findByUserId` 존재/미존재, `existsByUserId` true/false, `LearningMode` enum round-trip(10D/20D/30D), `updateMode` 후 raw_input_days·mapped_mode 동시 갱신 영속.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test` → BUILD SUCCESSFUL (1m 37s, 전체 통과)
- `./gradlew test --tests "com.example.thirdtool.UserSchedule.infrastructure.persistence.UserScheduleConfigRepositorySliceTest"` → BUILD SUCCESSFUL (5/5)
- 통합 / 성능: N/A. `user_id` UNIQUE 위반 동작은 H2/MySQL 차이 가능성으로 통합 테스트 범위로 위임.

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (DB·테스트만 변경, 응답 형식 무변경)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인·BC 의존 변경 없음, 마이그레이션 정합화만)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — UserSchedule BC 내부 + User FK만 (기존 의존 그대로)
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 4 (사용자별 학습 에너지 개인 설정) / Story 4-2 (사용자별 설정값 독립 저장 및 조회)

## Commits in this PR

- `ef53947` feat(user-schedule): V12 마이그레이션 — user_schedule_config + history 신설
- `0b8730f` test(user-schedule): UserScheduleConfigRepository 슬라이스 매트릭스

## 다음 PR 예고

- **Story 2-1/2-3 마무리** — `ReviewCommandService`가 `SystemBudgetConfig` 전역 단일 budget 대신 `UserScheduleConfigRepository.findByUserId(userId).resolveOnFieldBudget()`로 사용자별 budget 주입. 미존재 유저는 `createDefault` 자동 생성. Review BC → UserSchedule BC 의존 그래프 추가 (`docs/PACKAGE.md` 갱신 동반).