### PR TITLE
feat(card): Story 5-3 — ARCHIVE 연결 후보 (GET /cards/{cardId}/related-archive)

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/application/service/CardQueryService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardQueryService.java
@@ -70,6 +70,30 @@ public class CardQueryService {
                          .toList();
     }
 
+    // ─── ON_FIELD 학습 중 ARCHIVE 연결 후보 (Story 5-3) ───
+    // 현재 카드의 Tag를 가진 본인의 ARCHIVE 카드만 필터링.
+    // 공통 Tag 수 내림차순은 CardRelationFinder가 in-memory로 처리.
+
+    public List<CardResponse.RelatedCard> findArchiveRelated(Long cardId, Long userId) {
+        Card currentCard = findActiveCard(cardId);
+
+        List<Long> tagIds = currentCard.getCardTags().stream()
+                                       .map(ct -> ct.getTag().getId())
+                                       .toList();
+
+        // Tag가 없으면 섹션 미표시 — 빈 리스트 즉시 반환 (Spec 엣지 케이스)
+        if (tagIds.isEmpty()) return List.of();
+
+        List<Card> archivedCandidates =
+                cardRepository.findArchivedBySharedTagIdsAndUserId(tagIds, cardId, userId);
+        List<RelatedCardCandidate> candidates =
+                cardRelationFinder.findCandidates(currentCard, archivedCandidates);
+
+        return candidates.stream()
+                         .map(CardResponse.RelatedCard::of)
+                         .toList();
+    }
+
     // ─── 내부 유틸 ────────────────────────────────────────
 
     private Card findActiveCard(Long cardId) {

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -55,4 +55,26 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
             @Param("tagId") Long tagId,
             @Param("userId") Long userId
                                                   );
+
+    /**
+     * Story 5-3 — ON_FIELD 학습 중 Tag 기반 ARCHIVE 연결 후보.
+     * <p>전달받은 tagIds 중 하나 이상을 보유한 ARCHIVE 상태 사용자 카드를 자기 자신 제외하고 반환한다.
+     * 공통 Tag 수 정렬은 도메인 서비스(CardRelationFinder)가 in-memory로 수행하므로
+     * Repository는 후보 풀만 책임진다.
+     */
+    @Query("""
+            SELECT DISTINCT c FROM Card c
+            LEFT JOIN FETCH c.cardTags ct
+            LEFT JOIN FETCH ct.tag
+            WHERE ct.tag.id IN :tagIds
+              AND c.id != :excludeCardId
+              AND c.deck.user.id = :userId
+              AND c.status = com.example.thirdtool.Card.domain.model.CardStatus.ARCHIVE
+              AND c.deleted = false
+            """)
+    List<Card> findArchivedBySharedTagIdsAndUserId(
+            @Param("tagIds") List<Long> tagIds,
+            @Param("excludeCardId") Long excludeCardId,
+            @Param("userId") Long userId
+                                                  );
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
@@ -31,6 +31,13 @@ public interface CardRepository {
     List<Card> findByTagIdAndUserIdAndDeletedFalse(Long tagId, Long userId);
 
     /**
+     * Story 5-3 — ON_FIELD 학습 중 Tag 기반 ARCHIVE 연결 후보 풀.
+     * 전달받은 tagIds 중 하나 이상을 가진 ARCHIVE 상태 사용자 카드 (자기 자신 제외, deleted=false).
+     * 공통 Tag 수 정렬은 CardRelationFinder가 in-memory로 수행한다.
+     */
+    List<Card> findArchivedBySharedTagIdsAndUserId(List<Long> tagIds, Long excludeCardId, Long userId);
+
+    /**
      * ON_FIELD 만료 배치용 카드 조회.
      * 주어진 CardStatus를 가진 활성 카드 목록을 반환한다.
      */

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
@@ -67,4 +67,10 @@ public class CardRepositoryAdapter implements CardRepository {
         return cardJpaRepository.findByTagIdAndUserIdAndDeletedFalse(tagId, userId);
     }
 
+    @Override
+    public List<Card> findArchivedBySharedTagIdsAndUserId(List<Long> tagIds, Long excludeCardId, Long userId) {
+        if (tagIds == null || tagIds.isEmpty()) return List.of();
+        return cardJpaRepository.findArchivedBySharedTagIdsAndUserId(tagIds, excludeCardId, userId);
+    }
+
 }

