### PR TITLE
feat(review): Story 6-1 — 오늘의 학습 후보 수집 (GET /review-session/today)

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -101,14 +101,13 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
      * <p>본인 ON_FIELD 활성 카드 중 한 번도 노출되지 않았거나(lastViewedAt IS NULL)
      * 최소 간격을 통과한(lastViewedAt &le; :threshold) 카드 풀.
      * state별 분류는 도메인 {@link com.example.thirdtool.Card.domain.model.SoftScheduleTemplate}이 in-memory로 수행.
-     * <p>fetch join으로 keywordCues·cardTags를 함께 로딩해 응답 매핑 시 N+1을 방지한다.
+     * <p>Deck만 fetch join으로 함께 로딩(응답 매핑에 deckId/deckName이 필요). 카드 컬렉션(keywordCues,
+     * cardTags)은 응답 DTO에 미포함이므로 fetch 미수행 — Hibernate MultipleBagFetchException 회피.
      */
     @Query("""
-            SELECT DISTINCT c FROM Card c
-            LEFT JOIN FETCH c.keywordCues
-            LEFT JOIN FETCH c.cardTags ct
-            LEFT JOIN FETCH ct.tag
-            WHERE c.deck.user.id = :userId
+            SELECT c FROM Card c
+            JOIN FETCH c.deck d
+            WHERE d.user.id = :userId
               AND c.status = com.example.thirdtool.Card.domain.model.CardStatus.ON_FIELD
               AND c.deleted = false
               AND (c.lastViewedAt IS NULL OR c.lastViewedAt <= :threshold)

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -95,4 +95,26 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
               AND ct.card.deleted = false
             """)
     int detachTagFromUserCards(@Param("userId") Long userId, @Param("tagId") Long tagId);
