### PR TITLE
feat(user-schedule): Story 6-2 — dailyTarget 컬럼·도메인 토대

### DIFF
--- a/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleQueryService.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleQueryService.java
@@ -62,6 +62,16 @@ public class UserScheduleQueryService {
         return config.resolveSoftScheduleTemplate();
     }
 
+    /**
+     * Story 6-2 — 하루 학습 목표 카드 수를 반환한다.
+     * Review BC가 동적 비율 추천 시 사용. 설정 미보유 유저는 기본값(20)으로 자동 초기화.
+     */
+    public int resolveDailyTarget(Long userId) {
+        UserScheduleConfig config = configRepository.findByUserId(userId)
+                                                    .orElseGet(() -> initDefault(userId));
+        return config.getDailyTarget();
+    }
+
     @Transactional(readOnly = true)
     public List<UserScheduleResponse.HistoryItem> getHistory(Long userId, Integer limit) {
         int resolvedLimit = resolveLimit(limit);

--- a/src/main/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfig.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfig.java
@@ -24,6 +24,7 @@ public class UserScheduleConfig {
 
     // ─── 기본값 상수 ──────────────────────────────────────────────
     private static final int DEFAULT_INPUT_DAYS = 10;
+    private static final int DEFAULT_DAILY_TARGET = 20;
 
     // ─── 식별자 ──────────────────────────────────────────────────
     @Id
@@ -43,6 +44,10 @@ public class UserScheduleConfig {
     @Column(name = "mapped_mode", nullable = false, length = 20)
     private LearningMode mappedMode;
 
+    // Story 6-2 — 하루 학습 목표 카드 수. 동적 비율 추천의 분모.
+    @Column(name = "daily_target", nullable = false)
+    private int dailyTarget = DEFAULT_DAILY_TARGET;
+
     // ─── 타임스탬프 ───────────────────────────────────────────────
 
     @CreationTimestamp
@@ -57,9 +62,10 @@ public class UserScheduleConfig {
     protected UserScheduleConfig() {}
 
     private UserScheduleConfig(Long userId, int rawInputDays, LearningMode mappedMode) {
-        this.userId      = userId;
+        this.userId       = userId;
         this.rawInputDays = rawInputDays;
-        this.mappedMode  = mappedMode;
+        this.mappedMode   = mappedMode;
+        this.dailyTarget  = DEFAULT_DAILY_TARGET;
     }
 
     // ─── 생성 ────────────────────────────────────────────────────
@@ -87,6 +93,18 @@ public class UserScheduleConfig {
         LearningMode newMode = policy.resolve(newInputDays);
         this.rawInputDays = newInputDays;
         this.mappedMode   = newMode;
+    }
+
+    /**
+     * Story 6-2 — 하루 학습 목표 카드 수를 갱신한다. 1 이상 강제.
+     */
+    public void updateDailyTarget(int newDailyTarget) {
+        if (newDailyTarget < 1) {
+            throw UserScheduleDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "dailyTarget은 1 이상이어야 합니다. 입력값=" + newDailyTarget);
+        }
+        this.dailyTarget = newDailyTarget;
     }
 
     // ─── 파생값 제공 ─────────────────────────────────────────────

--- a/src/main/resources/db/migration/V13__user_schedule_config_daily_target.sql
+++ b/src/main/resources/db/migration/V13__user_schedule_config_daily_target.sql
@@ -1,0 +1,19 @@
+-- =============================================================
+-- V13. user_schedule_config 테이블에 daily_target 컬럼 추가
+--
+-- product-card.md Epic 6 Story 6-2 — 유저별 하루 학습 목표 카드 수.
+-- 동적 state 비율 추천(Story 6-2)이 dailyTarget × state 비례로 배분한다.
+--
+-- 기본값 20장 (Open Question 4 v1 잠정) — 첫 진입 사용자도 즉시 학습 가능하도록
+-- 운영 데이터 누적 후 재조정.
+--
+-- CHECK daily_target >= 1 (도메인은 1 이상 강제).
+-- 기존 row는 DEFAULT 20으로 자동 백필.
+-- =============================================================
+
+ALTER TABLE user_schedule_config
+    ADD COLUMN daily_target INT NOT NULL DEFAULT 20 AFTER mapped_mode;
+
+ALTER TABLE user_schedule_config
+    ADD CONSTRAINT chk_user_schedule_config_daily_target
+        CHECK (daily_target >= 1);

--- a/src/test/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfigDailyTargetTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfigDailyTargetTest.java
@@ -1,0 +1,63 @@
+package com.example.thirdtool.UserSchedule.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.UserSchedule.domain.exception.UserScheduleDomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("UserScheduleConfig — dailyTarget (Story 6-2)")
+class UserScheduleConfigDailyTargetTest {
+
+    private final LearningModeMappingPolicy policy = new LearningModeMappingPolicy();
+
+    @Test
+    @DisplayName("create — 기본값 dailyTarget=20")
+    void create_default_dailyTarget_20() {
+        UserScheduleConfig config = UserScheduleConfig.create(1L, 10, policy);
+
+        assertThat(config.getDailyTarget()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("createDefault — 기본값 dailyTarget=20")
+    void createDefault_default_dailyTarget_20() {
+        UserScheduleConfig config = UserScheduleConfig.createDefault(1L, policy);
+
+        assertThat(config.getDailyTarget()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("updateDailyTarget — 1 이상 정상 갱신")
+    void updateDailyTarget_valid_updates() {
+        UserScheduleConfig config = UserScheduleConfig.create(1L, 10, policy);
+
+        config.updateDailyTarget(50);
+
+        assertThat(config.getDailyTarget()).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("updateDailyTarget — 1 미만은 INVALID_INPUT 예외")
+    void updateDailyTarget_zero_throws() {
+        UserScheduleConfig config = UserScheduleConfig.create(1L, 10, policy);
+
+        assertThatThrownBy(() -> config.updateDailyTarget(0))
+                .isInstanceOf(UserScheduleDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("updateDailyTarget — 음수도 INVALID_INPUT")
+    void updateDailyTarget_negative_throws() {
+        UserScheduleConfig config = UserScheduleConfig.create(1L, 10, policy);
+
+        assertThatThrownBy(() -> config.updateDailyTarget(-5))
+                .isInstanceOf(UserScheduleDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+}

--- a/src/test/java/com/example/thirdtool/UserSchedule/infrastructure/persistence/UserScheduleConfigRepositorySliceTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/infrastructure/persistence/UserScheduleConfigRepositorySliceTest.java
@@ -110,6 +110,30 @@ class UserScheduleConfigRepositorySliceTest {
     }
 
     @Test
+    @DisplayName("Story 6-2 — dailyTarget 기본값 20 round-trip + updateDailyTarget 영속")
+    void dailyTarget_default20_updatePersists() {
+        // given — 기본 생성
+        repository.save(UserScheduleConfig.create(user.getId(), 10, policy));
+        em.flush();
+        em.clear();
+
+        UserScheduleConfig loaded = repository.findByUserId(user.getId()).orElseThrow();
+        assertThat(loaded.getDailyTarget()).isEqualTo(20);
+
+        // when — 50으로 수정
+        loaded.updateDailyTarget(50);
+        em.flush();
+        em.clear();
+
+        // then
+        UserScheduleConfig reloaded = repository.findByUserId(user.getId()).orElseThrow();
+        assertThat(reloaded.getDailyTarget()).isEqualTo(50);
+        // 다른 필드는 영향 없음
+        assertThat(reloaded.getRawInputDays()).isEqualTo(10);
+        assertThat(reloaded.getMappedMode()).isEqualTo(LearningMode.MODE_10D);
+    }
+
+    @Test
     @DisplayName("updateMode — raw_input_days와 mapped_mode가 함께 갱신·영속된다")
     void updateMode_persistsBothFields() {
         // given — 10D 모드로 시작


### PR DESCRIPTION
## 개요

product-card.md Epic 6 Story 6-2 — 사용자별 하루 학습 목표 카드 수(`dailyTarget`)의 데이터·도메인 토대. 이어질 PR에서 Review BC가 `resolveDailyTarget`을 호출해 동적 비율 추천(`dailyTarget × state 풀 비례`)을 수행한다. 본 PR은 분량 분리를 위해 **데이터 소스 + 도메인 + Query inbound만**.

## 왜 / 설계 결정

- **PR 분할** — Story 6-2 전체 = 데이터 토대 + 동적 비율 알고리즘 + DTO 확장. 데이터 토대 없이는 알고리즘 PR이 의존하므로 선행 분리. 알고리즘은 후속 PR.
- **기본값 20장** (Open Question 4 v1) — 첫 진입 사용자가 즉시 학습 가능하도록 임의 기본값. 운영 데이터 누적 후 재조정.
- **이중 방어** (`conventions.md` §1.6) — 도메인 `updateDailyTarget`이 `>= 1` 강제 + V13 마이그레이션에 `CHECK daily_target >= 1`.
- **Cross-BC inbound 패턴 통일** — `resolveOnFieldBudget`(#146) / `resolveSoftScheduleTemplate`(#153) / `resolveDailyTarget`(이번) 동일 시그니처 — 미보유 유저는 `createDefault` 자동 초기화. 호출자(Review)가 분기 없이 일관 사용.

## 작업 내용

- feat(db): Flyway V13 — `ALTER TABLE user_schedule_config ADD COLUMN daily_target INT NOT NULL DEFAULT 20` + `CHECK >= 1`. 기존 row는 DEFAULT 20 자동 백필.
- feat(user-schedule): `UserScheduleConfig` — `DEFAULT_DAILY_TARGET=20` 상수 + `dailyTarget` 필드 + getter + 생성자 초기화 + `updateDailyTarget(int)` 도메인 메서드 (1 이상 강제).
- feat(user-schedule): `UserScheduleQueryService.resolveDailyTarget(userId)` — 미보유 시 createDefault.
- test(user-schedule): `UserScheduleConfigDailyTargetTest` 도메인 5건 — 기본값·갱신·예외 매트릭스.
- test(user-schedule): `UserScheduleConfigRepositorySliceTest` 1건 추가 — DB round-trip + updateDailyTarget 영속.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfigDailyTargetTest"` → BUILD SUCCESSFUL (5/5)
- `./gradlew test` → BUILD SUCCESSFUL (1m 42s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (도메인·DB·서비스만)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (BC 의존·도메인 의도 변경 없음, 기존 UserScheduleConfig 확장만)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — UserSchedule BC 내부 + 기존 Card 도메인 의존 그대로
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 6 Story 6-2 (dailyTarget 설정 및 state 비율 기반 카드 추천) — 토대 부분

## Commits in this PR

- `77dfeff` feat(user-schedule): dailyTarget 컬럼·도메인 + resolve inbound
- `346ccca` test(user-schedule): dailyTarget 도메인·슬라이스 매트릭스

## 후속 PR 예고

- **Story 6-2 알고리즘 + 응답 확장** — `ReviewQueryService.getTodayCandidates`에서 `resolveDailyTarget`을 호출해 동적 state 비율 추천 추가. `TodayCandidates` 응답에 `dailyTarget` + state별 추천 수 노출.
- **Story 6-3** — +N장 추가 학습. 동일 비율로 잔여 풀에서 확장.
- **사용자 dailyTarget 수정 API** — Story 4-3 패턴 따라 `PATCH /api/v1/user-schedule/daily-target` 등. UserScheduleCommandService 확장.