### PR TITLE
feat(review): Story 6-2 — dailyTarget × state 풀 비례 동적 추천

### DIFF
--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -8,6 +8,7 @@ import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Review.domain.model.ReviewSession;
+import com.example.thirdtool.Review.domain.model.StateRecommendationDistributor;
 import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
 import com.example.thirdtool.Review.infrastructure.dto.ReviewSessionSearchCondition;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
@@ -32,6 +33,7 @@ public class ReviewQueryService {
     private final ReviewSessionRepository reviewSessionRepository;
     private final UserScheduleQueryService userScheduleQueryService;
     private final CardRepository cardRepository;
+    private final StateRecommendationDistributor stateRecommendationDistributor;
 
     // Story-5-2: Long userId → UserEntity user 시그니처 통일.
 
@@ -110,6 +112,17 @@ public class ReviewQueryService {
                           ));
 
         int total = byState.values().stream().mapToInt(List::size).sum();
-        return new ReviewResponse.TodayCandidates(total, byState);
+
+        // Story 6-2 — 동적 비율 추천. dailyTarget × state 풀 비례 (largest remainder).
+        int dailyTarget = userScheduleQueryService.resolveDailyTarget(userId);
+        Map<SoftScheduleState, Integer> poolSizes = new EnumMap<>(SoftScheduleState.class);
+        byState.forEach((state, list) -> poolSizes.put(state, list.size()));
+        Map<SoftScheduleState, Integer> recommendedByState =
+                stateRecommendationDistributor.distribute(poolSizes, dailyTarget);
+        int recommendedTotal = recommendedByState.values().stream().mapToInt(Integer::intValue).sum();
+
+        return new ReviewResponse.TodayCandidates(
+                total, dailyTarget, recommendedTotal, recommendedByState, byState
+        );
     }
 }

