### PR TITLE
feat(card): Story 5-1 — Tag 관리 API (GET /tags, DELETE /tags/{tagId})

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/application/service/TagCommandService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/TagCommandService.java
@@ -1,0 +1,28 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * product-card.md Epic 5 Story 5-1 — Tag 관리 화면의 "Tag 삭제" 액션.
+ *
+ * <p>본인 활성 카드에서 해당 Tag 부착(`card_tag` row)만 일괄 해제한다.
+ * Tag row 자체는 시스템 전역 UNIQUE 자원이므로 보존(다른 유저가 동일 Tag를 사용 중일 수 있음 —
+ * Open Question 5 v1 결정).
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TagCommandService {
+
+    private final CardRepository cardRepository;
+
+    /**
+     * 본인 카드에서 해당 Tag의 모든 부착을 해제하고 영향받은 매핑 row 수를 반환한다.
+     */
+    public int detachTagFromMyCards(Long tagId, Long userId) {
+        return cardRepository.detachTagFromUserCards(userId, tagId);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Card/application/service/TagQueryService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/TagQueryService.java
@@ -1,0 +1,28 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.infrastructure.persistence.TagRepository;
+import com.example.thirdtool.Card.presentation.dto.TagResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * product-card.md Epic 5 Story 5-1 — Tag 관리 화면 진입점 조회 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagQueryService {
+
+    private final TagRepository tagRepository;
+
+    /**
+     * 본인 카드에 부착된 Tag 목록 + 각 Tag별 연결 카드 수 반환.
+     * Tag value 사전순 정렬은 Repository 쿼리가 보장.
+     */
+    public List<TagResponse.Item> listMyTags(Long userId) {
+        return TagResponse.Item.listOf(tagRepository.findTagSummariesByUserId(userId));
+    }
+}

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/dto/TagSummaryRow.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/dto/TagSummaryRow.java
@@ -1,0 +1,14 @@
+package com.example.thirdtool.Card.infrastructure.dto;
+
+/**
+ * Story 5-1 — Tag 관리 화면용 프로젝션.
+ *
+ * <p>본인 카드(deleted=false)에 부착된 Tag 단위 집계.
+ * `connectedCardCount`는 해당 Tag가 부착된 본인 활성 카드 수.
+ */
+public record TagSummaryRow(
+        Long tagId,
+        String value,
+        long connectedCardCount
+) {
+}

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -3,6 +3,7 @@ package com.example.thirdtool.Card.infrastructure.persistence;
 import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.CardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -77,4 +78,21 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
             @Param("excludeCardId") Long excludeCardId,
             @Param("userId") Long userId
                                                   );
+
+    /**
+     * Story 5-1 — Tag 관리 화면의 "Tag 삭제" 액션.
+     * 본인의 모든 활성 카드에서 해당 Tag 부착(CardTag row)을 일괄 해제한다.
+     * Tag row 자체는 보존(시스템 전역 UNIQUE 자원, Open Question 5 v1 결정).
+     *
+     * <p>Aggregate 우회 — 본 메서드는 도메인 행위(`Card.removeTag`)를 N회 호출하는 대신
+     * 영속 계층에서 직접 매핑 row만 제거한다. 카드 자체 상태 변경이 없으므로 안전.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            DELETE FROM CardTag ct
+            WHERE ct.tag.id = :tagId
+              AND ct.card.deck.user.id = :userId
+              AND ct.card.deleted = false
+            """)
+    int detachTagFromUserCards(@Param("userId") Long userId, @Param("tagId") Long tagId);
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
@@ -38,6 +38,12 @@ public interface CardRepository {
     List<Card> findArchivedBySharedTagIdsAndUserId(List<Long> tagIds, Long excludeCardId, Long userId);
 
     /**
+     * Story 5-1 — Tag 관리 "삭제" 액션. 본인 활성 카드에서 해당 Tag 부착을 일괄 해제한다.
+     * Tag row는 보존(시스템 전역 UNIQUE 자원). 반환값은 제거된 매핑 row 수.
+     */
+    int detachTagFromUserCards(Long userId, Long tagId);
+
+    /**
      * ON_FIELD 만료 배치용 카드 조회.
      * 주어진 CardStatus를 가진 활성 카드 목록을 반환한다.
      */

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
@@ -73,4 +73,9 @@ public class CardRepositoryAdapter implements CardRepository {
         return cardJpaRepository.findArchivedBySharedTagIdsAndUserId(tagIds, excludeCardId, userId);
     }
 
+    @Override
+    public int detachTagFromUserCards(Long userId, Long tagId) {
+        return cardJpaRepository.detachTagFromUserCards(userId, tagId);
+    }
+
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/TagJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/TagJpaRepository.java
@@ -1,8 +1,12 @@
 package com.example.thirdtool.Card.infrastructure.persistence;
 
 import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagJpaRepository extends JpaRepository<Tag, Long> {
@@ -12,4 +16,21 @@ public interface TagJpaRepository extends JpaRepository<Tag, Long> {
      * Tag.value에 DB 유니크 제약이 걸려 있으므로 0 또는 1건이 반환된다.
      */
     Optional<Tag> findByValue(String value);
+
+    /**
+     * Story 5-1 — 사용자가 부착한 Tag 목록 + 각 Tag별 본인 활성 카드 수.
+     * <p>본인 카드 중 soft delete된 카드는 카운트에서 제외. ON_FIELD·ARCHIVE 모두 포함.
+     * 정렬은 tag value 사전순(클라이언트가 다시 정렬해도 무관).
+     */
+    @Query("""
+            SELECT new com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow(
+                       t.id, t.value, COUNT(DISTINCT ct.card.id))
+            FROM CardTag ct
+            JOIN ct.tag t
+            WHERE ct.card.deck.user.id = :userId
+              AND ct.card.deleted = false
+            GROUP BY t.id, t.value
+            ORDER BY t.value ASC
+            """)
+    List<TagSummaryRow> findTagSummariesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/TagRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/TagRepository.java
@@ -1,7 +1,9 @@
 package com.example.thirdtool.Card.infrastructure.persistence;
 
 import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagRepository {
@@ -9,5 +11,10 @@ public interface TagRepository {
     Optional<Tag> findByValue(String value);
 
     Tag save(Tag tag);
+
+    /**
+     * Story 5-1 — 본인 카드에 부착된 Tag 목록 + 연결 카드 수.
+     */
+    List<TagSummaryRow> findTagSummariesByUserId(Long userId);
 }
 

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/TagRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/TagRepositoryAdapter.java
@@ -1,9 +1,11 @@
 package com.example.thirdtool.Card.infrastructure.persistence;
 
 import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -20,6 +22,11 @@ public class TagRepositoryAdapter implements TagRepository {
     @Override
     public Tag save(Tag tag) {
         return tagJpaRepository.save(tag);
+    }
+
+    @Override
+    public List<TagSummaryRow> findTagSummariesByUserId(Long userId) {
+        return tagJpaRepository.findTagSummariesByUserId(userId);
     }
 }
 

--- a/src/main/java/com/example/thirdtool/Card/presentation/TagController.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/TagController.java
@@ -1,0 +1,47 @@
+package com.example.thirdtool.Card.presentation;
+
+import com.example.thirdtool.Card.application.service.TagCommandService;
+import com.example.thirdtool.Card.application.service.TagQueryService;
+import com.example.thirdtool.Card.presentation.dto.TagResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Tag 관리 화면 진입점 (Story 5-1).
+ *
+ * <p>카드 상세에서의 Tag 추가/제거는 {@link CardController}의 카드 부속물 엔드포인트가 담당하고,
+ * 본 컨트롤러는 사용자 단위 Tag 관리(목록 / 일괄 해제)만 노출한다.
+ */
+@RestController
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagQueryService tagQueryService;
+    private final TagCommandService tagCommandService;
+
+    /** GET /api/v1/tags — 본인 Tag 목록 + 연결 카드 수. value 사전순. */
+    @GetMapping("/api/v1/tags")
+    public ResponseEntity<List<TagResponse.Item>> listMyTags(
+            @AuthenticationPrincipal UserEntity user
+                                                            ) {
+        return ResponseEntity.ok(tagQueryService.listMyTags(user.getId()));
+    }
+
+    /** DELETE /api/v1/tags/{tagId} — 본인 카드에서 해당 Tag 일괄 해제. Tag row는 보존. */
+    @DeleteMapping("/api/v1/tags/{tagId}")
+    public ResponseEntity<Void> detachTag(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long tagId
+                                         ) {
+        tagCommandService.detachTagFromMyCards(tagId, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/thirdtool/Card/presentation/dto/TagResponse.java
+++ b/src/main/java/com/example/thirdtool/Card/presentation/dto/TagResponse.java
@@ -1,0 +1,26 @@
+package com.example.thirdtool.Card.presentation.dto;
+
+import com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow;
+
+import java.util.List;
+
+public class TagResponse {
+
+    /**
+     * GET /api/v1/tags — 본인 Tag 목록 응답.
+     * connectedCardCount는 해당 Tag가 부착된 본인 활성 카드 수(ON_FIELD + ARCHIVE).
+     */
+    public record Item(
+            Long tagId,
+            String value,
+            long connectedCardCount
+    ) {
+        public static Item of(TagSummaryRow row) {
+            return new Item(row.tagId(), row.value(), row.connectedCardCount());
+        }
+
+        public static List<Item> listOf(List<TagSummaryRow> rows) {
+            return rows.stream().map(Item::of).toList();
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/application/service/TagManagementServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/TagManagementServiceTest.java
@@ -1,0 +1,95 @@
+package com.example.thirdtool.Card.application.service;
+
+import com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Card.infrastructure.persistence.TagRepository;
+import com.example.thirdtool.Card.presentation.dto.TagResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * TagQueryService / TagCommandService — Story 5-1 Mockist 매트릭스.
+ */
+@DisplayName("Tag 관리 서비스 — Story 5-1")
+class TagManagementServiceTest {
+
+    private TagRepository tagRepository;
+    private CardRepository cardRepository;
+    private TagQueryService queryService;
+    private TagCommandService commandService;
+
+    @BeforeEach
+    void setUp() {
+        tagRepository  = mock(TagRepository.class);
+        cardRepository = mock(CardRepository.class);
+        queryService   = new TagQueryService(tagRepository);
+        commandService = new TagCommandService(cardRepository);
+    }
+
+    @Nested
+    @DisplayName("TagQueryService.listMyTags")
+    class Query {
+
+        @Test
+        @DisplayName("Repository 결과를 TagResponse.Item으로 매핑")
+        void listMyTags_mapsToItems() {
+            when(tagRepository.findTagSummariesByUserId(eq(1L))).thenReturn(List.of(
+                    new TagSummaryRow(10L, "alpha", 3),
+                    new TagSummaryRow(20L, "beta",  1)
+            ));
+
+            List<TagResponse.Item> result = queryService.listMyTags(1L);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).tagId()).isEqualTo(10L);
+            assertThat(result.get(0).value()).isEqualTo("alpha");
+            assertThat(result.get(0).connectedCardCount()).isEqualTo(3);
+            assertThat(result.get(1).tagId()).isEqualTo(20L);
+        }
+
+        @Test
+        @DisplayName("빈 결과면 빈 리스트 (예외 없음)")
+        void listMyTags_emptyResult() {
+            when(tagRepository.findTagSummariesByUserId(eq(1L))).thenReturn(List.of());
+
+            assertThat(queryService.listMyTags(1L)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("TagCommandService.detachTagFromMyCards")
+    class Command {
+
+        @Test
+        @DisplayName("Repository.detachTagFromUserCards 호출 + 영향 row 수 반환")
+        void detach_delegatesAndReturnsCount() {
+            when(cardRepository.detachTagFromUserCards(eq(1L), eq(77L))).thenReturn(4);
+
+            int affected = commandService.detachTagFromMyCards(77L, 1L);
+
+            assertThat(affected).isEqualTo(4);
+            verify(cardRepository, times(1)).detachTagFromUserCards(1L, 77L);
+        }
+
+        @Test
+        @DisplayName("영향 row 0건이어도 정상 (예외 없음)")
+        void detach_zeroRows_noException() {
+            when(cardRepository.detachTagFromUserCards(eq(1L), eq(77L))).thenReturn(0);
+
+            int affected = commandService.detachTagFromMyCards(77L, 1L);
+
+            assertThat(affected).isZero();
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/TagManagementSliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/TagManagementSliceTest.java
@@ -1,0 +1,173 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.domain.model.Tag;
+import com.example.thirdtool.Card.infrastructure.dto.TagSummaryRow;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 5-1 — Tag 관리 화면 슬라이스.
+ *
+ * <ul>
+ *   <li>{@code findTagSummariesByUserId}: 본인 활성 카드의 Tag만 집계, value 사전순</li>
+ *   <li>{@code detachTagFromUserCards}: 본인 카드 매핑만 일괄 제거, 다른 유저 영향 없음</li>
+ * </ul>
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("Tag 관리 slice — Story 5-1")
+class TagManagementSliceTest {
+
+    @Autowired TestEntityManager em;
+    @Autowired TagJpaRepository tagJpaRepository;
+    @Autowired CardJpaRepository cardJpaRepository;
+
+    private UserEntity owner;
+    private UserEntity other;
+    private Deck deckOwner;
+    private Deck deckOther;
+    private Tag tagAlpha;
+    private Tag tagBeta;
+    private Tag tagGamma;
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
+        other = UserEntity.ofLocal("other", "pw", "n", "x@e.com");
+        em.persist(owner);
+        em.persist(other);
+
+        deckOwner = Deck.of("owner 덱", null, owner);
+        deckOther = Deck.of("other 덱", null, other);
+        em.persist(deckOwner);
+        em.persist(deckOther);
+
+        tagAlpha = Tag.of("alpha");
+        tagBeta  = Tag.of("beta");
+        tagGamma = Tag.of("gamma");
+        em.persist(tagAlpha);
+        em.persist(tagBeta);
+        em.persist(tagGamma);
+        em.flush();
+    }
+
+    private Card persistCard(Deck deck, List<Tag> tags) {
+        Card card = Card.create(
+                deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"), tags
+        );
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+
+    // ─── findTagSummariesByUserId ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("findTagSummariesByUserId")
+    class Summaries {
+
+        @Test
+        @DisplayName("정상: 본인 카드 Tag만 집계 + 각 Tag별 본인 카드 수 + value 사전순")
+        void summaries_groupByTag_owner_only_sortedByValue() {
+            persistCard(deckOwner, List.of(tagAlpha));
+            persistCard(deckOwner, List.of(tagAlpha, tagBeta));
+            persistCard(deckOwner, List.of(tagBeta));
+            persistCard(deckOther, List.of(tagAlpha)); // 다른 유저 — 집계 제외
+            em.clear();
+
+            List<TagSummaryRow> result = tagJpaRepository.findTagSummariesByUserId(owner.getId());
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).value()).isEqualTo("alpha");
+            assertThat(result.get(0).connectedCardCount()).isEqualTo(2);
+            assertThat(result.get(1).value()).isEqualTo("beta");
+            assertThat(result.get(1).connectedCardCount()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("soft delete된 카드의 부착은 카운트에서 제외")
+        void summaries_excludeSoftDeleted() {
+            persistCard(deckOwner, List.of(tagAlpha));
+            Card removed = persistCard(deckOwner, List.of(tagAlpha));
+            removed.softDelete();
+            em.flush();
+            em.clear();
+
+            List<TagSummaryRow> result = tagJpaRepository.findTagSummariesByUserId(owner.getId());
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).value()).isEqualTo("alpha");
+            assertThat(result.get(0).connectedCardCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Tag가 0개면 빈 리스트")
+        void summaries_emptyWhenNoCards() {
+            List<TagSummaryRow> result = tagJpaRepository.findTagSummariesByUserId(owner.getId());
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ─── detachTagFromUserCards ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("detachTagFromUserCards")
+    class Detach {
+
+        @Test
+        @DisplayName("본인 카드 부착만 일괄 해제 + 다른 유저 부착·다른 Tag·Tag row 자체는 보존")
+        void detach_ownerOnly_preservesOtherUserAndTagRow() {
+            persistCard(deckOwner, List.of(tagAlpha));               // 해제 대상
+            persistCard(deckOwner, List.of(tagAlpha, tagBeta));      // alpha만 해제, beta 유지
+            persistCard(deckOther, List.of(tagAlpha));               // 다른 유저 — 유지
+            em.flush();
+
+            int removed = cardJpaRepository.detachTagFromUserCards(owner.getId(), tagAlpha.getId());
+            em.clear();
+
+            assertThat(removed).isEqualTo(2);
+
+            // 본인 카드의 Tag 카운트: alpha 0, beta 1
+            List<TagSummaryRow> ownerSummaries =
+                    tagJpaRepository.findTagSummariesByUserId(owner.getId());
+            assertThat(ownerSummaries).hasSize(1);
+            assertThat(ownerSummaries.get(0).value()).isEqualTo("beta");
+
+            // 다른 유저 카드는 alpha 1건 그대로
+            List<TagSummaryRow> otherSummaries =
+                    tagJpaRepository.findTagSummariesByUserId(other.getId());
+            assertThat(otherSummaries).hasSize(1);
+            assertThat(otherSummaries.get(0).value()).isEqualTo("alpha");
+
+            // Tag row 자체는 보존
+            assertThat(tagJpaRepository.findByValue("alpha")).isPresent();
+        }
+
+        @Test
+        @DisplayName("Tag가 어디에도 부착되지 않은 경우 0 반환")
+        void detach_returnsZero_whenNoMatch() {
+            int removed = cardJpaRepository.detachTagFromUserCards(owner.getId(), tagGamma.getId());
+
+            assertThat(removed).isZero();
+        }
+    }
+}


### PR DESCRIPTION
## 개요

product-card.md Epic 5 Story 5-1 — Tag 관리 화면 진입점. 본인 카드에 부착된 Tag 전체 목록과 각 Tag별 연결 카드 수를 조회하고, "Tag 삭제" 액션으로 본인 카드 부착만 일괄 해제한다. Tag row 자체는 시스템 전역 UNIQUE 자원이므로 보존(Open Question 5 v1 결정).

## 왜 / 설계 결정

- **Tag row 보존** — 시스템 전역 UNIQUE이므로 다른 유저가 동일 value를 사용 중일 수 있다. row 삭제 시 다른 유저 영향 → 권한 문제. 본 PR은 "본인 카드의 `card_tag` 매핑만 해제"로 한정. dead Tag row 누적은 운영 cleanup으로 별도 처리(v2).
- **Aggregate 우회 bulk delete** — Tag 1개에 본인 카드 N건 부착 시 `Card.removeTag` × N 호출은 N쿼리. JPQL `DELETE FROM CardTag` 한 번으로 처리. 카드 자체 상태·불변식 변경이 없으므로 우회 안전(주석에 명시). Aggregate를 통해야 하는 케이스는 카드의 다른 필드 변경이 동반될 때.
- **Tag 목록 집계** — `CardTag` 테이블에서 GROUP BY Tag로 `COUNT(DISTINCT card.id)` — 같은 카드가 한 Tag를 두 번 가질 수 없는 도메인이지만 표준 안전 조치. ARCHIVE 카드도 카운트 포함(사용자가 인지하는 "내 Tag" 정의).
- **별도 `TagController`** — 카드 상세에서의 Tag 추가/제거(`CardController.addTag`/`removeTag`)는 카드 부속물 작업. Tag 관리 화면은 사용자 단위 작업이라 라우팅을 분리해 의미를 명확히. 같은 BC 안에서 Controller만 분리.
- **응답 정렬** — Tag value 사전순. ON_FIELD/ARCHIVE 구분 없음(둘 다 "내 Tag").

## 작업 내용

- feat(card): `Card/infrastructure/dto/TagSummaryRow` record — JPQL projection (tagId/value/connectedCardCount).
- feat(card): `TagJpaRepository.findTagSummariesByUserId` — `CardTag JOIN t + GROUP BY + COUNT(DISTINCT card.id)`, deleted=false 활성 카드만 집계, value 사전순.
- feat(card): `CardJpaRepository.detachTagFromUserCards` — `@Modifying` JPQL `DELETE FROM CardTag` 본인 활성 카드 매핑만. Aggregate 우회 주석 명시. 반환값은 제거 row 수.
- feat(card): `TagRepository` / `CardRepository` Port + Adapter 동기.
- feat(card): `TagResponse.Item(tagId, value, connectedCardCount)` 응답 record.
- feat(card): `TagQueryService.listMyTags` + `TagCommandService.detachTagFromMyCards` Command/Query 분리.
- feat(card): `TagController` 신설 — `GET /api/v1/tags` + `DELETE /api/v1/tags/{tagId}`, `@AuthenticationPrincipal UserEntity`.
- test(card): `TagManagementSliceTest` (`@DataJpaTest`, 5건) — 본인 한정 집계 + 사전순 / soft delete 카운트 제외 / 빈 결과 / 본인 매핑만 해제 + 다른 유저·Tag row 보존 / 미부착 0 반환.
- test(card): `TagManagementServiceTest` (Mockist, 4건) — Repository 위임·매핑·빈 결과 / 영향 row 수 반환.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Card.infrastructure.persistence.TagManagementSliceTest"` → BUILD SUCCESSFUL (5/5)
- `./gradlew test --tests "com.example.thirdtool.Card.application.service.TagManagementServiceTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test` → BUILD SUCCESSFUL (1m 45s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (기존 record 직접 반환 형식 유지)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인·BC 의존 변경 없음, Card BC 내부 신규 컨트롤러)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Card BC 내부 + 기존 `@AuthenticationPrincipal UserEntity` 패턴
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 5 / Story 5-1 (Tag 추가 및 전체 Tag 목록 관리)

## Commits in this PR

- `feat(card): Tag 관리 API — GET /tags + DELETE /tags/{tagId}`
- `test(card): Tag 관리 슬라이스 + 서비스 매트릭스`

## Epic 5 완료

5-1(관리) + 5-2(클릭 탐색) + 5-3(Archive 연결 후보) 모두 BE 핵심 완료. FE 화면 작업 외 BE 측 Tag 흐름은 Epic 5 DoD 충족.

## 후속 PR 예고

- **Epic 7 Archive → ON_field 복귀 정합** — `returnToField` 엔드포인트·도메인은 PR #144에 들어갔지만 사이클 이력 보존 정책(Spec Story 7-1 인수 조건)과 Deck progressStatus 재계산 정합 통합 테스트 보강.
- **Epic 6 ReviewSession Layer 1 수집** — Deck 단위 → Layer 1(LearningFacade) 단위 카드 수집 + state 비율 추천. LearningFacade BC 의존 추가.