### PR TITLE
test(card): Story 7-1 — Archive ↔ ON_field 사이클 통합 테스트

### DIFF
--- a/src/test/java/com/example/thirdtool/Card/integration/CardArchiveReturnToFieldIntegrationTest.java
+++ b/src/test/java/com/example/thirdtool/Card/integration/CardArchiveReturnToFieldIntegrationTest.java
@@ -1,0 +1,165 @@
+package com.example.thirdtool.Card.integration;
+
+import com.example.thirdtool.Card.application.service.CardCommandService;
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.CardStatusHistory;
+import com.example.thirdtool.Card.infrastructure.persistence.CardJpaRepository;
+import com.example.thirdtool.Card.infrastructure.persistence.CardStatusHistoryJpaRepository;
+import com.example.thirdtool.Card.presentation.dto.CardRequest;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.model.DeckProgressStatus;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * product-card.md Epic 7 — Archive → ON_field 복귀 사이클 통합 검증.
+ *
+ * <p>Card 도메인 행위 + CardStatusHistoryAppender + Deck progressStatus 재계산까지
+ * Spring 컨텍스트 전체에서 정합한지 확인한다. 단위 테스트(CardCommandServiceArchiveTest)는
+ * Mock 기반이라 영속 흐름의 회귀를 잡지 못한다.
+ *
+ * <p>인수 시나리오 (Story 7-1)
+ * <ul>
+ *   <li>이전 ON_FIELD 구간 통계는 유지(`CardStatusHistory`)되고 새 사이클은 깨끗한 상태에서 시작</li>
+ *   <li>복귀 시점 `enteredFieldAt` 새 기록, `viewCount=0`, `lastViewedAt=null` 재초기화</li>
+ *   <li>Deck progressStatus가 COMPLETED → IN_PROGRESS로 회귀</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Archive ↔ ON_field 복귀 사이클 통합 — Story 7-1")
+class CardArchiveReturnToFieldIntegrationTest {
+
+    @Autowired CardCommandService cardCommandService;
+    @Autowired CardJpaRepository cardJpaRepository;
+    @Autowired CardStatusHistoryJpaRepository historyJpaRepository;
+
+    @PersistenceContext EntityManager em;
+
+    private UserEntity user;
+    private Deck deck;
+    private Card card;
+    private LocalDateTime initialEnteredFieldAt;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("owner", "encoded-pw", "닉네임", "owner@example.com");
+        em.persist(user);
+        deck = Deck.of("테스트 덱", null, user);
+        em.persist(deck);
+        em.flush();
+
+        var request = new CardRequest.Create(
+                new CardRequest.MainNoteDto("스택은 LIFO 구조다.", null),
+                List.of("LIFO", "push", "pop"),
+                "스택은 LIFO 구조다.",
+                List.of()
+        );
+        Long cardId = cardCommandService.create(deck.getId(), request).cardId();
+        em.flush();
+        em.clear();
+
+        card = cardJpaRepository.findById(cardId).orElseThrow();
+        initialEnteredFieldAt = card.getEnteredFieldAt();
+    }
+
+    @Test
+    @DisplayName("archive → returnToField — Card 필드 재초기화 + History 2건 + Deck IN_PROGRESS 회귀")
+    void archive_then_returnToField_resetsCard_keepsHistory_recalculatesDeck() {
+        // given — 노출 누적해 viewCount/lastViewedAt이 0/null 아님을 보장
+        card.recordView();
+        em.flush();
+
+        // when — archive(MANUAL) → returnToField
+        cardCommandService.archive(card.getId(), ArchiveReason.MANUAL);
+        em.flush();
+        em.clear();
+
+        Card afterArchive = cardJpaRepository.findById(card.getId()).orElseThrow();
+        assertThat(afterArchive.getStatus()).isEqualTo(CardStatus.ARCHIVE);
+        assertThat(afterArchive.getDeck().getProgressStatus()).isEqualTo(DeckProgressStatus.COMPLETED);
+
+        cardCommandService.returnToField(card.getId());
+        em.flush();
+        em.clear();
+
+        Card afterReturn = cardJpaRepository.findById(card.getId()).orElseThrow();
+
+        // then — 새 사이클 시작
+        assertThat(afterReturn.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+        assertThat(afterReturn.getViewCount()).isZero();
+        assertThat(afterReturn.getLastViewedAt()).isNull();
+        assertThat(afterReturn.getEnteredFieldAt()).isNotNull();
+        assertThat(afterReturn.getEnteredFieldAt()).isAfterOrEqualTo(initialEnteredFieldAt);
+
+        // Deck recalculate → IN_PROGRESS 회귀 (활성 카드 1건 모두 ON_FIELD)
+        assertThat(afterReturn.getDeck().getProgressStatus()).isEqualTo(DeckProgressStatus.IN_PROGRESS);
+
+        // 이력 2건 — ON_FIELD→ARCHIVE(MANUAL) + ARCHIVE→ON_FIELD(reason=null)
+        List<CardStatusHistory> histories = historyJpaRepository.findAll();
+        assertThat(histories).hasSize(2);
+        assertThat(histories).extracting(CardStatusHistory::getFromStatus)
+                .containsExactlyInAnyOrder(CardStatus.ON_FIELD, CardStatus.ARCHIVE);
+        assertThat(histories).extracting(CardStatusHistory::getToStatus)
+                .containsExactlyInAnyOrder(CardStatus.ARCHIVE, CardStatus.ON_FIELD);
+        assertThat(histories).extracting(CardStatusHistory::getReason)
+                .containsExactlyInAnyOrder(ArchiveReason.MANUAL, null);
+    }
+
+    @Test
+    @DisplayName("이미 ON_FIELD인 카드에 returnToField — 멱등 no-op, 이력 미생성")
+    void returnToField_onActiveCard_isIdempotent() {
+        // 카드는 setUp 직후 ON_FIELD 상태
+        assertThat(card.getStatus()).isEqualTo(CardStatus.ON_FIELD);
+
+        cardCommandService.returnToField(card.getId());
+        em.flush();
+
+        assertThat(historyJpaRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("두 사이클 반복 — History 4건이 모두 보존 (이전 사이클 이력 손실 없음)")
+    void twoFullCycles_preserveAllHistories() {
+        // 사이클 1
+        cardCommandService.archive(card.getId(), ArchiveReason.MANUAL);
+        em.flush();
+        cardCommandService.returnToField(card.getId());
+        em.flush();
+
+        // 사이클 2
+        cardCommandService.archive(card.getId(), ArchiveReason.MAX_DURATION);
+        em.flush();
+        cardCommandService.returnToField(card.getId());
+        em.flush();
+        em.clear();
+
+        List<CardStatusHistory> histories = historyJpaRepository.findAll();
+        assertThat(histories).hasSize(4);
+
+        Set<ArchiveReason> reasonsForArchive = histories.stream()
+                .filter(h -> h.getToStatus() == CardStatus.ARCHIVE)
+                .map(CardStatusHistory::getReason)
+                .collect(java.util.stream.Collectors.toSet());
+        assertThat(reasonsForArchive).containsExactlyInAnyOrder(
+                ArchiveReason.MANUAL, ArchiveReason.MAX_DURATION
+        );
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,3 +21,41 @@ spring:
 card:
   expiry:
     cron: "-"
+
+# @SpringBootTest로 컨텍스트 전체 로드 시 S3Config 같은 외부 인프라 빈이 placeholder를 요구한다.
+# 슬라이스 테스트는 영향 없지만 통합 테스트에서 dummy 값을 둔다.
+cloud:
+  aws:
+    credentials:
+      access-key: test-access-key
+      secret-key: test-secret-key
+    s3:
+      bucket: test-bucket
+    region:
+      static: ap-northeast-2
+
+# JWT 시크릿 더미 (TokenProvider Bean 초기화용)
+jwt:
+  secret-key: test-test-test-test-test-test-test
+  access-token-ttl: 30m
+  refresh-token-ttl: 7d
+  cookie:
+    name: access_token
+    path: /
+    http-only: true
+    same-site: Strict
+    secure: false
+
+# 소셜 로그인 dummy (통합 테스트 컨텍스트 로딩용)
+kakao:
+  client-id: test-kakao
+  client-secret: test-kakao-secret
+  redirect-uri: http://localhost/oauth/kakao
+naver:
+  client-id: test-naver
+  client-secret: test-naver-secret
+  redirect-uri: http://localhost/oauth/naver
+
+seed:
+  s3-base-url: "http://localhost"
+  image-count: 0


### PR DESCRIPTION
## 개요

product-card.md Epic 7 Story 7-1 — Archive → ON_field 복귀의 도메인·서비스·엔드포인트는 이미 구현되어 머지된 상태(`Card.returnToField` + `CardCommandService.returnToField` + `POST /api/v1/cards/{cardId}/return-to-field`). 본 PR은 **영속 흐름이 컨텍스트 전체에서 정합한지** 검증하는 첫 `@SpringBootTest` 통합 테스트를 추가하고, 통합 테스트가 동작하도록 `application-test.yml`에 외부 인프라 placeholder 더미 값을 보강한다.

## 왜 / 설계 결정

- **단위 테스트의 한계** — `CardCommandServiceArchiveTest`(Mockist)와 도메인 단위 테스트는 통과하지만 `CardStatusHistoryAppender` → JPA 저장 → 재조회 시 데이터 정합, `Deck.recalculateProgressStatus()`의 `deck.cards` 컬렉션 LAZY 로드 동작 등은 컨텍스트 전체에서만 회귀를 잡을 수 있다.
- **`@SpringBootTest` + `@Transactional`** — 테스트 트랜잭션이 서비스 트랜잭션을 흡수(REQUIRED)하므로 각 단계 사이 `em.flush()`/`em.clear()`로 1차 캐시 비우고 재조회해 실제 영속 상태를 검증.
- **`application-test.yml` 외부 placeholder 보강** — `S3Config`, JWT, 소셜 로그인이 `@Value("${...}")`로 placeholder를 요구해 컨텍스트 로딩이 막혔다. 더미 값으로 채워 슬라이스 테스트는 영향 없이 통합 테스트만 풀어준다. 기각: `@MockitoBean`으로 S3Client 등 개별 빈 mock — 통합 테스트가 늘 때마다 mock 정의가 누적되어 비용 큼.
- **검증 범위 한정** — `archive`/`returnToField` 1·2 사이클 + 멱등. UserSchedule·Review 흐름은 다른 PR(`ReviewCommandServiceTest`, `CardExpiryBatchServiceTest`)에서 단위 커버되어 본 PR 중복 검증 불필요.

## 작업 내용

- test(card): `CardArchiveReturnToFieldIntegrationTest`(@SpringBootTest, 3건)
  - `archive → returnToField`: Card 필드 재초기화(viewCount=0 · lastViewedAt=null · 새 enteredFieldAt) + `CardStatusHistory` 2건(MANUAL → reason=null 복귀) + Deck COMPLETED → IN_PROGRESS 자동 회귀.
  - 이미 ON_FIELD인 카드에 `returnToField` → 멱등 no-op + 이력 미생성.
  - 두 사이클 반복(MANUAL → 복귀 → MAX_DURATION → 복귀) → History 4건 모두 보존(이전 사이클 손실 없음).
- chore(test): `application-test.yml` placeholder 보강 — `cloud.aws.*` / `jwt.*` / `kakao.*` / `naver.*` / `seed.*` 더미. `@SpringBootTest` 컨텍스트 로딩용. 슬라이스/단위 테스트 동작 영향 없음.

## 변경 유형

- [ ] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [x] chore (yml dummy)

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Card.integration.CardArchiveReturnToFieldIntegrationTest"` → BUILD SUCCESSFUL (3/3)
- `./gradlew test` → BUILD SUCCESSFUL (1m 32s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (테스트 + yml만)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (코드/도메인 변경 없음, 통합 검증 보강)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — 테스트 + yml만
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 7 / Story 7-1 (Archive → ON_field 복귀 — 새 사이클 시작, 이력 보존)

## Commits in this PR

- `4ae5f02` test(card): Archive ↔ ON_field 사이클 통합 검증

## 후속 PR 예고

- **Epic 6 ReviewSession Layer 1 수집** — Deck 단위 → Layer 1(LearningFacade) 단위 카드 수집 + state 비율 추천. LearningFacade BC 의존 추가. 일정 큰 PR이 될 가능성이 높아 1차 Repository·서비스 골격 + 2차 Controller·통합 테스트로 분할 가능.
- **Epic 7 추가 정합 (v2)** — Spec 비목표였던 "복귀 횟수 제한·쿨다운"이 필요해질 때 도입. 본 PR은 v1 핵심까지.