--- a/src/main/java/com/example/thirdtool/Review/domain/model/StateRecommendationDistributor.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/StateRecommendationDistributor.java
@@ -1,0 +1,80 @@
+package com.example.thirdtool.Review.domain.model;
+
+import com.example.thirdtool.Card.domain.model.SoftScheduleState;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * product-card.md Epic 6 Story 6-2 — 동적 비율 추천 분배기.
+ *
+ * <p>오늘 수집된 state별 카드 수에 비례하여 사용자 {@code dailyTarget}을 배분한다.
+ * Alternative B(Spec) — 카드 풀이 비어 있는 state는 자동 0장, 풀이 적으면 풀 크기까지만.
+ *
+ * <p>알고리즘 — Largest Remainder Method (LRM)
+ * <ol>
+ *   <li>각 state share = pool_size × target / total_pool (실수)</li>
+ *   <li>floor 적용해 base allocation 산출</li>
+ *   <li>잔여 = target - sum(base)</li>
+ *   <li>분수 부분 큰 state 순으로 잔여를 1씩 추가 — 단 각 state의 풀 크기를 초과하지 않음</li>
+ * </ol>
+ *
+ * <p>경계
+ * <ul>
+ *   <li>total_pool = 0 → 빈 분배</li>
+ *   <li>dailyTarget &le; 0 → 빈 분배 (방어, 도메인은 1 이상 강제)</li>
+ *   <li>dailyTarget &gt; total_pool → 풀 전체 분배</li>
+ * </ul>
+ */
+@Component
+public class StateRecommendationDistributor {
+
+    public Map<SoftScheduleState, Integer> distribute(
+            Map<SoftScheduleState, Integer> poolSizes,
+            int dailyTarget
+                                                     ) {
+        int totalPool = poolSizes.values().stream().mapToInt(Integer::intValue).sum();
+        if (totalPool == 0 || dailyTarget <= 0) {
+            return new EnumMap<>(SoftScheduleState.class);
+        }
+        int target = Math.min(dailyTarget, totalPool);
+
+        Map<SoftScheduleState, Integer> allocation  = new EnumMap<>(SoftScheduleState.class);
+        Map<SoftScheduleState, Double>  fractionals = new EnumMap<>(SoftScheduleState.class);
+        int allocated = 0;
+
+        for (var entry : poolSizes.entrySet()) {
+            double exact = (double) entry.getValue() * target / totalPool;
+            int floor = (int) Math.floor(exact);
+            allocation.put(entry.getKey(), floor);
+            fractionals.put(entry.getKey(), exact - floor);
+            allocated += floor;
+        }
+
+        int remaining = target - allocated;
+        if (remaining > 0) {
+            // 분수 부분 큰 순서로 +1, 풀 cap 준수.
+            List<Map.Entry<SoftScheduleState, Double>> sortedByFraction = fractionals.entrySet().stream()
+                    .sorted(Map.Entry.<SoftScheduleState, Double>comparingByValue().reversed())
+                    .toList();
+
+            for (Map.Entry<SoftScheduleState, Double> entry : sortedByFraction) {
+                if (remaining <= 0) break;
+                SoftScheduleState state = entry.getKey();
+                int current = allocation.get(state);
+                int cap     = poolSizes.get(state);
+                if (current < cap) {
+                    allocation.put(state, current + 1);
+                    remaining--;
+                }
+            }
+        }
+
+        // 0 allocation은 응답에서 제외 — 의미 있는 state만 키로 유지.
+        allocation.entrySet().removeIf(e -> e.getValue() == 0);
+        return allocation;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/dto/ReviewResponse.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/dto/ReviewResponse.java
@@ -113,11 +113,18 @@ public class ReviewResponse {
         }
     }
 
-    // ─── 6. 오늘의 학습 후보 응답 (Story 6-1) ───────────────────────────────
-    // 사용자의 ON_FIELD 카드 중 soft schedule 통과 카드를 state별로 분류해 노출.
-    // NOT_YET은 응답에서 제외. byState 키는 SoftScheduleState enum (FRESH, INTERVAL_*).
+    // ─── 6. 오늘의 학습 후보 응답 (Story 6-1·6-2) ───────────────────────────
+    // - byState: 적격 풀 전체 (FE가 각 state별 카드를 모두 표시)
+    // - recommendedByState: dailyTarget × 풀 비례 분배 결과 (FE가 추천 카드 N장 take)
+    // - recommendedTotal: 실제 추천된 카드 수 (≤ dailyTarget, ≤ total)
+    // - dailyTarget: 사용자 설정 학습 목표
+    // - total: 적격 카드 전체 수
+    // NOT_YET은 응답에서 제외.
     public record TodayCandidates(
             int total,
+            int dailyTarget,
+            int recommendedTotal,
+            Map<SoftScheduleState, Integer> recommendedByState,
             Map<SoftScheduleState, List<CandidateItem>> byState
     ) {
         public record CandidateItem(

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
@@ -5,6 +5,7 @@ import com.example.thirdtool.Card.domain.model.MainNote;
 import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Review.domain.model.StateRecommendationDistributor;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Deck.domain.model.Deck;
@@ -51,7 +52,10 @@ class ReviewQueryServiceTest {
         sessionRepository        = mock(ReviewSessionRepository.class);
         userScheduleQueryService = mock(UserScheduleQueryService.class);
         cardRepository           = mock(CardRepository.class);
-        service = new ReviewQueryService(sessionRepository, userScheduleQueryService, cardRepository);
+        service = new ReviewQueryService(
+                sessionRepository, userScheduleQueryService, cardRepository,
+                new StateRecommendationDistributor()
+        );
 
         owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
         ReflectionTestUtils.setField(owner, "id", 1L);

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
@@ -7,6 +7,7 @@ import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Review.domain.model.StateRecommendationDistributor;
 import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
 import com.example.thirdtool.User.domain.model.UserEntity;
@@ -47,12 +48,18 @@ class ReviewQueryServiceTodayCandidatesTest {
         sessionRepository        = mock(ReviewSessionRepository.class);
         userScheduleQueryService = mock(UserScheduleQueryService.class);
         cardRepository           = mock(CardRepository.class);
-        service = new ReviewQueryService(sessionRepository, userScheduleQueryService, cardRepository);
+        service = new ReviewQueryService(
+                sessionRepository, userScheduleQueryService, cardRepository,
+                new StateRecommendationDistributor()
+        );
 
         user = UserEntity.ofLocal("u", "pw", "n", "u@e.com");
         ReflectionTestUtils.setField(user, "id", 1L);
         deck = Deck.createFromLearningMaterial(user, 10L, 200L, "DDD");
         ReflectionTestUtils.setField(deck, "id", 500L);
+
+        // 기본 dailyTarget stub — 각 테스트가 override 가능
+        when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(20);
     }
 
     private Card cardWith(Long id, LocalDateTime lastViewedAt) {
@@ -121,5 +128,65 @@ class ReviewQueryServiceTodayCandidatesTest {
         assertThat(item.deckId()).isEqualTo(500L);
         assertThat(item.deckName()).isEqualTo("DDD");
         assertThat(item.summary()).isEqualTo("한 문장.");
+    }
+
+    @Test
+    @DisplayName("Story 6-2 — dailyTarget=3 + 풀 FRESH:1·1D:1·7D:1 → 각 state 1장씩 권장")
+    void getTodayCandidates_recommendation_evenSmallPool() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(3);
+
+        Card fresh  = cardWith(1000L, null);
+        Card oneD   = cardWith(1001L, LocalDateTime.now().minusDays(2));
+        Card sevenD = cardWith(1002L, LocalDateTime.now().minusDays(10));
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(fresh, oneD, sevenD));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isEqualTo(3);
+        assertThat(result.dailyTarget()).isEqualTo(3);
+        assertThat(result.recommendedTotal()).isEqualTo(3);
+        assertThat(result.recommendedByState()).containsOnly(
+                org.assertj.core.api.Assertions.entry(SoftScheduleState.FRESH, 1),
+                org.assertj.core.api.Assertions.entry(SoftScheduleState.INTERVAL_1D, 1),
+                org.assertj.core.api.Assertions.entry(SoftScheduleState.INTERVAL_7D, 1)
+        );
+    }
+
+    @Test
+    @DisplayName("Story 6-2 — dailyTarget > total 이면 풀 전체 권장")
+    void getTodayCandidates_recommendation_dailyTargetExceedsPool() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(50);
+
+        Card fresh = cardWith(1000L, null);
+        Card oneD  = cardWith(1001L, LocalDateTime.now().minusDays(2));
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(fresh, oneD));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isEqualTo(2);
+        assertThat(result.recommendedTotal()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Story 6-2 — 후보 0건이면 dailyTarget 노출 + recommended 빈 분배")
+    void getTodayCandidates_noCandidates_exposesDailyTarget() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(15);
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of());
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isZero();
+        assertThat(result.dailyTarget()).isEqualTo(15);
+        assertThat(result.recommendedTotal()).isZero();
+        assertThat(result.recommendedByState()).isEmpty();
     }
 }

