### PR TITLE
feat(review): Story 6-3 — +N장 추가 학습 (target override)

### DIFF
--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -89,6 +89,19 @@ public class ReviewQueryService {
     // (Spec 6-1 엣지 케이스 "Layer 1 미설정 유저" 경로 그대로).
 
     public ReviewResponse.TodayCandidates getTodayCandidates(UserEntity user) {
+        return collectToday(user, userScheduleQueryService.resolveDailyTarget(user.getId()));
+    }
+
+    /**
+     * Story 6-3 — "+N장 추가 학습". 동일 풀에 대해 target만 다르게 적용해 분배를 재계산한다.
+     * 호출자(FE)는 이미 표시된 카드 수 + 확장 N장을 합해 target으로 전달한다 (stateless).
+     * 응답 {@code recommendedTotal}이 target보다 작으면 풀 소진 — "오늘 학습 완료" 안내 가능.
+     */
+    public ReviewResponse.TodayCandidates getTodayCandidatesWithTarget(UserEntity user, int target) {
+        return collectToday(user, target);
+    }
+
+    private ReviewResponse.TodayCandidates collectToday(UserEntity user, int effectiveTarget) {
         Long userId = user.getId();
         SoftScheduleTemplate template = userScheduleQueryService.resolveSoftScheduleTemplate(userId);
 
@@ -113,12 +126,13 @@ public class ReviewQueryService {
 
         int total = byState.values().stream().mapToInt(List::size).sum();
 
-        // Story 6-2 — 동적 비율 추천. dailyTarget × state 풀 비례 (largest remainder).
+        // 응답의 dailyTarget은 사용자 설정 값(원래값) — 추천이 그 값을 따랐는지는 recommendedTotal로 판단.
         int dailyTarget = userScheduleQueryService.resolveDailyTarget(userId);
+
         Map<SoftScheduleState, Integer> poolSizes = new EnumMap<>(SoftScheduleState.class);
         byState.forEach((state, list) -> poolSizes.put(state, list.size()));
         Map<SoftScheduleState, Integer> recommendedByState =
-                stateRecommendationDistributor.distribute(poolSizes, dailyTarget);
+                stateRecommendationDistributor.distribute(poolSizes, effectiveTarget);
         int recommendedTotal = recommendedByState.values().stream().mapToInt(Integer::intValue).sum();
 
         return new ReviewResponse.TodayCandidates(

--- a/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
@@ -6,16 +6,19 @@ import com.example.thirdtool.Review.presentation.dto.ReviewRequest;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class ReviewController {
 
     private final ReviewCommandService reviewCommandService;
@@ -68,12 +71,17 @@ public class ReviewController {
         return ResponseEntity.ok(reviewQueryService.searchSessions(deckId, currentUser));
     }
 
-    // ─── 6. 오늘의 학습 후보 (Story 6-1) ────────────────────
+    // ─── 6. 오늘의 학습 후보 (Story 6-1·6-2·6-3) ──────────
     // 사용자의 ON_FIELD + soft schedule 통과 카드를 state별 분류해 반환.
+    // target 미입력 시 사용자 dailyTarget 사용. target 입력 시 그 값으로 분배(Story 6-3 "+N장").
     @GetMapping("/api/v1/review-session/today")
     public ResponseEntity<ReviewResponse.TodayCandidates> getTodayCandidates(
-            @AuthenticationPrincipal UserEntity currentUser
+            @AuthenticationPrincipal UserEntity currentUser,
+            @RequestParam(required = false) @Min(1) Integer target
                                                                             ) {
-        return ResponseEntity.ok(reviewQueryService.getTodayCandidates(currentUser));
+        ReviewResponse.TodayCandidates response = (target == null)
+                ? reviewQueryService.getTodayCandidates(currentUser)
+                : reviewQueryService.getTodayCandidatesWithTarget(currentUser, target);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
@@ -174,6 +174,48 @@ class ReviewQueryServiceTodayCandidatesTest {
     }
 
     @Test
+    @DisplayName("Story 6-3 — target override (+10장) — 분배가 override 값을 따른다")
+    void getTodayCandidatesWithTarget_overridesDailyTarget() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        // dailyTarget=20이 stub되어 있지만 명시 target은 그를 무시한다
+        when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(20);
+
+        // 풀 5장 — target=30이면 풀 cap으로 5장만 분배되고, target=3이면 3장만 분배되어야 함
+        Card c1 = cardWith(1001L, null);
+        Card c2 = cardWith(1002L, null);
+        Card c3 = cardWith(1003L, LocalDateTime.now().minusDays(2));
+        Card c4 = cardWith(1004L, LocalDateTime.now().minusDays(2));
+        Card c5 = cardWith(1005L, LocalDateTime.now().minusDays(10));
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(c1, c2, c3, c4, c5));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidatesWithTarget(user, 3);
+
+        assertThat(result.total()).isEqualTo(5);
+        assertThat(result.dailyTarget()).isEqualTo(20);   // 사용자 설정 그대로 노출
+        assertThat(result.recommendedTotal()).isEqualTo(3); // target=3 적용
+    }
+
+    @Test
+    @DisplayName("Story 6-3 — target이 풀보다 크면 풀 전체만 분배 + recommendedTotal < target")
+    void getTodayCandidatesWithTarget_poolSmallerThanTarget() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(20);
+
+        Card c1 = cardWith(1001L, null);
+        Card c2 = cardWith(1002L, null);
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(c1, c2));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidatesWithTarget(user, 30);
+
+        assertThat(result.total()).isEqualTo(2);
+        assertThat(result.recommendedTotal()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("Story 6-2 — 후보 0건이면 dailyTarget 노출 + recommended 빈 분배")
     void getTodayCandidates_noCandidates_exposesDailyTarget() {
         when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))


### PR DESCRIPTION
## 개요

product-card.md Epic 6 Story 6-3 — 사용자가 dailyTarget 소진 후 "+10장" 액션으로 잔여 풀에서 동일 비율 추가 학습이 가능하도록 `GET /api/v1/review-session/today`에 `target` 쿼리 파라미터를 노출. distributor는 기존 PR(#155) 그대로 재사용.

## 왜 / 설계 결정

- **Stateless 설계** — 서버가 "오늘 추천한 카드" 상태를 보유하지 않는다. 클라이언트가 (이미 표시한 카드 수 + 확장 N) 합산해 `target`으로 전달하면 서버는 동일 풀에서 그 수만큼 분배 재계산. 동일 입력 → 동일 출력 멱등.
- **메서드 분리 vs 단일 nullable** — 두 메서드(`getTodayCandidates(user)` / `getTodayCandidatesWithTarget(user, target)`) 분리. API 의도가 코드에 명확히 드러나고 호출자 코드가 분기 없이 깨끗. 공통 로직은 내부 `collectToday` 헬퍼로 1곳에서 처리.
- **응답의 `dailyTarget` 의미 고정** — 항상 사용자 설정 값을 노출. target override가 들어와도 `dailyTarget`은 사용자 원래값. `recommendedTotal`이 보낸 target보다 작으면 풀 소진(= Spec "오늘 학습 완료" 안내) 시그널.
- **`@Min(1)` 검증** — `@Validated` 클래스 + `@RequestParam @Min(1) Integer target`. distributor가 비양수 방어를 갖추긴 했지만 BE 진입점에서 1차 검증으로 잘못된 요청 차단.

## 작업 내용

- feat(review): `ReviewQueryService` 메서드 분리 — `getTodayCandidates(user)` / `getTodayCandidatesWithTarget(user, target)` / 내부 `collectToday(user, effectiveTarget)` 헬퍼.
- feat(review): `ReviewController` `@Validated` + `getTodayCandidates`에 `@RequestParam(required=false) @Min(1) Integer target` 추가. 미입력은 기존 동작.
- test(review): `ReviewQueryServiceTodayCandidatesTest` 2건 추가 — target override 적용 / target > 풀 시 풀 cap.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.Review.application.ReviewQueryServiceTodayCandidatesTest"` → BUILD SUCCESSFUL (8/8, 기존 6 + 추가 2)
- `./gradlew test` → BUILD SUCCESSFUL (1m 30s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (기존 엔드포인트 확장만)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Review BC 내부 + 기존 의존 그대로
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 6 / Story 6-3 (+N장 추가 학습 — 동일 비율 확장)

## Commits in this PR

- `1a890ec` feat(review): Story 6-3 — +N장 추가 학습 (target override)

## 후속 PR 예고

- **사용자 dailyTarget 수정 API** — `UserScheduleCommandService.updateDailyTarget` + `PATCH /api/v1/user-schedule/daily-target`. Story 4-3 패턴 따라.
- **Layer 1 한정 필터링** — LearningFacade BC 의존 추가. Repository에 user→facade→axis→topic→material→deck→card 경로 또는 단순화된 user_id+layer1_id 쿼리. Epic 6 마무리.
- **Epic 8 — UI 문구 정책 문서**(`docs/ux/wip-language.md`). BE 영향 없는 docs-only PR.