### PR TITLE
feat(card): Story 5-2 — Tag 클릭 탐색 (GET /api/v1/tags/{tagId}/cards)

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/application/service/CardQueryService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardQueryService.java
@@ -39,6 +39,17 @@ public class CardQueryService {
                              .toList();
     }
 
+    // ─── Tag 클릭 탐색 (Story 5-2) ────────────────────
+    // 특정 tagId가 부착된 본인 카드를 ON_FIELD/ARCHIVE 모두 포함해 반환.
+    // FE가 응답 DTO의 status 필드로 섹션 분리한다.
+
+    public List<CardResponse.Summary> findByTag(Long tagId, Long userId) {
+        return cardRepository.findByTagIdAndUserIdAndDeletedFalse(tagId, userId)
+                             .stream()
+                             .map(CardResponse.Summary::of)
+                             .toList();
+    }
+
     // ─── 관련 카드 후보 조회 ──────────────────────────
 
     public List<CardResponse.RelatedCard> findRelated(Long cardId) {

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -37,4 +37,22 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
             @Param("tagIds") List<Long> tagIds,
             @Param("excludeCardId") Long excludeCardId
                                  );
+
+    /**
+     * Story 5-2 — Tag 클릭 탐색 진입점.
+     * <p>특정 tagId가 부착된 사용자 소유 활성 카드를 createdDate 내림차순으로 반환한다.
+     * ON_FIELD / ARCHIVE 모두 포함 (FE에서 status 필드로 섹션 분리).
+     */
+    @Query("""
+            SELECT DISTINCT c FROM Card c
+            JOIN c.cardTags ct
+            WHERE ct.tag.id = :tagId
+              AND c.deck.user.id = :userId
+              AND c.deleted = false
+            ORDER BY c.createdDate DESC
+            """)
+    List<Card> findByTagIdAndUserIdAndDeletedFalse(
+            @Param("tagId") Long tagId,
+            @Param("userId") Long userId
+                                                  );
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
@@ -25,6 +25,12 @@ public interface CardRepository {
     List<Card> findBySharedTagIds(List<Long> tagIds, Long excludeCardId);
 
     /**
+     * Story 5-2 — Tag별 사용자 소유 카드 조회 (ON_FIELD/ARCHIVE 모두, 본인 카드만).
+     * createdDate 내림차순. status 필드는 응답 DTO에 노출되어 FE가 섹션 분리.
+     */
+    List<Card> findByTagIdAndUserIdAndDeletedFalse(Long tagId, Long userId);
+
+    /**
      * ON_FIELD 만료 배치용 카드 조회.
      * 주어진 CardStatus를 가진 활성 카드 목록을 반환한다.
      */

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
@@ -62,4 +62,9 @@ public class CardRepositoryAdapter implements CardRepository {
         return cardJpaRepository.findAllByStatusAndDeletedFalse(status);
     }
 
+    @Override
+    public List<Card> findByTagIdAndUserIdAndDeletedFalse(Long tagId, Long userId) {
+        return cardJpaRepository.findByTagIdAndUserIdAndDeletedFalse(tagId, userId);
+    }
+
 }

--- a/src/main/java/com/example/thirdtool/Card/presentation/CardController.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/CardController.java
@@ -5,10 +5,12 @@ import com.example.thirdtool.Card.application.service.CardCommandService;
 import com.example.thirdtool.Card.application.service.CardQueryService;
 import com.example.thirdtool.Card.presentation.dto.CardRequest;
 import com.example.thirdtool.Card.presentation.dto.CardResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -158,5 +160,16 @@ public class CardController {
             @PathVariable Long cardId
                                                             ) {
         return ResponseEntity.ok(cardCommandService.returnToField(cardId));
+    }
+
+    // ─── 16. Tag 클릭 탐색 (Story 5-2) ────────────────────
+    // 특정 Tag가 부착된 본인 카드를 ON_FIELD/ARCHIVE 모두 포함해 반환.
+    // FE가 응답 DTO의 status 필드로 ON_FIELD / ARCHIVE 섹션 분리.
+    @GetMapping("/api/v1/tags/{tagId}/cards")
+    public ResponseEntity<List<CardResponse.Summary>> findCardsByTag(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long tagId
+                                                                    ) {
+        return ResponseEntity.ok(cardQueryService.findByTag(tagId, user.getId()));
     }
 }

