### PR TITLE
test(review): Story 2-1·2-3 — ReviewCommandService·QueryService 매트릭스 신규

### DIFF
--- a/src/test/java/com/example/thirdtool/Review/application/ReviewCommandServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewCommandServiceTest.java
@@ -1,0 +1,270 @@
+package com.example.thirdtool.Review.application;
+
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.OnFieldBudget;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.application.service.DeckQueryService;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.model.DeckProgressStatus;
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.Review.domain.model.ReviewSession;
+import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
+import com.example.thirdtool.Review.presentation.dto.ReviewRequest;
+import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ReviewCommandService 매트릭스 (Story-2-1·2-3 사용자별 budget 주입 + maxView 자동 archive).
+ *
+ * <p>전략 (`.claude/rules/conventions.md` §4.7): Repository·Cross-BC Service Mock + 도메인 객체(Card, Deck,
+ * ReviewSession, UserEntity)는 실제 인스턴스로 생성해 상태 변화를 그대로 관찰한다.
+ */
+@DisplayName("ReviewCommandService — Story 2-1·2-3 (사용자별 budget + maxView archive)")
+class ReviewCommandServiceTest {
+
+    private ReviewSessionRepository sessionRepository;
+    private ReviewQueryService queryService;
+    private DeckQueryService deckQueryService;
+    private CardRepository cardRepository;
+    private CardStatusHistoryAppender historyAppender;
+    private UserScheduleQueryService userScheduleQueryService;
+    private ReviewCommandService service;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        sessionRepository        = mock(ReviewSessionRepository.class);
+        queryService             = mock(ReviewQueryService.class);
+        deckQueryService         = mock(DeckQueryService.class);
+        cardRepository           = mock(CardRepository.class);
+        historyAppender          = mock(CardStatusHistoryAppender.class);
+        userScheduleQueryService = mock(UserScheduleQueryService.class);
+
+        service = new ReviewCommandService(
+                sessionRepository, queryService, deckQueryService,
+                cardRepository, historyAppender, userScheduleQueryService
+        );
+
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        deck = Deck.createFromLearningMaterial(user, 10L, 200L, "DDD");
+        ReflectionTestUtils.setField(deck, "id", 500L);
+    }
+
+    private Card persistedCard() {
+        Card card = Card.create(
+                deck,
+                MainNote.of("본문", null),
+                Summary.of("한 문장."),
+                List.of("키워드")
+        );
+        ReflectionTestUtils.setField(card, "id", 1000L);
+        return card;
+    }
+
+    // ─── startReview ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("startReview()")
+    class StartReview {
+
+        @Test
+        @DisplayName("정상 시작 — 첫 카드 viewCount+1, budget 사용자별로 조회, isLastView=false")
+        void startReview_happy_incrementsView_noArchive() {
+            Card card = persistedCard();
+            when(deckQueryService.getActiveDeck(500L)).thenReturn(deck);
+            when(cardRepository.findAllByDeckIdAndDeletedFalse(500L)).thenReturn(List.of(card));
+            // budget maxView=3 — 첫 진입(viewCount=1)은 isLastView=false
+            when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                    .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+
+            ReviewResponse.StartSession response =
+                    service.startReview(new ReviewRequest.StartSession(500L), user);
+
+            assertThat(card.getViewCount()).isEqualTo(1);
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+            assertThat(response.currentCard().isLastView()).isFalse();
+            verify(historyAppender, never()).append(any(), any(), any(), any());
+            verify(cardRepository, times(1)).save(card);
+        }
+
+        @Test
+        @DisplayName("maxView=1 budget — 첫 노출이 곧 마지막 노출 → MAX_VIEW archive + history append + Deck recalc")
+        void startReview_maxViewReached_archivesWithHistory() {
+            Card card = persistedCard();
+            ReflectionTestUtils.setField(deck, "progressStatus", DeckProgressStatus.IN_PROGRESS);
+
+            when(deckQueryService.getActiveDeck(500L)).thenReturn(deck);
+            when(cardRepository.findAllByDeckIdAndDeletedFalse(500L)).thenReturn(List.of(card));
+            when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                    .thenReturn(OnFieldBudget.of(1, Duration.ofDays(10)));
+
+            ReviewResponse.StartSession response =
+                    service.startReview(new ReviewRequest.StartSession(500L), user);
+
+            assertThat(card.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+            assertThat(response.currentCard().isLastView()).isTrue();
+            verify(historyAppender, times(1))
+                    .append(eq(card), eq(CardStatus.ON_FIELD), eq(CardStatus.ARCHIVE), eq(ArchiveReason.MAX_VIEW));
+            // deck.cards 컬렉션이 빈 상태 → recalculate 호출되면 NOT_STARTED로 회귀 (호출 검증 대체)
+            assertThat(deck.getProgressStatus()).isEqualTo(DeckProgressStatus.NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("다른 유저의 deck 접근 시 REVIEW_SESSION_FORBIDDEN — budget 조회 미발생")
+        void startReview_otherUserDeck_throws() {
+            UserEntity otherOwner = UserEntity.ofLocal("other", "pw", "n", "o@e.com");
+            ReflectionTestUtils.setField(otherOwner, "id", 99L);
+            Deck otherDeck = Deck.createFromLearningMaterial(otherOwner, 10L, 200L, "DDD");
+            ReflectionTestUtils.setField(otherDeck, "id", 500L);
+            when(deckQueryService.getActiveDeck(500L)).thenReturn(otherDeck);
+
+            assertThatThrownBy(() ->
+                    service.startReview(new ReviewRequest.StartSession(500L), user))
+                    .isInstanceOf(ReviewSessionException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REVIEW_SESSION_FORBIDDEN);
+
+            verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+            verify(cardRepository, never()).save(any());
+        }
+    }
+
+    // ─── moveToNext ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("moveToNext()")
+    class MoveToNext {
+
+        @Test
+        @DisplayName("다음 카드 진입 시 viewCount+1 — budget 사용자별 주입, archive 미발생")
+        void moveToNext_happy_incrementsView() {
+            // first card는 startReview에서 진입 처리됨. 본 테스트는 moveToNext 단독 검증.
+            Card card1 = persistedCard();
+            Card card2 = Card.create(deck, MainNote.of("본문2", null), Summary.of("두번째."), List.of("k2"));
+            ReflectionTestUtils.setField(card2, "id", 1001L);
+
+            ReviewSession session = buildComparingSession(List.of(card1, card2));
+            when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
+            when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                    .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+
+            ReviewResponse.NextCard response = service.moveToNext(700L, user);
+
+            assertThat(card2.getViewCount()).isEqualTo(1);
+            assertThat(response.currentCard().isLastView()).isFalse();
+            verify(historyAppender, never()).append(any(), any(), any(), any());
+            verify(cardRepository, times(1)).save(card2);
+        }
+
+        @Test
+        @DisplayName("세션 종료 카드(마지막+1) — finished, budget 미조회·save 미호출")
+        void moveToNext_lastCard_finishedSession_noBudgetCall() {
+            Card only = persistedCard();
+            ReviewSession session = buildComparingSession(List.of(only));
+            // currentIndex=0이 COMPARING이라 moveToNext 호출 시 currentIndex=1 → finished=true
+            when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
+
+            ReviewResponse.NextCard response = service.moveToNext(700L, user);
+
+            assertThat(session.isFinished()).isTrue();
+            assertThat(response.isFinished()).isTrue();
+            assertThat(response.currentCard()).isNull();
+            verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+            verify(cardRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("다음 카드가 maxView에 도달 — MAX_VIEW archive + history append")
+        void moveToNext_maxViewReached_archives() {
+            Card card1 = persistedCard();
+            Card card2 = Card.create(deck, MainNote.of("본문2", null), Summary.of("두번째."), List.of("k2"));
+            ReflectionTestUtils.setField(card2, "id", 1001L);
+
+            ReviewSession session = buildComparingSession(List.of(card1, card2));
+            when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
+            // budget maxView=1 — moveToNext에서 viewCount=1로 즉시 isLastView=true
+            when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                    .thenReturn(OnFieldBudget.of(1, Duration.ofDays(10)));
+
+            ReviewResponse.NextCard response = service.moveToNext(700L, user);
+
+            assertThat(card2.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+            assertThat(response.currentCard().isLastView()).isTrue();
+            verify(historyAppender, times(1))
+                    .append(eq(card2), eq(CardStatus.ON_FIELD), eq(CardStatus.ARCHIVE), eq(ArchiveReason.MAX_VIEW));
+        }
+    }
+
+    // ─── startComparing ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("startComparing()")
+    class StartComparing {
+
+        @Test
+        @DisplayName("RECALLING → COMPARING 전환 + isLastView는 현재 카드 상태로 결정")
+        void startComparing_transitionsStep_returnsIsLastView() {
+            Card card = persistedCard();
+            // viewCount를 2로 만들어 두기 (startReview에서 진입했다 가정)
+            card.recordView();
+            card.recordView();
+            assertThat(card.getViewCount()).isEqualTo(2);
+
+            ReviewSession session = buildNewSession(List.of(card));
+            when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
+            // budget maxView=2 → 현재 viewCount=2이므로 isLastView=true
+            when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                    .thenReturn(OnFieldBudget.of(2, Duration.ofDays(10)));
+
+            ReviewResponse.CardReviewDto response = service.startComparing(700L, user);
+
+            assertThat(session.currentCardReview().isComparing()).isTrue();
+            assertThat(response.isLastView()).isTrue();
+            // startComparing은 archive를 호출하지 않는다 (자동 archive는 recordView 경로만)
+            verify(historyAppender, never()).append(any(), any(), any(), any());
+        }
+    }
+
+    // ─── helper ────────────────────────────────────────────────────────────────
+
+    private ReviewSession buildNewSession(List<Card> cards) {
+        ReviewSession session = ReviewSession.of(deck, cards, user, cards.size());
+        ReflectionTestUtils.setField(session, "id", 700L);
+        return session;
+    }
+
+    /** 첫 카드가 COMPARING 상태인 세션 (moveToNext 호출 가능 상태) */
+    private ReviewSession buildComparingSession(List<Card> cards) {
+        ReviewSession session = buildNewSession(cards);
+        session.startComparingCurrentCard();
+        return session;
+    }
+}

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
@@ -1,0 +1,132 @@
+package com.example.thirdtool.Review.application;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.OnFieldBudget;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Common.Exception.BusinessException;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Review.domain.model.ReviewSession;
+import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
+import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ReviewQueryService — Story 2-1·2-3 budget 주입 + 소유자 검증 매트릭스.
+ */
+@DisplayName("ReviewQueryService — Story 2-1·2-3 budget 주입 / 소유자 검증")
+class ReviewQueryServiceTest {
+
+    private ReviewSessionRepository sessionRepository;
+    private UserScheduleQueryService userScheduleQueryService;
+    private ReviewQueryService service;
+
+    private UserEntity owner;
+    private UserEntity other;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        sessionRepository        = mock(ReviewSessionRepository.class);
+        userScheduleQueryService = mock(UserScheduleQueryService.class);
+        service = new ReviewQueryService(sessionRepository, userScheduleQueryService);
+
+        owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
+        ReflectionTestUtils.setField(owner, "id", 1L);
+        other = UserEntity.ofLocal("other", "pw", "n", "x@e.com");
+        ReflectionTestUtils.setField(other, "id", 2L);
+        deck = Deck.createFromLearningMaterial(owner, 10L, 200L, "DDD");
+        ReflectionTestUtils.setField(deck, "id", 500L);
+    }
+
+    private Card sampleCard() {
+        Card card = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k1"));
+        ReflectionTestUtils.setField(card, "id", 1000L);
+        return card;
+    }
+
+    private ReviewSession persistedSession(Card... cards) {
+        ReviewSession s = ReviewSession.of(deck, List.of(cards), owner, cards.length);
+        ReflectionTestUtils.setField(s, "id", 700L);
+        when(sessionRepository.findById(700L)).thenReturn(Optional.of(s));
+        return s;
+    }
+
+    @Test
+    @DisplayName("findById — 소유자 정상 + isLastView가 사용자별 budget으로 결정된다")
+    void findById_owner_resolvesIsLastViewByUserBudget() {
+        Card card = sampleCard();
+        card.recordView();
+        assertThat(card.getViewCount()).isEqualTo(1);
+        persistedSession(card);
+        // budget maxView=1 → 현재 viewCount=1이므로 isLastView=true
+        when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                .thenReturn(OnFieldBudget.of(1, Duration.ofDays(10)));
+
+        ReviewResponse.SessionDetail response = service.findById(700L, owner);
+
+        assertThat(response.currentCard()).isNotNull();
+        assertThat(response.currentCard().isLastView()).isTrue();
+    }
+
+    @Test
+    @DisplayName("findById — 미존재 sessionId면 REVIEW_SESSION_NOT_FOUND")
+    void findById_notFound_throws() {
+        when(sessionRepository.findById(9999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findById(9999L, owner))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REVIEW_SESSION_NOT_FOUND);
+
+        verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+    }
+
+    @Test
+    @DisplayName("findById — 소유자 아님이면 REVIEW_SESSION_FORBIDDEN")
+    void findById_otherUser_throws() {
+        Card card = sampleCard();
+        persistedSession(card);
+
+        assertThatThrownBy(() -> service.findById(700L, other))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REVIEW_SESSION_FORBIDDEN);
+
+        verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+    }
+
+    @Test
+    @DisplayName("findById — 종료된 세션은 currentCard=null + isLastView 결정 미발생(budget 미조회)")
+    void findById_finishedSession_currentCardNull() {
+        Card card = sampleCard();
+        ReviewSession s = persistedSession(card);
+        ReflectionTestUtils.setField(s, "finished", true);
+
+        ReviewResponse.SessionDetail response = service.findById(700L, owner);
+
+        assertThat(response.isFinished()).isTrue();
+        assertThat(response.currentCard()).isNull();
+        // budget 조회 자체는 finished 검사 전에 발생할 수 있으나, isLastView가 false로 고정되어 의미 없음.
+        // 결과 정합만 검증한다.
+    }
+}


### PR DESCRIPTION
## 개요

Review BC는 프로젝트 시작 이래 **0 테스트 상태**였다. 직전 PR(#146)에서 사용자별 OnFieldBudget 주입으로 전환했고 본 PR이 첫 단위 테스트 매트릭스를 신규로 추가한다. 11 케이스(Command 7 + Query 4)로 budget 주입 경로·maxView 자동 archive 트리거·소유자 검증·세션 종료 분기까지 커버.

## 왜 / 설계 결정

- 사용자별 budget 주입이 PR #146로 들어갔지만 테스트 없이 머지된 상태 — 추후 회귀 시 누구도 잡지 못한다. 본 PR이 회귀 안전망.
- **Mockist 전략** (`.claude/rules/conventions.md` §4.7) — `ReviewSessionRepository`, `ReviewQueryService`, `DeckQueryService`, `CardRepository`, `CardStatusHistoryAppender`, `UserScheduleQueryService` 6 협력자 Mock. 도메인 객체(`Card`, `Deck`, `ReviewSession`, `UserEntity`)는 실제 생성해 상태 변화를 그대로 관찰. 기각: 통합 테스트(`@SpringBootTest`) — Review BC 특성상 Card·Deck·UserSchedule 다 묶여 비용이 크고 조건 격리가 어렵다.
- **검증 포인트** — (1) budget이 사용자별로 매 호출 조회되는지 verify, (2) maxView 도달 시 `archive()` + `history.append(MAX_VIEW)` + `deck.recalculateProgressStatus()` 트리거 모두 발생, (3) 예외 경로에서 budget·save 등 부수 효과 미발생.

## 작업 내용

- test(review): `ReviewCommandServiceTest` 7건
  - `startReview`: 정상 첫 진입(budget·viewCount+1·archive 미발생) / maxView=1 즉시 archive(MAX_VIEW + history + Deck recalc) / 타 유저 deck 시 REVIEW_SESSION_FORBIDDEN + budget·save 미발생
  - `moveToNext`: 다음 카드 viewCount+1 / 마지막 종료 시 finished + budget·save 미호출 / 다음 카드 maxView 도달 archive
  - `startComparing`: RECALLING → COMPARING 전환 + isLastView 사용자별 budget 결정
- test(review): `ReviewQueryServiceTest` 4건
  - `findById`: 소유자 정상 + isLastView 결정 / 미존재 NOT_FOUND / 비소유자 FORBIDDEN / 종료된 세션 currentCard=null

## 변경 유형

- [ ] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Review.application.ReviewCommandServiceTest"` → BUILD SUCCESSFUL (7/7)
- `./gradlew test --tests "com.example.thirdtool.Review.application.ReviewQueryServiceTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test` → BUILD SUCCESSFUL (1m 27s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (테스트 추가만)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — 테스트만 추가
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 2 Story 2-1·2-3 (사용자별 budget + maxView 자동 archive)

## Commits in this PR

- `(이번 commit)` test(review): ReviewCommandService·ReviewQueryService 매트릭스

## 후속 PR 예고

- **Story 2-2** — `CardExpiryBatchService` 야간 배치(`@Scheduled` 03:00) + 사용자별 maxDuration 만료 처리. `UserScheduleQueryService.resolveOnFieldBudget`을 그대로 재사용 + 배치 단위 트랜잭션 + history append(MAX_DURATION).