### PR TITLE
feat(card): Story 2-2 — CardExpiryBatchService 야간 만료 배치

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/application/service/CardExpiryBatchService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardExpiryBatchService.java
@@ -1,0 +1,114 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardExpiryPolicy;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
+import com.example.thirdtool.Card.domain.model.OnFieldBudget;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * product-card.md Epic 2 Story 2-2 — 야간 배치로 maxDuration / maxView 예산 초과 카드를 자동 ARCHIVE 한다.
+ *
+ * <p>실행 주기는 `card.expiry.cron`(기본 매일 03:00). 비활성화는 `-` 값으로 가능.
+ * (Spring `@Scheduled`는 cron="-"을 disabled 트리거로 해석).
+ *
+ * <p>처리 흐름
+ * <ol>
+ *   <li>ON_FIELD 상태(deleted=false) 후보 카드 일괄 조회.</li>
+ *   <li>사용자별로 묶어 각 사용자당 {@link UserScheduleQueryService#resolveOnFieldBudget} 1회만 조회.</li>
+ *   <li>각 카드에 대해 {@link CardExpiryPolicy#expire}로 만료 사유 판정 → ARCHIVE 전환.</li>
+ *   <li>만료된 카드는 history append + 소속 Deck 재계산을 모음 단위로 1회 실행.</li>
+ * </ol>
+ *
+ * <p>멱등성 — 같은 카드가 두 번 archive되어도 도메인 행위가 no-op이므로 안전.
+ * 재실행 / 동시 실행 모두 동일 결과.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CardExpiryBatchService {
+
+    private static final Logger log = LoggerFactory.getLogger(CardExpiryBatchService.class);
+
+    private final CardRepository cardRepository;
+    private final CardStatusHistoryAppender historyAppender;
+    private final CardExpiryPolicy cardExpiryPolicy;
+    private final UserScheduleQueryService userScheduleQueryService;
+
+    /**
+     * Spring Scheduler 진입점. 결과만 info 로그로 기록한다.
+     * 단위 테스트는 {@link #processExpired()} 를 직접 호출한다.
+     */
+    @Scheduled(cron = "${card.expiry.cron:0 0 3 * * *}")
+    public void runScheduledExpiry() {
+        log.info("[CardExpiryBatch] scheduled run started");
+        ExpiryResult result = processExpired();
+        log.info(
+                "[CardExpiryBatch] done — candidates={}, archived={}, reasons[MAX_VIEW={}, MAX_DURATION={}]",
+                result.candidates(), result.archived(),
+                result.maxViewCount(), result.maxDurationCount()
+        );
+    }
+
+    public ExpiryResult processExpired() {
+        List<Card> candidates = cardRepository.findAllByStatus(CardStatus.ON_FIELD);
+        if (candidates.isEmpty()) {
+            return ExpiryResult.empty();
+        }
+
+        Map<Long, List<Card>> byUser = candidates.stream()
+                .collect(Collectors.groupingBy(c -> c.getDeck().getUser().getId()));
+
+        int archived = 0;
+        int maxViewCount = 0;
+        int maxDurationCount = 0;
+        Set<Deck> changedDecks = new HashSet<>();
+
+        for (Map.Entry<Long, List<Card>> entry : byUser.entrySet()) {
+            Long userId = entry.getKey();
+            OnFieldBudget budget = userScheduleQueryService.resolveOnFieldBudget(userId);
+            for (Card card : entry.getValue()) {
+                CardStatus before = card.getStatus();
+                Optional<ArchiveReason> reason = cardExpiryPolicy.expire(card, budget);
+                if (reason.isEmpty()) continue;
+
+                historyAppender.append(card, before, card.getStatus(), reason.get());
+                changedDecks.add(card.getDeck());
+                archived++;
+                if (reason.get() == ArchiveReason.MAX_VIEW) {
+                    maxViewCount++;
+                } else if (reason.get() == ArchiveReason.MAX_DURATION) {
+                    maxDurationCount++;
+                }
+            }
+        }
+
+        // 한 Deck에 여러 카드가 archive되어도 recalculate는 1회만 호출되도록 모은다.
+        changedDecks.forEach(Deck::recalculateProgressStatus);
+
+        return new ExpiryResult(candidates.size(), archived, maxViewCount, maxDurationCount);
+    }
+
+    public record ExpiryResult(int candidates, int archived, int maxViewCount, int maxDurationCount) {
+        static ExpiryResult empty() {
+            return new ExpiryResult(0, 0, 0, 0);
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,9 @@ spring:
 
   flyway:
     enabled: false
+
+# Card 야간 만료 배치(Story 2-2)는 로컬에서 비활성화 — Spring `@Scheduled`는 cron="-"을 disabled로 해석.
+# 운영 환경(application.yml, gitignored)에서 cron 활성화한다.
+card:
+  expiry:
+    cron: "-"

--- a/src/test/java/com/example/thirdtool/Card/application/service/CardExpiryBatchServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/CardExpiryBatchServiceTest.java
@@ -1,0 +1,181 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardExpiryPolicy;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.OnFieldBudget;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.model.DeckProgressStatus;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * CardExpiryBatchService 매트릭스 — Story 2-2 야간 만료 처리.
+ *
+ * <p>Mockist (`conventions.md` §4.7) — Repository / Cross-BC Service Mock + 도메인 객체는 실제 생성.
+ * 시간 의존성은 `enteredFieldAt` reflection 주입으로 통제 (`DomainFixture` 패턴 동일).
+ */
+@DisplayName("CardExpiryBatchService — Story 2-2 야간 만료 처리")
+class CardExpiryBatchServiceTest {
+
+    private CardRepository cardRepository;
+    private CardStatusHistoryAppender historyAppender;
+    private CardExpiryPolicy cardExpiryPolicy;
+    private UserScheduleQueryService userScheduleQueryService;
+    private CardExpiryBatchService service;
+
+    private UserEntity userA;
+    private UserEntity userB;
+    private Deck deckA;
+    private Deck deckB;
+
+    @BeforeEach
+    void setUp() {
+        cardRepository           = mock(CardRepository.class);
+        historyAppender          = mock(CardStatusHistoryAppender.class);
+        userScheduleQueryService = mock(UserScheduleQueryService.class);
+        cardExpiryPolicy         = new CardExpiryPolicy(); // 도메인 서비스는 실제로
+
+        service = new CardExpiryBatchService(
+                cardRepository, historyAppender, cardExpiryPolicy, userScheduleQueryService
+        );
+
+        userA = UserEntity.ofLocal("a", "pw", "n", "a@e.com");
+        ReflectionTestUtils.setField(userA, "id", 1L);
+        userB = UserEntity.ofLocal("b", "pw", "n", "b@e.com");
+        ReflectionTestUtils.setField(userB, "id", 2L);
+
+        deckA = Deck.createFromLearningMaterial(userA, 10L, 200L, "A 덱");
+        ReflectionTestUtils.setField(deckA, "id", 500L);
+        ReflectionTestUtils.setField(deckA, "progressStatus", DeckProgressStatus.IN_PROGRESS);
+
+        deckB = Deck.createFromLearningMaterial(userB, 11L, 201L, "B 덱");
+        ReflectionTestUtils.setField(deckB, "id", 501L);
+        ReflectionTestUtils.setField(deckB, "progressStatus", DeckProgressStatus.IN_PROGRESS);
+    }
+
+    private Card cardIn(Deck deck, Long id, LocalDateTime enteredFieldAt, int viewCount) {
+        Card card = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"));
+        ReflectionTestUtils.setField(card, "id", id);
+        ReflectionTestUtils.setField(card, "enteredFieldAt", enteredFieldAt);
+        ReflectionTestUtils.setField(card, "viewCount", viewCount);
+        return card;
+    }
+
+    @Test
+    @DisplayName("후보 0건이면 budget·history·recalc 어떤 호출도 없다 (no-op)")
+    void noCandidates_noSideEffects() {
+        when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of());
+
+        CardExpiryBatchService.ExpiryResult result = service.processExpired();
+
+        assertThat(result.candidates()).isZero();
+        assertThat(result.archived()).isZero();
+        verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+        verify(historyAppender, never()).append(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("maxDuration 초과 카드만 archive — MAX_DURATION history append + Deck recalc")
+    void durationExpired_archivesWithMaxDuration() {
+        Card expired = cardIn(deckA, 1000L, LocalDateTime.now().minusDays(15), 0);  // 15일 경과
+        Card fresh   = cardIn(deckA, 1001L, LocalDateTime.now().minusDays(2),  0);  // 2일 경과
+
+        when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(expired, fresh));
+        // userA budget — 10일 maxDuration, maxView=3
+        when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+
+        CardExpiryBatchService.ExpiryResult result = service.processExpired();
+
+        assertThat(expired.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+        assertThat(fresh.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+        assertThat(result.archived()).isEqualTo(1);
+        assertThat(result.maxDurationCount()).isEqualTo(1);
+        assertThat(result.maxViewCount()).isZero();
+
+        verify(historyAppender, times(1))
+                .append(eq(expired), eq(CardStatus.ON_FIELD), eq(CardStatus.ARCHIVE), eq(ArchiveReason.MAX_DURATION));
+        verify(historyAppender, never())
+                .append(eq(fresh), any(), any(), any());
+        // deckA의 카드 중 1건 ARCHIVE → recalculate 호출 (deck.cards 빈 컬렉션 기준 NOT_STARTED로 회귀)
+        assertThat(deckA.getProgressStatus()).isEqualTo(DeckProgressStatus.NOT_STARTED);
+    }
+
+    @Test
+    @DisplayName("MAX_VIEW · MAX_DURATION 동시 도달 시 MAX_VIEW 우선 (OnFieldBudget 규칙)")
+    void simultaneousMaxViewAndDuration_maxViewWins() {
+        // viewCount=3 + 15일 경과 → 둘 다 충족 → MAX_VIEW
+        Card both = cardIn(deckA, 1000L, LocalDateTime.now().minusDays(15), 3);
+
+        when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(both));
+        when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+
+        CardExpiryBatchService.ExpiryResult result = service.processExpired();
+
+        assertThat(both.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+        assertThat(result.maxViewCount()).isEqualTo(1);
+        assertThat(result.maxDurationCount()).isZero();
+        verify(historyAppender, times(1))
+                .append(eq(both), eq(CardStatus.ON_FIELD), eq(CardStatus.ARCHIVE), eq(ArchiveReason.MAX_VIEW));
+    }
+
+    @Test
+    @DisplayName("여러 사용자 — 각 사용자별 budget 1회만 조회 (N+1 회피)")
+    void multipleUsers_budgetCalledOncePerUser() {
+        Card a1 = cardIn(deckA, 1000L, LocalDateTime.now().minusDays(2), 0);
+        Card a2 = cardIn(deckA, 1001L, LocalDateTime.now().minusDays(3), 0);
+        Card b1 = cardIn(deckB, 2000L, LocalDateTime.now().minusDays(4), 0);
+
+        when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(a1, a2, b1));
+        when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                .thenReturn(OnFieldBudget.of(5, Duration.ofDays(10)));
+        when(userScheduleQueryService.resolveOnFieldBudget(2L))
+                .thenReturn(OnFieldBudget.of(5, Duration.ofDays(20)));
+
+        service.processExpired();
+
+        verify(userScheduleQueryService, times(1)).resolveOnFieldBudget(1L);
+        verify(userScheduleQueryService, times(1)).resolveOnFieldBudget(2L);
+    }
+
+    @Test
+    @DisplayName("같은 Deck에 만료 카드 2건이면 recalculateProgressStatus 호출은 1회만 (모음 정리)")
+    void sameDeckMultipleExpiry_recalcOnce() {
+        Card e1 = cardIn(deckA, 1000L, LocalDateTime.now().minusDays(15), 0);
+        Card e2 = cardIn(deckA, 1001L, LocalDateTime.now().minusDays(20), 0);
+
+        when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(e1, e2));
+        when(userScheduleQueryService.resolveOnFieldBudget(1L))
+                .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+
+        CardExpiryBatchService.ExpiryResult result = service.processExpired();
+
+        assertThat(result.archived()).isEqualTo(2);
+        // deckA recalc 결과는 NOT_STARTED (deck.cards 컬렉션 비어있는 단위 테스트 조건)
+        assertThat(deckA.getProgressStatus()).isEqualTo(DeckProgressStatus.NOT_STARTED);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,3 +16,8 @@ spring:
 
   flyway:
     enabled: false
+
+# 테스트 컨텍스트에서 Card 야간 만료 배치(@Scheduled) 비활성화 — `-` 값은 disabled 트리거.
+card:
+  expiry:
+    cron: "-"


### PR DESCRIPTION
## 개요

product-card.md Epic 2 Story 2-2 — `maxDuration` 초과 ON_FIELD 카드를 야간 03:00 배치로 자동 ARCHIVE 한다. `OnFieldBudget` / `CardExpiryPolicy` / `CardStatusHistoryAppender` / `UserScheduleQueryService.resolveOnFieldBudget`(PR #146)을 그대로 재사용해 새 도메인 도입 없이 조율 레이어만 추가.

## 왜 / 설계 결정

- maxView는 노출(`recordView`) 경로에서 즉시 archive되지만, **maxDuration은 노출이 없는 사용자의 카드도 처리해야** 하므로 배치가 필수다. Story 2-2 Spec Option C — 야간 배치 단일 진입점.
- **사용자별 budget 1회 조회** — 후보 카드를 사용자별로 묶고 각 사용자당 `resolveOnFieldBudget(userId)`을 1번만 호출(N+1 회피). 기각: 카드별 매번 조회(트래픽 N배).
- **CardExpiryPolicy 재사용** — 도메인 서비스가 이미 `expire(card, budget)`을 제공. MAX_VIEW · MAX_DURATION 동시 도달 시 MAX_VIEW 우선 규칙도 `OnFieldBudget.resolveReason`에 박혀 있어 추가 분기 불필요. 본 배치는 안전망으로 MAX_VIEW도 함께 커버 — 노출 경로가 어떤 이유로 누락한 카드를 야간에 정리.
- **Deck recalculate 모음 정리** — 같은 Deck의 만료 카드 N건이면 recalculate는 1회만. `Set<Deck>`에 모았다가 끝에서 일괄 호출.
- **멱등성** — 도메인 `archive()` / `CardStatusHistoryAppender.append`(fromStatus==toStatus면 no-op) 모두 멱등이라 재실행·중복 안전.
- **활성/비활성 토글** — `@Scheduled(cron="${card.expiry.cron:0 0 3 * * *}")`. cron="-"이면 Spring이 disabled 트리거로 해석. application-local.yml / application-test.yml에 cron="-" 설정해 로컬·테스트 컨텍스트 자동 실행 차단.

## 작업 내용

- feat(card): `Card/application/service/CardExpiryBatchService.java` 신설.
  - `@Service`, `@Transactional` 단일 트랜잭션 처리.
  - `runScheduledExpiry()` — `@Scheduled` 진입점, 결과 분포(`MAX_VIEW`/`MAX_DURATION` count) info 로그.
  - `processExpired()` — 단위 테스트 친화 public 메서드. 사용자별 묶음 → budget 1회 조회 → `CardExpiryPolicy.expire` → history append → Deck recalc 모음.
  - `ExpiryResult` record — candidates/archived/maxViewCount/maxDurationCount.
- chore(config): `application-local.yml` / `application-test.yml`에 `card.expiry.cron: "-"` 추가 — 로컬·테스트 자동 실행 차단. 운영(application.yml, gitignored)은 기본값 `0 0 3 * * *` 사용 또는 명시 cron 지정.
- test(card): `CardExpiryBatchServiceTest` 5건 — 후보 0 no-op / maxDuration 초과 archive / MAX_VIEW · MAX_DURATION 동시 MAX_VIEW 우선 / 여러 사용자 budget 1회 호출 / 같은 Deck N건 recalculate 1회.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore (yml 설정 포함)

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Card.application.service.CardExpiryBatchServiceTest"` → BUILD SUCCESSFUL (5/5)
- `./gradlew test` → BUILD SUCCESSFUL (1m 11s, 전체 통과)
- 통합 / 성능: N/A. 운영에서 실제 cron 발사·후보 수·처리 시간은 logger 출력으로 관찰 예정. `@SpringBootTest`로 cron 트리거 자체를 검증하지는 않음(비결정성 회피).

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (배치 서비스, 응답 형식 무관)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인 신설 없음, 기존 행위·VO 재사용. BC 의존도 #146 등록분 그대로 유지)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Card BC application → UserSchedule application read 협력만 (기존 PACKAGE.md §6에 명시된 Review→UserSchedule와 동일 패턴)
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 2 (ON_field 무한 반복 방지) / Story 2-2 (maxDuration 초과 시 Archive 자동 이동)

## Commits in this PR

- `131af3f` feat(card): CardExpiryBatchService — 야간 만료 배치 도입
- `3080326` test(card): CardExpiryBatchService 매트릭스

## 후속 PR 예고

- **Story 5-2** — `GET /api/v1/cards/archive?tags=...` (Tag 클릭 탐색 / Archive 카드 목록).
- **운영 가시성 보강 (v2)** — 배치 결과 Metrics(`card_auto_archive_total{reason}`, `card_expiry_batch_duration_seconds`) — Story 2-2 §관측 지표 v2 범위로 별도 진행.
- **Card BC PACKAGE.md 의존 행** — Card BC application → UserSchedule read 협력을 별도 행으로 명시할지 검토 (Review와 동일 패턴이라 묵시 가능).