--- a/src/test/java/com/example/thirdtool/Card/application/service/CardQueryServiceFindByTagTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/CardQueryServiceFindByTagTest.java
@@ -1,0 +1,91 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardRelationFinder;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Card.presentation.dto.CardResponse;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * CardQueryService.findByTag (Story 5-2) — Repository 위임 + DTO 매핑 검증.
+ */
+@DisplayName("CardQueryService — findByTag (Story 5-2)")
+class CardQueryServiceFindByTagTest {
+
+    private CardRepository cardRepository;
+    private CardRelationFinder cardRelationFinder;
+    private CardQueryService service;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        cardRepository     = mock(CardRepository.class);
+        cardRelationFinder = mock(CardRelationFinder.class);
+        service = new CardQueryService(cardRepository, cardRelationFinder);
+
+        user = UserEntity.ofLocal("u", "pw", "n", "u@e.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        deck = Deck.createFromLearningMaterial(user, 10L, 200L, "DDD");
+        ReflectionTestUtils.setField(deck, "id", 500L);
+    }
+
+    private Card sampleCard(Long id, Tag... tags) {
+        Card card = Card.create(
+                deck,
+                MainNote.of("본문", null),
+                Summary.of("한 문장."),
+                List.of("k"),
+                List.of(tags)
+        );
+        ReflectionTestUtils.setField(card, "id", id);
+        return card;
+    }
+
+    @Test
+    @DisplayName("Repository에 tagId·userId 그대로 위임 + 결과를 CardResponse.Summary로 매핑")
+    void findByTag_delegatesAndMapsToSummary() {
+        Tag tag = Tag.of("백엔드");
+        ReflectionTestUtils.setField(tag, "id", 77L);
+        Card c1 = sampleCard(1000L, tag);
+        Card c2 = sampleCard(1001L, tag);
+
+        when(cardRepository.findByTagIdAndUserIdAndDeletedFalse(eq(77L), eq(1L)))
+                .thenReturn(List.of(c1, c2));
+
+        List<CardResponse.Summary> result = service.findByTag(77L, 1L);
+
+        verify(cardRepository, times(1)).findByTagIdAndUserIdAndDeletedFalse(77L, 1L);
+        assertThat(result).extracting(CardResponse.Summary::cardId)
+                          .containsExactly(1000L, 1001L);
+    }
+
+    @Test
+    @DisplayName("결과 0건이면 빈 리스트 — 예외 미발생 (미존재 Tag도 동일 분기)")
+    void findByTag_emptyResult_returnsEmptyList() {
+        when(cardRepository.findByTagIdAndUserIdAndDeletedFalse(eq(9_999L), eq(1L)))
+                .thenReturn(List.of());
+
+        List<CardResponse.Summary> result = service.findByTag(9_999L, 1L);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryTagQuerySliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryTagQuerySliceTest.java
@@ -1,0 +1,144 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CardRepository slice — Story 5-2 Tag 클릭 탐색 쿼리.
+ *
+ * <p>검증 범위
+ *   - Tag에 부착된 본인 카드만 반환 (다른 유저의 동일 Tag 카드는 제외)
+ *   - ON_FIELD / ARCHIVE 모두 포함
+ *   - soft delete 카드는 제외
+ *   - createdDate DESC 정렬
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("CardRepository slice — Story 5-2 findByTagIdAndUserIdAndDeletedFalse")
+class CardRepositoryTagQuerySliceTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    CardJpaRepository cardJpaRepository;
+
+    private UserEntity owner;
+    private UserEntity other;
+    private Deck deckOwner;
+    private Deck deckOther;
+    private Tag tagAlpha;
+    private Tag tagBeta;
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
+        other = UserEntity.ofLocal("other", "pw", "n", "x@e.com");
+        em.persist(owner);
+        em.persist(other);
+
+        deckOwner = Deck.of("owner 덱", null, owner);
+        deckOther = Deck.of("other 덱", null, other);
+        em.persist(deckOwner);
+        em.persist(deckOther);
+
+        tagAlpha = Tag.of("백엔드");
+        tagBeta  = Tag.of("프론트");
+        em.persist(tagAlpha);
+        em.persist(tagBeta);
+        em.flush();
+    }
+
+    private Card persistCard(Deck deck, List<Tag> tags) {
+        Card card = Card.create(
+                deck,
+                MainNote.of("본문", null),
+                Summary.of("한 문장."),
+                List.of("k1"),
+                tags
+        );
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+
+    @Test
+    @DisplayName("정상: tagAlpha를 가진 본인 카드 2건만 반환 — 다른 유저·다른 태그 카드 제외")
+    void findByTagIdAndUserId_filtersByTagAndOwner() {
+        Card c1 = persistCard(deckOwner, List.of(tagAlpha));
+        Card c2 = persistCard(deckOwner, List.of(tagAlpha, tagBeta));
+        persistCard(deckOwner, List.of(tagBeta));            // 다른 태그
+        persistCard(deckOther, List.of(tagAlpha));           // 다른 유저
+        em.clear();
+
+        List<Card> result = cardJpaRepository
+                .findByTagIdAndUserIdAndDeletedFalse(tagAlpha.getId(), owner.getId());
+
+        assertThat(result)
+                .extracting(Card::getId)
+                .containsExactlyInAnyOrder(c1.getId(), c2.getId());
+    }
+
+    @Test
+    @DisplayName("ON_FIELD / ARCHIVE 모두 포함된다 (status 무관)")
+    void findByTagIdAndUserId_includesBothStatuses() {
+        Card onField = persistCard(deckOwner, List.of(tagAlpha));
+        Card archived = persistCard(deckOwner, List.of(tagAlpha));
+        archived.archive();
+        em.flush();
+        em.clear();
+
+        List<Card> result = cardJpaRepository
+                .findByTagIdAndUserIdAndDeletedFalse(tagAlpha.getId(), owner.getId());
+
+        assertThat(result)
+                .extracting(Card::getId)
+                .containsExactlyInAnyOrder(onField.getId(), archived.getId());
+    }
+
+    @Test
+    @DisplayName("soft delete된 카드는 제외된다")
+    void findByTagIdAndUserId_excludesSoftDeleted() {
+        Card alive = persistCard(deckOwner, List.of(tagAlpha));
+        Card removed = persistCard(deckOwner, List.of(tagAlpha));
+        removed.softDelete();
+        em.flush();
+        em.clear();
+
+        List<Card> result = cardJpaRepository
+                .findByTagIdAndUserIdAndDeletedFalse(tagAlpha.getId(), owner.getId());
+
+        assertThat(result)
+                .extracting(Card::getId)
+                .containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("미존재 태그 ID는 빈 리스트")
+    void findByTagIdAndUserId_nonexistentTag_returnsEmpty() {
+        persistCard(deckOwner, List.of(tagAlpha));
+
+        List<Card> result = cardJpaRepository
+                .findByTagIdAndUserIdAndDeletedFalse(9_999L, owner.getId());
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 개요

product-card.md Epic 5 Story 5-2 — Tag 뱃지 클릭 진입점. 특정 `tagId`가 부착된 본인 카드를 ON_FIELD / ARCHIVE 모두 포함해 반환한다. FE는 응답 DTO의 `status` 필드(Story 1-1 PR #143에서 노출)로 섹션을 분리한다.

## 왜 / 설계 결정

- **API 형태** — `GET /api/v1/tags/{tagId}/cards`. RESTful 자원 중첩 표현으로 "이 Tag에 속한 카드 컬렉션"을 직관적으로 표현. 기각: `GET /api/v1/cards?tagId=...` (자원 위계 모호), `GET /api/v1/cards/archive?tags=...` (Spec의 Story 5-3 형태로 본 PR 범위 아님 — ARCHIVE-only 연결 후보는 다음 PR).
- **본인 카드 한정** — 쿼리 조건에 `c.deck.user.id = :userId` 일차 안전망. Tag 자체는 시스템 전역 UNIQUE라 다른 유저가 만든 동일 Tag도 같은 row지만, 카드는 사용자 자산이므로 본인 카드만 반환.
- **status 노출 정렬 미사용** — `CardStatus` `@Enumerated(STRING)`은 VARCHAR로 저장되어 ORDER BY는 알파벳순(ARCHIVE < ON_FIELD). FE에서 그룹화하므로 BE는 `createdDate DESC` 최신순만 보장. 기각: `ORDER BY status, createdDate DESC` (사전순 의존이라 의도 모호).
- **빈 결과 / 미존재 tagId 동일 분기** — 둘 다 빈 리스트 반환. 404를 만들지 않는 이유: FE 시나리오상 "이 Tag에 연결된 카드가 없습니다" 안내가 둘 다 동일하고, Tag UNIQUE row 조회를 강제하면 불필요한 query 1회 추가.
- **DISTINCT** — `JOIN c.cardTags` 다대다 중복을 제거. 한 카드가 같은 Tag를 여러 row로 가질 수 없는 도메인이지만 JPQL JOIN의 표준 안전 조치.

## 작업 내용

- feat(card): `CardJpaRepository.findByTagIdAndUserIdAndDeletedFalse(tagId, userId)` — JPQL `JOIN c.cardTags + tag.id + deck.user.id + deleted=false`, `ORDER BY c.createdDate DESC`, `DISTINCT`.
- feat(card): `CardRepository` Port + `CardRepositoryAdapter` 동기.
- feat(card): `CardQueryService.findByTag(tagId, userId) : List<CardResponse.Summary>`.
- feat(card): `CardController.findCardsByTag` — `GET /api/v1/tags/{tagId}/cards` + `@AuthenticationPrincipal UserEntity user`.
- test(card): `CardRepositoryTagQuerySliceTest` (`@DataJpaTest`, 4건) — 본인 한정 / ON_FIELD·ARCHIVE 둘 다 포함 / soft delete 제외 / 미존재 tag 빈 리스트.
- test(card): `CardQueryServiceFindByTagTest` (Mockist, 2건) — Repository 위임 + Summary 매핑 / 빈 결과 분기.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Card.infrastructure.persistence.CardRepositoryTagQuerySliceTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test --tests "com.example.thirdtool.Card.application.service.CardQueryServiceFindByTagTest"` → BUILD SUCCESSFUL (2/2)
- `./gradlew test` → BUILD SUCCESSFUL (1m 17s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (기존 CardController record 직접 반환 형식 유지)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인·BC 의존 변경 없음, Repository 메서드 추가만)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Card BC 내부 변경 + 기존 `@AuthenticationPrincipal UserEntity` 패턴 재사용
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 5 (Tag 클릭 탐색 및 Tag 목록 관리) / Story 5-2 (Tag 클릭 탐색 — ON_field/Archive 카드 목록 이동)

## Commits in this PR

- `1a48e96` feat(card): GET /api/v1/tags/{tagId}/cards — Story 5-2 Tag 클릭 탐색
- `(이번 commit)` test(card): Tag 클릭 탐색 슬라이스 + 서비스 매트릭스

## 후속 PR 예고

- **Story 5-3** — ON_field 학습 중 Tag 기반 Archive 연결 후보 표시 (`GET /api/v1/cards/{cardId}/related-archive` 또는 기존 `/related` 확장 + ARCHIVE 필터 옵션). 공통 Tag 수 정렬은 기존 `CardRelationFinder` 재사용.
- **Story 5-1** — Tag 관리 API: 전체 본인 Tag 목록 + 연결 카드 수, Tag 해제(`DELETE /api/v1/tags/{tagId}` — 본인 카드 부착 해제, Tag row 자체는 보존).