--- a/src/main/java/com/example/thirdtool/Card/presentation/CardController.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/CardController.java
@@ -172,4 +172,15 @@ public class CardController {
                                                                     ) {
         return ResponseEntity.ok(cardQueryService.findByTag(tagId, user.getId()));
     }
+
+    // ─── 17. ON_FIELD 학습 중 ARCHIVE 연결 후보 (Story 5-3) ─
+    // 현재 카드의 Tag와 공유하는 본인 ARCHIVE 카드 후보. 공통 Tag 수 내림차순.
+    // 현재 카드에 Tag가 없으면 빈 리스트(섹션 미표시).
+    @GetMapping("/api/v1/cards/{cardId}/related-archive")
+    public ResponseEntity<List<CardResponse.RelatedCard>> findArchiveRelated(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long cardId
+                                                                            ) {
+        return ResponseEntity.ok(cardQueryService.findArchiveRelated(cardId, user.getId()));
+    }
 }

--- a/src/test/java/com/example/thirdtool/Card/application/service/CardQueryServiceArchiveRelatedTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/CardQueryServiceArchiveRelatedTest.java
@@ -1,0 +1,135 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.domain.exception.CardDomainException;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardRelationFinder;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Card.presentation.dto.CardResponse;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+/**
+ * CardQueryService.findArchiveRelated (Story 5-3) — 매트릭스.
+ *
+ * <p>Mockist + CardRelationFinder 실제 인스턴스 (도메인 서비스는 Classist).
+ * Repository만 Mock으로 후보 풀을 통제, 정렬·자기제외는 도메인 서비스가 검증한다.
+ */
+@DisplayName("CardQueryService — findArchiveRelated (Story 5-3)")
+class CardQueryServiceArchiveRelatedTest {
+
+    private CardRepository cardRepository;
+    private CardRelationFinder cardRelationFinder;
+    private CardQueryService service;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        cardRepository     = mock(CardRepository.class);
+        cardRelationFinder = new CardRelationFinder();   // 도메인 서비스는 실제
+        service = new CardQueryService(cardRepository, cardRelationFinder);
+
+        user = UserEntity.ofLocal("u", "pw", "n", "u@e.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        deck = Deck.createFromLearningMaterial(user, 10L, 200L, "DDD");
+        ReflectionTestUtils.setField(deck, "id", 500L);
+    }
+
+    private Tag tag(Long id, String value) {
+        Tag t = Tag.of(value);
+        ReflectionTestUtils.setField(t, "id", id);
+        return t;
+    }
+
+    private Card cardWith(Long id, Tag... tags) {
+        Card c = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"), List.of(tags));
+        ReflectionTestUtils.setField(c, "id", id);
+        return c;
+    }
+
+    @Test
+    @DisplayName("정상: 후보 카드 중 공통 Tag 수 내림차순 정렬되어 RelatedCard로 반환")
+    void findArchiveRelated_sortedBySharedTagCountDesc() {
+        Tag alpha = tag(10L, "백엔드");
+        Tag beta  = tag(20L, "프론트");
+        Tag gamma = tag(30L, "인프라");
+
+        Card current = cardWith(1000L, alpha, beta, gamma);
+        Card a1 = cardWith(2001L, alpha);                // 공통 1
+        Card a2 = cardWith(2002L, alpha, beta);          // 공통 2
+        Card a3 = cardWith(2003L, alpha, beta, gamma);   // 공통 3
+        a1.archive(); a2.archive(); a3.archive();
+
+        when(cardRepository.findById(1000L)).thenReturn(Optional.of(current));
+        when(cardRepository.findArchivedBySharedTagIdsAndUserId(
+                eq(List.of(alpha.getId(), beta.getId(), gamma.getId())),
+                eq(1000L),
+                eq(1L)
+        )).thenReturn(List.of(a1, a2, a3));
+
+        List<CardResponse.RelatedCard> result = service.findArchiveRelated(1000L, 1L);
+
+        assertThat(result).extracting(CardResponse.RelatedCard::cardId)
+                          .containsExactly(2003L, 2002L, 2001L);
+        assertThat(result).extracting(CardResponse.RelatedCard::sharedTagCount)
+                          .containsExactly(3, 2, 1);
+    }
+
+    @Test
+    @DisplayName("현재 카드 Tag 0개면 Repository 호출 없이 빈 리스트 반환 (Spec 엣지 케이스)")
+    void findArchiveRelated_noTags_emptyList_noRepoCall() {
+        Card current = cardWith(1000L); // no tags
+        when(cardRepository.findById(1000L)).thenReturn(Optional.of(current));
+
+        List<CardResponse.RelatedCard> result = service.findArchiveRelated(1000L, 1L);
+
+        assertThat(result).isEmpty();
+        // findArchivedBySharedTagIdsAndUserId 미호출 검증
+        org.mockito.Mockito.verify(cardRepository, never())
+                .findArchivedBySharedTagIdsAndUserId(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("미존재 cardId면 CARD_NOT_FOUND")
+    void findArchiveRelated_notFound_throws() {
+        when(cardRepository.findById(9_999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findArchiveRelated(9_999L, 1L))
+                .isInstanceOf(CardDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("soft delete된 카드는 CARD_NOT_FOUND")
+    void findArchiveRelated_softDeleted_throws() {
+        Card current = cardWith(1000L);
+        current.softDelete();
+        when(cardRepository.findById(1000L)).thenReturn(Optional.of(current));
+
+        assertThatThrownBy(() -> service.findArchiveRelated(1000L, 1L))
+                .isInstanceOf(CardDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryArchiveRelatedSliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryArchiveRelatedSliceTest.java
@@ -1,0 +1,159 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CardRepository slice — Story 5-3 ARCHIVE 연결 후보 쿼리.
+ *
+ * <p>검증 범위
+ *   - 본인 ARCHIVE 카드만 (ON_FIELD·다른 유저 카드 제외)
+ *   - 자기 자신 제외
+ *   - tagIds 중 하나만 일치해도 후보 포함 (OR 의미)
+ *   - soft delete 제외
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("CardRepository slice — Story 5-3 findArchivedBySharedTagIdsAndUserId")
+class CardRepositoryArchiveRelatedSliceTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    CardJpaRepository cardJpaRepository;
+
+    private UserEntity owner;
+    private UserEntity other;
+    private Deck deckOwner;
+    private Deck deckOther;
+    private Tag tagAlpha;
+    private Tag tagBeta;
+    private Tag tagGamma;
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
+        other = UserEntity.ofLocal("other", "pw", "n", "x@e.com");
+        em.persist(owner);
+        em.persist(other);
+
+        deckOwner = Deck.of("owner 덱", null, owner);
+        deckOther = Deck.of("other 덱", null, other);
+        em.persist(deckOwner);
+        em.persist(deckOther);
+
+        tagAlpha = Tag.of("백엔드");
+        tagBeta  = Tag.of("프론트");
+        tagGamma = Tag.of("인프라");
+        em.persist(tagAlpha);
+        em.persist(tagBeta);
+        em.persist(tagGamma);
+        em.flush();
+    }
+
+    private Card persistCard(Deck deck, boolean archived, List<Tag> tags) {
+        Card card = Card.create(
+                deck,
+                MainNote.of("본문", null),
+                Summary.of("한 문장."),
+                List.of("k1"),
+                tags
+        );
+        if (archived) card.archive();
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+
+    @Test
+    @DisplayName("ARCHIVE 상태 본인 카드만 — ON_FIELD·다른 유저 카드 제외")
+    void findArchivedShared_filtersByStatusAndOwner() {
+        Card current = persistCard(deckOwner, false, List.of(tagAlpha, tagBeta));   // 호출 시작점
+        Card a1 = persistCard(deckOwner, true,  List.of(tagAlpha));                 // ARCHIVE + Alpha 공유
+        persistCard(deckOwner, false, List.of(tagAlpha));                            // ON_FIELD → 제외
+        persistCard(deckOther, true,  List.of(tagAlpha));                            // 다른 유저 → 제외
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findArchivedBySharedTagIdsAndUserId(
+                List.of(tagAlpha.getId(), tagBeta.getId()),
+                current.getId(),
+                owner.getId()
+        );
+
+        assertThat(result).extracting(Card::getId).containsExactly(a1.getId());
+    }
+
+    @Test
+    @DisplayName("자기 자신은 제외된다")
+    void findArchivedShared_excludesCurrent() {
+        // 현재 카드도 ARCHIVE이고 tag를 공유해도 자기 자신은 후보 아님
+        Card current = persistCard(deckOwner, true, List.of(tagAlpha));
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findArchivedBySharedTagIdsAndUserId(
+                List.of(tagAlpha.getId()),
+                current.getId(),
+                owner.getId()
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("tagIds 중 하나만 일치해도 후보 — OR 의미 + DISTINCT")
+    void findArchivedShared_anyTagMatch() {
+        Card current = persistCard(deckOwner, false, List.of(tagAlpha, tagGamma));
+        Card a1 = persistCard(deckOwner, true,  List.of(tagAlpha));                 // alpha만
+        Card a2 = persistCard(deckOwner, true,  List.of(tagGamma));                 // gamma만
+        Card a3 = persistCard(deckOwner, true,  List.of(tagAlpha, tagGamma));       // 둘 다 — DISTINCT로 1건
+        persistCard(deckOwner, true, List.of(tagBeta));                              // beta만 → 제외
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findArchivedBySharedTagIdsAndUserId(
+                List.of(tagAlpha.getId(), tagGamma.getId()),
+                current.getId(),
+                owner.getId()
+        );
+
+        assertThat(result).extracting(Card::getId)
+                .containsExactlyInAnyOrder(a1.getId(), a2.getId(), a3.getId());
+    }
+
+    @Test
+    @DisplayName("soft delete된 ARCHIVE 카드는 제외")
+    void findArchivedShared_excludesSoftDeleted() {
+        Card current = persistCard(deckOwner, false, List.of(tagAlpha));
+        Card alive = persistCard(deckOwner, true, List.of(tagAlpha));
+        Card removed = persistCard(deckOwner, true, List.of(tagAlpha));
+        removed.softDelete();
+        em.flush();
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findArchivedBySharedTagIdsAndUserId(
+                List.of(tagAlpha.getId()),
+                current.getId(),
+                owner.getId()
+        );
+
+        assertThat(result).extracting(Card::getId).containsExactly(alive.getId());
+    }
+}


### PR DESCRIPTION
## 개요

product-card.md Epic 5 Story 5-3 — ON_FIELD 학습 중 현재 카드의 Tag와 공유하는 본인 ARCHIVE 카드 후보를 학습 화면 하단 "관련 Archive 카드" 섹션에 노출하기 위한 진입점. 공통 Tag 수 내림차순 정렬은 기존 `CardRelationFinder` 재사용.

## 왜 / 설계 결정

- **별도 엔드포인트** — 기존 `/cards/{id}/related`는 status 무관 모든 카드를 반환하지만, Story 5-3는 ARCHIVE만 + 본인 카드 한정. 기존 엔드포인트에 query param 추가(`?status=archive`)도 가능했으나 (a) 응답 의미가 달라지고 (b) 다른 호출자(`/related`)에 영향 — 별도 엔드포인트가 안전.
- **소유자 검증을 쿼리 조건으로** — `c.deck.user.id = :userId` 일차 안전망. 다른 유저의 ARCHIVE 카드는 처음부터 후보 풀에 없으므로 도메인 서비스 단계에서 추가 검증 불필요.
- **fetch join 유지** — `LEFT JOIN FETCH c.cardTags · ct.tag` 그대로 — 후속 `CardRelationFinder.findCandidates`가 각 후보의 `card.getCardTags()`를 순회하므로 N+1 회피 필수.
- **Tag 0개 단락** — Service 단에서 빈 리스트 즉시 반환. Repository 미호출(DB 트래픽 0). Adapter도 이중 안전망(빈 tagIds 입력 단락).
- **CardRelationFinder 재사용** — 정렬·자기제외·공유 Tag 추출 로직이 이미 도메인 서비스에 있다. Story 5-2 때 분리한 도메인 계산 패턴 그대로.

## 작업 내용

- feat(card): `CardJpaRepository.findArchivedBySharedTagIdsAndUserId` — JPQL JOIN c.cardTags + `tag.id IN :tagIds` + `status=ARCHIVE` + `deck.user.id` + 자기 제외 + `deleted=false`, fetch join + DISTINCT.
- feat(card): `CardRepository` Port + `CardRepositoryAdapter` 동기. Adapter는 tagIds 빈 입력 단락.
- feat(card): `CardQueryService.findArchiveRelated(cardId, userId)` — 현재 카드 Tag 추출 → 후보 조회 → `CardRelationFinder.findCandidates` → `CardResponse.RelatedCard` 매핑. Tag 0개면 빈 리스트 즉시 반환.
- feat(card): `CardController.findArchiveRelated` — `GET /api/v1/cards/{cardId}/related-archive` + `@AuthenticationPrincipal UserEntity`.
- test(card): `CardRepositoryArchiveRelatedSliceTest` (`@DataJpaTest`, 4건) — ARCHIVE·본인만 / 자기 제외 / tagIds OR + DISTINCT / soft delete 제외.
- test(card): `CardQueryServiceArchiveRelatedTest` (Mockist + 실제 `CardRelationFinder`, 4건) — 공통 Tag 수 내림차순·DTO 매핑 / Tag 0개 Repository 미호출 / NOT_FOUND / soft deleted NOT_FOUND.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Card.infrastructure.persistence.CardRepositoryArchiveRelatedSliceTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test --tests "com.example.thirdtool.Card.application.service.CardQueryServiceArchiveRelatedTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test` → BUILD SUCCESSFUL (1m 21s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (기존 CardController record 직접 반환 형식 유지)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인 변경 없음, Repository 메서드 추가만)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Card BC 내부 변경 + 기존 `@AuthenticationPrincipal UserEntity` 패턴
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 5 / Story 5-3 (ON_field 학습 중 Tag 기반 Archive 연결 후보 표시)

## Commits in this PR

- `5738642` feat(card): GET /api/v1/cards/{cardId}/related-archive — Story 5-3 Archive 연결 후보
- `(이번 commit)` test(card): Archive 연결 후보 슬라이스 + 서비스 매트릭스

## 후속 PR 예고

- **Story 5-1** — Tag 관리 API: 전체 본인 Tag 목록 + 연결 카드 수, Tag 해제(`DELETE /api/v1/tags/{tagId}` — 본인 카드 부착만 해제, Tag row 보존).
- **운영 정합** — 본 PR로 Epic 5 Tag 탐색 흐름의 핵심(5-2, 5-3) 완료. 다음으로 Epic 6 ReviewSession Layer 1 수집 또는 Epic 7 Archive→ON_field 복귀로 진입 가능.