+
+    /**
+     * Story 6-1 — 사용자의 오늘 학습 후보 카드.
+     * <p>본인 ON_FIELD 활성 카드 중 한 번도 노출되지 않았거나(lastViewedAt IS NULL)
+     * 최소 간격을 통과한(lastViewedAt &le; :threshold) 카드 풀.
+     * state별 분류는 도메인 {@link com.example.thirdtool.Card.domain.model.SoftScheduleTemplate}이 in-memory로 수행.
+     * <p>fetch join으로 keywordCues·cardTags를 함께 로딩해 응답 매핑 시 N+1을 방지한다.
+     */
+    @Query("""
+            SELECT DISTINCT c FROM Card c
+            LEFT JOIN FETCH c.keywordCues
+            LEFT JOIN FETCH c.cardTags ct
+            LEFT JOIN FETCH ct.tag
+            WHERE c.deck.user.id = :userId
+              AND c.status = com.example.thirdtool.Card.domain.model.CardStatus.ON_FIELD
+              AND c.deleted = false
+              AND (c.lastViewedAt IS NULL OR c.lastViewedAt <= :threshold)
+            """)
+    List<Card> findOnFieldEligibleByUserId(
+            @Param("userId") Long userId,
+            @Param("threshold") java.time.LocalDateTime threshold
+                                          );
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
@@ -7,6 +7,7 @@ import com.example.thirdtool.Card.infrastructure.dto.CardSummaryRow;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,6 +43,13 @@ public interface CardRepository {
      * Tag row는 보존(시스템 전역 UNIQUE 자원). 반환값은 제거된 매핑 row 수.
      */
     int detachTagFromUserCards(Long userId, Long tagId);
+
+    /**
+     * Story 6-1 — 사용자의 오늘 학습 후보 카드 풀.
+     * <p>본인 ON_FIELD 활성 카드 중 한 번도 노출되지 않았거나 threshold 이전에 노출된 카드를 반환한다.
+     * 도메인 SoftScheduleTemplate가 in-memory에서 state별 분류·NOT_YET 제외를 책임진다.
+     */
+    List<Card> findOnFieldEligibleByUserId(Long userId, LocalDateTime threshold);
 
     /**
      * ON_FIELD 만료 배치용 카드 조회.

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,6 +77,11 @@ public class CardRepositoryAdapter implements CardRepository {
     @Override
     public int detachTagFromUserCards(Long userId, Long tagId) {
         return cardJpaRepository.detachTagFromUserCards(userId, tagId);
+    }
+
+    @Override
+    public List<Card> findOnFieldEligibleByUserId(Long userId, LocalDateTime threshold) {
+        return cardJpaRepository.findOnFieldEligibleByUserId(userId, threshold);
     }
 
 }

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -1,6 +1,10 @@
 package com.example.thirdtool.Review.application;
 
+import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.OnFieldBudget;
+import com.example.thirdtool.Card.domain.model.SoftScheduleState;
+import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Review.domain.model.ReviewSession;
@@ -13,7 +17,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +31,7 @@ public class ReviewQueryService {
 
     private final ReviewSessionRepository reviewSessionRepository;
     private final UserScheduleQueryService userScheduleQueryService;
+    private final CardRepository cardRepository;
 
     // Story-5-2: Long userId → UserEntity user 시그니처 통일.
 
@@ -69,5 +79,37 @@ public class ReviewQueryService {
     private boolean resolveIsLastView(ReviewSession session, OnFieldBudget budget) {
         if (session.isFinished()) return false;
         return session.currentCardReview().getCard().isLastView(budget.getMaxView());
+    }
+
+    // ─── 3. 오늘의 학습 후보 (Story 6-1) ─────────────────
+    // 사용자의 ON_FIELD + soft schedule 통과 카드를 SoftScheduleState별 분류해 반환한다.
+    // Layer 1(LearningFacade) 기준 필터링은 후속 PR에서 도입 — 본 PR은 사용자 전체 카드 기준
+    // (Spec 6-1 엣지 케이스 "Layer 1 미설정 유저" 경로 그대로).
+
+    public ReviewResponse.TodayCandidates getTodayCandidates(UserEntity user) {
+        Long userId = user.getId();
+        SoftScheduleTemplate template = userScheduleQueryService.resolveSoftScheduleTemplate(userId);
+
+        Duration minInterval = template.getIntervalSteps().get(0).minDuration();
+        LocalDateTime threshold = LocalDateTime.now().minus(minInterval);
+
+        List<Card> candidates = cardRepository.findOnFieldEligibleByUserId(userId, threshold);
+
+        Map<SoftScheduleState, List<ReviewResponse.TodayCandidates.CandidateItem>> byState =
+                candidates.stream()
+                          .map(card -> Map.entry(template.resolveState(card), card))
+                          // NOT_YET은 threshold 통과 카드 중에서도 도메인 재판정으로 걸러진 경우 제외.
+                          .filter(entry -> entry.getKey() != SoftScheduleState.NOT_YET)
+                          .collect(Collectors.groupingBy(
+                                  Map.Entry::getKey,
+                                  () -> new EnumMap<>(SoftScheduleState.class),
+                                  Collectors.mapping(
+                                          entry -> ReviewResponse.TodayCandidates.CandidateItem.of(entry.getValue()),
+                                          Collectors.toList()
+                                  )
+                          ));
+
+        int total = byState.values().stream().mapToInt(List::size).sum();
+        return new ReviewResponse.TodayCandidates(total, byState);
     }
 }

--- a/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
@@ -67,4 +67,13 @@ public class ReviewController {
                                                                              ) {
         return ResponseEntity.ok(reviewQueryService.searchSessions(deckId, currentUser));
     }
+
+    // ─── 6. 오늘의 학습 후보 (Story 6-1) ────────────────────
+    // 사용자의 ON_FIELD + soft schedule 통과 카드를 state별 분류해 반환.
+    @GetMapping("/api/v1/review-session/today")
+    public ResponseEntity<ReviewResponse.TodayCandidates> getTodayCandidates(
+            @AuthenticationPrincipal UserEntity currentUser
+                                                                            ) {
+        return ResponseEntity.ok(reviewQueryService.getTodayCandidates(currentUser));
+    }
 }

--- a/src/main/java/com/example/thirdtool/Review/presentation/dto/ReviewResponse.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/dto/ReviewResponse.java
@@ -1,7 +1,9 @@
 package com.example.thirdtool.Review.presentation.dto;
 
+import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.KeywordCue;
 import com.example.thirdtool.Card.domain.model.MainContentType;
+import com.example.thirdtool.Card.domain.model.SoftScheduleState;
 import com.example.thirdtool.Review.domain.model.CardReview;
 import com.example.thirdtool.Review.domain.model.CardVisibleContent;
 import com.example.thirdtool.Review.domain.model.ReviewSession;
@@ -10,6 +12,7 @@ import com.example.thirdtool.Review.infrastructure.dto.ReviewSessionSummaryRow;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class ReviewResponse {
 
@@ -107,6 +110,30 @@ public class ReviewResponse {
                     row.getTotalCardCount(),
                     row.getStartedAt()
             );
+        }
+    }
+
+    // ─── 6. 오늘의 학습 후보 응답 (Story 6-1) ───────────────────────────────
+    // 사용자의 ON_FIELD 카드 중 soft schedule 통과 카드를 state별로 분류해 노출.
+    // NOT_YET은 응답에서 제외. byState 키는 SoftScheduleState enum (FRESH, INTERVAL_*).
+    public record TodayCandidates(
+            int total,
+            Map<SoftScheduleState, List<CandidateItem>> byState
+    ) {
+        public record CandidateItem(
+                Long cardId,
+                Long deckId,
+                String deckName,
+                String summary
+        ) {
+            public static CandidateItem of(Card card) {
+                return new CandidateItem(
+                        card.getId(),
+                        card.getDeck().getId(),
+                        card.getDeck().getName(),
+                        card.getSummary().getValue()
+                );
+            }
         }
     }
 

--- a/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleQueryService.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleQueryService.java
@@ -1,6 +1,7 @@
 package com.example.thirdtool.UserSchedule.application.service;
 
 import com.example.thirdtool.Card.domain.model.OnFieldBudget;
+import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.UserSchedule.domain.exception.UserScheduleDomainException;
 import com.example.thirdtool.UserSchedule.domain.model.LearningModeMappingPolicy;
@@ -47,6 +48,18 @@ public class UserScheduleQueryService {
         UserScheduleConfig config = configRepository.findByUserId(userId)
                                                     .orElseGet(() -> initDefault(userId));
         return config.resolveOnFieldBudget();
+    }
+
+    /**
+     * Cross-BC inbound — Card BC {@link SoftScheduleTemplate}을 사용자별 설정에서 파생해 반환한다.
+     *
+     * <p>Review BC가 오늘 학습 후보 수집 시 사용자별 간격 단계(1·3·7일 / 1·3·7·14일 / 1·3·7·14·21일)
+     * 를 가져오기 위해 호출한다. 설정 미보유 유저는 첫 호출 시 기본 모드(MODE_10D)로 자동 초기화.
+     */
+    public SoftScheduleTemplate resolveSoftScheduleTemplate(Long userId) {
+        UserScheduleConfig config = configRepository.findByUserId(userId)
+                                                    .orElseGet(() -> initDefault(userId));
+        return config.resolveSoftScheduleTemplate();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryTodayCandidatesSliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryTodayCandidatesSliceTest.java
@@ -1,0 +1,120 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 6-1 — findOnFieldEligibleByUserId 슬라이스.
+ *
+ * <p>검증
+ *   - 본인 ON_FIELD 활성 카드만 (다른 유저·ARCHIVE·soft delete 제외)
+ *   - lastViewedAt이 null이거나 threshold 이전이면 포함
+ *   - lastViewedAt이 threshold 이후이면 제외
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("CardRepository slice — Story 6-1 findOnFieldEligibleByUserId")
+class CardRepositoryTodayCandidatesSliceTest {
+
+    @Autowired TestEntityManager em;
+    @Autowired CardJpaRepository cardJpaRepository;
+
+    private UserEntity owner;
+    private UserEntity other;
+    private Deck deckOwner;
+    private Deck deckOther;
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
+        other = UserEntity.ofLocal("other", "pw", "n", "x@e.com");
+        em.persist(owner);
+        em.persist(other);
+
+        deckOwner = Deck.of("o", null, owner);
+        deckOther = Deck.of("x", null, other);
+        em.persist(deckOwner);
+        em.persist(deckOther);
+        em.flush();
+    }
+
+    private Card persistCard(Deck deck, boolean archived, LocalDateTime lastViewedAt) {
+        Card card = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"));
+        if (archived) card.archive();
+        if (lastViewedAt != null) ReflectionTestUtils.setField(card, "lastViewedAt", lastViewedAt);
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+
+    @Test
+    @DisplayName("정상: lastViewedAt NULL인 본인 ON_FIELD 카드 포함, 다른 유저·ARCHIVE 제외")
+    void eligible_includesNullLastViewedAt_ownerOnly() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+        Card fresh = persistCard(deckOwner, false, null);                            // 신규(null) — 포함
+        persistCard(deckOwner, true, null);                                          // ARCHIVE — 제외
+        persistCard(deckOther, false, null);                                         // 다른 유저 — 제외
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findOnFieldEligibleByUserId(owner.getId(), threshold);
+
+        assertThat(result).extracting(Card::getId).containsExactly(fresh.getId());
+    }
+
+    @Test
+    @DisplayName("lastViewedAt이 threshold 이전이면 포함, 이후면 제외")
+    void eligible_thresholdFiltering() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+        Card oldView    = persistCard(deckOwner, false, LocalDateTime.now().minusDays(2));  // threshold 이전 — 포함
+        Card recentView = persistCard(deckOwner, false, LocalDateTime.now().minusHours(2)); // threshold 이후 — 제외
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findOnFieldEligibleByUserId(owner.getId(), threshold);
+
+        assertThat(result).extracting(Card::getId).containsExactly(oldView.getId());
+    }
+
+    @Test
+    @DisplayName("soft delete된 카드는 제외")
+    void eligible_excludesSoftDeleted() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+        Card alive = persistCard(deckOwner, false, null);
+        Card removed = persistCard(deckOwner, false, null);
+        removed.softDelete();
+        em.flush();
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findOnFieldEligibleByUserId(owner.getId(), threshold);
+
+        assertThat(result).extracting(Card::getId).containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("후보 0건은 빈 리스트")
+    void eligible_emptyWhenNoMatches() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(1);
+
+        List<Card> result = cardJpaRepository.findOnFieldEligibleByUserId(owner.getId(), threshold);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.MainNote;
 import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Deck.domain.model.Deck;
@@ -38,6 +39,7 @@ class ReviewQueryServiceTest {
 
     private ReviewSessionRepository sessionRepository;
     private UserScheduleQueryService userScheduleQueryService;
+    private CardRepository cardRepository;
     private ReviewQueryService service;
 
     private UserEntity owner;
@@ -48,7 +50,8 @@ class ReviewQueryServiceTest {
     void setUp() {
         sessionRepository        = mock(ReviewSessionRepository.class);
         userScheduleQueryService = mock(UserScheduleQueryService.class);
-        service = new ReviewQueryService(sessionRepository, userScheduleQueryService);
+        cardRepository           = mock(CardRepository.class);
+        service = new ReviewQueryService(sessionRepository, userScheduleQueryService, cardRepository);
 
         owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
         ReflectionTestUtils.setField(owner, "id", 1L);

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
@@ -1,0 +1,125 @@
+package com.example.thirdtool.Review.application;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.SoftScheduleState;
+import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
+import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Story 6-1 — getTodayCandidates 매트릭스.
+ *
+ * <p>Mockist (`conventions.md` §4.7) — Repository / Cross-BC Service Mock + Card·Deck·User는 실제 생성.
+ * 도메인 SoftScheduleTemplate.DEFAULT(1·3·7일)를 사용해 state 분류 검증.
+ */
+@DisplayName("ReviewQueryService — getTodayCandidates (Story 6-1)")
+class ReviewQueryServiceTodayCandidatesTest {
+
+    private ReviewSessionRepository sessionRepository;
+    private UserScheduleQueryService userScheduleQueryService;
+    private CardRepository cardRepository;
+    private ReviewQueryService service;
+
+    private UserEntity user;
+    private Deck deck;
+
+    @BeforeEach
+    void setUp() {
+        sessionRepository        = mock(ReviewSessionRepository.class);
+        userScheduleQueryService = mock(UserScheduleQueryService.class);
+        cardRepository           = mock(CardRepository.class);
+        service = new ReviewQueryService(sessionRepository, userScheduleQueryService, cardRepository);
+
+        user = UserEntity.ofLocal("u", "pw", "n", "u@e.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        deck = Deck.createFromLearningMaterial(user, 10L, 200L, "DDD");
+        ReflectionTestUtils.setField(deck, "id", 500L);
+    }
+
+    private Card cardWith(Long id, LocalDateTime lastViewedAt) {
+        Card card = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"));
+        ReflectionTestUtils.setField(card, "id", id);
+        if (lastViewedAt != null) ReflectionTestUtils.setField(card, "lastViewedAt", lastViewedAt);
+        return card;
+    }
+
+    @Test
+    @DisplayName("FRESH(null) / INTERVAL_1D / INTERVAL_7D 각각 분류되고 NOT_YET은 응답에서 제외된다")
+    void getTodayCandidates_groupsByState_excludesNotYet() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+
+        Card fresh   = cardWith(1000L, null);                                            // FRESH
+        Card oneDay  = cardWith(1001L, LocalDateTime.now().minusDays(2));                // INTERVAL_1D
+        Card sevenD  = cardWith(1002L, LocalDateTime.now().minusDays(10));               // INTERVAL_7D
+        // notYet 카드는 후보 풀에서 이미 제외되어야 하지만 NOT_YET 안전망도 검증
+        Card notYet  = cardWith(1003L, LocalDateTime.now().minusHours(2));               // NOT_YET (1일 미만)
+
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(fresh, oneDay, sevenD, notYet));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isEqualTo(3);
+        assertThat(result.byState()).doesNotContainKey(SoftScheduleState.NOT_YET);
+        assertThat(result.byState().get(SoftScheduleState.FRESH))
+                .extracting(ReviewResponse.TodayCandidates.CandidateItem::cardId).containsExactly(1000L);
+        assertThat(result.byState().get(SoftScheduleState.INTERVAL_1D))
+                .extracting(ReviewResponse.TodayCandidates.CandidateItem::cardId).containsExactly(1001L);
+        assertThat(result.byState().get(SoftScheduleState.INTERVAL_7D))
+                .extracting(ReviewResponse.TodayCandidates.CandidateItem::cardId).containsExactly(1002L);
+    }
+
+    @Test
+    @DisplayName("후보 0건이면 total=0 + 빈 byState")
+    void getTodayCandidates_noCandidates_emptyResponse() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of());
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isZero();
+        assertThat(result.byState()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("CandidateItem 매핑 — cardId / deckId / deckName / summary")
+    void getTodayCandidates_itemMapping() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+
+        Card card = cardWith(1000L, null);
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(card));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        ReviewResponse.TodayCandidates.CandidateItem item =
+                result.byState().get(SoftScheduleState.FRESH).get(0);
+        assertThat(item.cardId()).isEqualTo(1000L);
+        assertThat(item.deckId()).isEqualTo(500L);
+        assertThat(item.deckName()).isEqualTo("DDD");
+        assertThat(item.summary()).isEqualTo("한 문장.");
+    }
+}


### PR DESCRIPTION
## 개요

product-card.md Epic 6 Story 6-1 — 사용자의 ON_FIELD + soft schedule 통과 카드를 SoftScheduleState별로 분류해 ReviewSession 대기열 미리보기 형태로 반환한다. Layer 1(LearningFacade) 한정 필터링은 후속 PR로 분리하고, 본 PR은 **Spec 엣지 케이스 "Layer 1 미설정 유저는 전체 ON_field 카드 기준" 경로**(사용자 전체 카드)로 한정.

## 왜 / 설계 결정

- **분할 진행** — Epic 6 핵심은 (a) 수집 (b) state 분류 (c) dailyTarget × 비율 추천 + (d) Layer 1 한정. 본 PR은 (a) + (b)까지. LearningFacade BC 의존 추가는 별도 PR로 분리해 리뷰 부담 ↓ + 사용자 학습 흐름 BE 최소 제공이 우선.
- **사용자별 SoftScheduleTemplate** — `UserScheduleQueryService.resolveSoftScheduleTemplate` 추가. 직전 PR(#146) `resolveOnFieldBudget` 자매 메서드, 동일한 미보유 자동 초기화 패턴 재사용.
- **2단계 필터링** — DB 1차(최소 간격 threshold) → in-memory 2차(도메인 `SoftScheduleTemplate.resolveState`). DB는 가장 짧은 간격으로 후보 풀을 좁히고, 도메인이 정확한 state 분류·NOT_YET 제외를 담당. 기각: DB에서 state별 GROUP BY (시간 의존성·dialect 의존성·재사용성 낮음).
- **응답 DTO 최소화** — `CandidateItem(cardId, deckId, deckName, summary)`만. keywords·tags는 미리보기에 불필요 → `MultipleBagFetchException`도 자연스럽게 회피. Deck만 fetch join.
- **EnumMap 사용** — `byState`는 `EnumMap<SoftScheduleState, ...>`. JSON 직렬화 시 enum 키 순서가 선언 순서를 따라 FE 표시 일관성. NOT_YET은 응답에서 제외(도메인 재판정 안전망).

## 작업 내용

- feat(card): `CardJpaRepository.findOnFieldEligibleByUserId(userId, threshold)` + Port/Adapter. JPQL `JOIN FETCH c.deck` + `status=ON_FIELD + deleted=false + (lastViewedAt IS NULL OR <= threshold)`.
- feat(user-schedule): `UserScheduleQueryService.resolveSoftScheduleTemplate(userId)` — 미보유 시 createDefault 자동 초기화.
- feat(review): `ReviewQueryService.getTodayCandidates(user)` — 사용자 template에서 최소 간격 추출 → DB 후보 조회 → in-memory state 분류 → NOT_YET 제외 + EnumMap 그룹화.
- feat(review): `ReviewResponse.TodayCandidates(total, byState)` + `CandidateItem(cardId, deckId, deckName, summary)` 응답 record.
- feat(review): `ReviewController` — `GET /api/v1/review-session/today` + `@AuthenticationPrincipal UserEntity`.
- chore(test): 기존 `ReviewQueryServiceTest` 생성자 인자 추가(`CardRepository`).
- test(card): `CardRepositoryTodayCandidatesSliceTest` (`@DataJpaTest`, 4건).
- test(review): `ReviewQueryServiceTodayCandidatesTest` (Mockist, 3건).

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Card.infrastructure.persistence.CardRepositoryTodayCandidatesSliceTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test --tests "com.example.thirdtool.Review.application.ReviewQueryServiceTodayCandidatesTest"` → BUILD SUCCESSFUL (3/3)
- `./gradlew test` → BUILD SUCCESSFUL (1m 45s, 전체 통과)
- 통합 / 성능: N/A (단일 사용자 시나리오만, multi-user 분포 확인은 추후 운영 데이터)

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (BC 의존은 기존 Review→UserSchedule + 새 Review→Card 패턴, 이미 §6 명시)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Review BC application → Card BC Repository / UserSchedule application (read only)
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 6 / Story 6-1 (Layer 1 기준 오늘 학습 가능한 카드 수집)

## Commits in this PR

- `92affd9` feat(review): GET /review-session/today — 사용자별 오늘 학습 후보 수집
- `(test commit)` test(review): 오늘 학습 후보 슬라이스 + 서비스 매트릭스

## 후속 PR 예고

- **Story 6-2 — dailyTarget + state 비율 추천** — UserScheduleConfig에 dailyTarget 추가 또는 기본값 20장 적용. 동적 비율(state별 실제 풀 크기 기준)로 dailyTarget 배분. 본 PR의 byState 그대로 활용 가능.
- **Story 6-3 — +N장 추가 학습** — 동일 비율로 잔여 후보 확장.
- **Layer 1 한정 필터링** — LearningFacade BC 의존 추가 + Repository 메서드 신설. fallback 경로 유지 (LearningFacade 없는 유저는 전체 카드 그대로).