--- a/src/test/java/com/example/thirdtool/Review/domain/model/StateRecommendationDistributorTest.java
+++ b/src/test/java/com/example/thirdtool/Review/domain/model/StateRecommendationDistributorTest.java
@@ -1,0 +1,105 @@
+package com.example.thirdtool.Review.domain.model;
+
+import com.example.thirdtool.Card.domain.model.SoftScheduleState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * StateRecommendationDistributor — Story 6-2 분배 알고리즘.
+ *
+ * <p>Pure function 단위 테스트 — 입력 풀·dailyTarget → 출력 분배 결과 검증.
+ */
+@DisplayName("StateRecommendationDistributor — Story 6-2")
+class StateRecommendationDistributorTest {
+
+    private final StateRecommendationDistributor distributor = new StateRecommendationDistributor();
+
+    private Map<SoftScheduleState, Integer> pool(int fresh, int oneD, int sevenD) {
+        Map<SoftScheduleState, Integer> m = new EnumMap<>(SoftScheduleState.class);
+        if (fresh > 0)  m.put(SoftScheduleState.FRESH, fresh);
+        if (oneD > 0)   m.put(SoftScheduleState.INTERVAL_1D, oneD);
+        if (sevenD > 0) m.put(SoftScheduleState.INTERVAL_7D, sevenD);
+        return m;
+    }
+
+    @Test
+    @DisplayName("정확한 비례 — 풀 10·10·10 + 6 → 2·2·2")
+    void exactProportional() {
+        Map<SoftScheduleState, Integer> result = distributor.distribute(pool(10, 10, 10), 6);
+
+        assertThat(result).containsOnly(
+                entry(SoftScheduleState.FRESH, 2),
+                entry(SoftScheduleState.INTERVAL_1D, 2),
+                entry(SoftScheduleState.INTERVAL_7D, 2)
+        );
+    }
+
+    @Test
+    @DisplayName("largest remainder — 풀 3·3·4 + 5 → 1·1·2 (4쪽 분수 큼 +1)")
+    void largestRemainderBoosts() {
+        Map<SoftScheduleState, Integer> result = distributor.distribute(pool(3, 3, 4), 5);
+
+        // FRESH/1D: 3*5/10 = 1.5, 7D: 4*5/10 = 2.0
+        // base: 1, 1, 2 (sum=4, remaining=1) → 분수 가장 큰 FRESH/1D 중 하나에 +1 (둘 다 0.5)
+        // EnumMap 순회 순서가 결정적: FRESH 먼저 → FRESH=2
+        assertThat(result.values().stream().mapToInt(Integer::intValue).sum()).isEqualTo(5);
+        assertThat(result.get(SoftScheduleState.INTERVAL_7D)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("풀 부족 — 풀 2·1 + dailyTarget 10 → 풀 전체 2·1 분배")
+    void poolSmallerThanTarget() {
+        Map<SoftScheduleState, Integer> result = distributor.distribute(pool(2, 1, 0), 10);
+
+        assertThat(result).containsOnly(
+                entry(SoftScheduleState.FRESH, 2),
+                entry(SoftScheduleState.INTERVAL_1D, 1)
+        );
+    }
+
+    @Test
+    @DisplayName("특정 state 풀 0 — 빈 state는 0장 분배 (응답에서 제외)")
+    void zeroPoolStateExcluded() {
+        Map<SoftScheduleState, Integer> result = distributor.distribute(pool(5, 0, 5), 4);
+
+        assertThat(result).containsOnly(
+                entry(SoftScheduleState.FRESH, 2),
+                entry(SoftScheduleState.INTERVAL_7D, 2)
+        );
+        assertThat(result).doesNotContainKey(SoftScheduleState.INTERVAL_1D);
+    }
+
+    @Test
+    @DisplayName("총 풀 0 → 빈 분배")
+    void emptyPool() {
+        Map<SoftScheduleState, Integer> result = distributor.distribute(new EnumMap<>(SoftScheduleState.class), 20);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("dailyTarget 0 또는 음수 → 빈 분배 (방어)")
+    void nonPositiveTarget() {
+        assertThat(distributor.distribute(pool(5, 5, 0), 0)).isEmpty();
+        assertThat(distributor.distribute(pool(5, 5, 0), -3)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("불균형 풀 — 100·1·1 + 10 → FRESH 10 (분수 압도적, 0 state는 응답 제외)")
+    void unbalancedPool_dominantStateAbsorbsAll() {
+        Map<SoftScheduleState, Integer> result = distributor.distribute(pool(100, 1, 1), 10);
+
+        // FRESH: 100*10/102 ≈ 9.80 (floor 9, fraction 0.80) — 분수 최대
+        // 1D/7D: 1*10/102 ≈ 0.098 (floor 0) — 분수 작음
+        // base=9, remaining=1 → 분수 큰 FRESH +1 → FRESH=10
+        // 0 allocation은 응답에서 제외 → FRESH만 남음
+        assertThat(result.values().stream().mapToInt(Integer::intValue).sum()).isEqualTo(10);
+        assertThat(result).containsOnly(entry(SoftScheduleState.FRESH, 10));
+    }
+}


### PR DESCRIPTION
## 개요

product-card.md Epic 6 Story 6-2 — 직전 PR(#154)의 `dailyTarget` 토대를 이어받아 `ReviewQueryService.getTodayCandidates`가 **state별 풀 크기 비례**로 `dailyTarget`을 분배하고 추천 결과를 응답에 노출한다. 분배는 Largest Remainder Method(LRM)로 정수 보정.

## 왜 / 설계 결정

- **Spec Alternative B 채택** — 동적 비율(오늘 수집된 state 풀 비례). 기각: 고정 비율(1:1:1) — state별 풀 불균형 시 풀 부족 state에서 0장 처리하는 안전망이 도메인적으로 자연스러움.
- **Largest Remainder Method** — 단순 floor만 적용하면 합이 부족(예: 풀 10·10·10 + 6 → 2·2·2 OK, 풀 3·3·4 + 5 → 1·1·2 분수 보정 필요). 분수 부분 큰 state에 +1씩 분배해 정확한 dailyTarget 충족. 풀 cap 준수로 풀보다 큰 분배 차단.
- **별도 도메인 서비스로 분리** — `Review/domain/model/StateRecommendationDistributor`. Pure function(Map → Map)이라 도메인 테스트가 간단하고, Application Service는 조율만 담당. v2에서 알고리즘 교체(AI 기반 가중 등) 시 Distributor 1곳만 교체.
- **0 allocation 제외** — `byState`는 전체 풀이지만 `recommendedByState`는 0장 분배된 state를 응답에서 제외. FE가 의미 있는 state만 표시.
- **DTO 확장 방향** — 기존 `byState`(전체 풀) 유지 + `recommendedByState` / `recommendedTotal` / `dailyTarget` 신규 필드. FE는 적격 풀 전체를 보여주거나(byState) 추천만 보여주거나(앞에서 N장 take) 자유 선택.

## 작업 내용

- feat(review): `Review/domain/model/StateRecommendationDistributor`(Component) — `distribute(poolSizes, dailyTarget) → Map<SoftScheduleState, Integer>`. LRM + 풀 cap + 비양수 target 방어 + 0 allocation 자동 제외.
- feat(review): `ReviewQueryService.getTodayCandidates` 확장 — `resolveDailyTarget` 호출 + 풀 Map → distributor → recommendedByState 산출 + recommendedTotal 합산.
- feat(review): `ReviewResponse.TodayCandidates` 확장 — `dailyTarget`, `recommendedTotal`, `recommendedByState` 필드 추가. `byState`는 그대로 유지.
- test(review): `StateRecommendationDistributorTest`(도메인 단위, 7건) — 정비례 / LRM 분수 보정 / 풀 부족 / 빈 state / 빈 풀 / 비양수 target / 불균형 풀.
- test(review): `ReviewQueryServiceTodayCandidatesTest` 3건 추가 — dailyTarget=풀 정확 매칭 / dailyTarget > 풀 / 후보 0건도 dailyTarget 노출.
- chore(test): 기존 `ReviewQueryServiceTest` 생성자에 `distributor` 추가.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Review.domain.model.StateRecommendationDistributorTest"` → BUILD SUCCESSFUL (7/7)
- `./gradlew test --tests "com.example.thirdtool.Review.application.ReviewQueryServiceTodayCandidatesTest"` → BUILD SUCCESSFUL (6/6, 기존 3 + 추가 3)
- `./gradlew test` → BUILD SUCCESSFUL (1m 41s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (Review BC 내부 도메인 서비스 신설만, BC 의존 변경 없음)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Review BC 내부 + 기존 Card·UserSchedule 의존 그대로
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 6 / Story 6-2 (dailyTarget 설정 및 state 비율 기반 카드 추천) — 알고리즘 완료

## Commits in this PR

- `feat(review): Story 6-2 — dailyTarget × state 풀 비례 동적 추천`

## 후속 PR 예고

- **Story 6-3** — +N장 추가 학습. 잔여 후보(byState - recommendedByState)에서 동일 비율로 +10장 확장. distributor 재사용 가능.
- **사용자 dailyTarget 수정 API** — Story 4-3 패턴 따라 `PATCH /api/v1/user-schedule/daily-target`.
- **Layer 1 한정 필터링** — LearningFacade BC 의존 추가.