### PR TITLE
feat(user-schedule): dailyTarget 수정 API + 응답 노출 [Story-6-2/6-3]

### DIFF
--- a/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandService.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandService.java
@@ -25,7 +25,27 @@ public class UserScheduleCommandService {
                                .orElseGet(() -> create(userId, inputDays));
     }
 
+    /**
+     * Story 6-3 후속 — 사용자 dailyTarget 갱신. 미보유 유저는 기본 모드(MODE_10D)로 자동 생성한 뒤
+     * dailyTarget만 갱신한다. dailyTarget 변경 자체는 v1에서 mode 이력에 기록하지 않는다
+     * (mode/inputDays 변경 이력만 추적 — Spec Story 4-2 §3).
+     */
+    public UserScheduleResponse.Save updateDailyTarget(Long userId, int newDailyTarget) {
+        UserScheduleConfig config = configRepository.findByUserId(userId)
+                                                    .orElseGet(() -> createDefault(userId));
+        config.updateDailyTarget(newDailyTarget);
+        configRepository.save(config);
+        return UserScheduleResponse.Save.of(config);
+    }
+
     // ─── 내부 처리 ───────────────────────────────────────────────
+
+    private UserScheduleConfig createDefault(Long userId) {
+        UserScheduleConfig config = UserScheduleConfig.createDefault(userId, mappingPolicy);
+        configRepository.save(config);
+        historyAppender.append(config, null, config.getMappedMode(), config.getRawInputDays());
+        return config;
+    }
     private UserScheduleResponse.Save update(UserScheduleConfig config, int newInputDays) {
         LearningMode before = config.getMappedMode();
 

--- a/src/main/java/com/example/thirdtool/UserSchedule/presentation/UserScheduleController.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/presentation/UserScheduleController.java
@@ -49,6 +49,17 @@ public class UserScheduleController {
         return ResponseEntity.ok(queryService.getHistory(userId, limit));
     }
 
+    // ─── 4. 하루 학습 목표 수정 (Story 6-2/6-3) ──────────────────
+    @PatchMapping("/daily-target")
+    public ResponseEntity<UserScheduleResponse.Save> updateDailyTarget(
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody UserScheduleRequest.UpdateDailyTarget request
+                                                                      ) {
+        return ResponseEntity.ok(
+                commandService.updateDailyTarget(userId, request.dailyTarget())
+        );
+    }
+
     // ─── 내부 유틸 ───────────────────────────────────────────────
 
     private void validateInputDays(int inputDays) {

--- a/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleRequest.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleRequest.java
@@ -1,5 +1,6 @@
 package com.example.thirdtool.UserSchedule.presentation.dto;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public class UserScheduleRequest {
@@ -11,5 +12,14 @@ public class UserScheduleRequest {
 
     public record HistoryQuery(
             Integer limit
+    ) {}
+
+    /**
+     * Story 6-2/6-3 — 하루 학습 목표 카드 수 수정 요청.
+     */
+    public record UpdateDailyTarget(
+            @NotNull(message = "dailyTarget은 필수입니다.")
+            @Min(value = 1, message = "dailyTarget은 1 이상이어야 합니다.")
+            Integer dailyTarget
     ) {}
 }

--- a/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleResponse.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleResponse.java
@@ -78,6 +78,7 @@ public class UserScheduleResponse {
             String modeDisplayName,
             int maxView,
             int maxDuration,
+            int dailyTarget,
             List<Integer> softScheduleIntervals
     ) {
         public static ScheduleDto of(UserScheduleConfig config) {
@@ -95,6 +96,7 @@ public class UserScheduleResponse {
                     mode.getDisplayName(),
                     mode.getMaxView(),
                     mode.getDurationDays(),
+                    config.getDailyTarget(),
                     intervals
             );
         }

--- a/src/test/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandServiceUpdateDailyTargetTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandServiceUpdateDailyTargetTest.java
@@ -1,0 +1,94 @@
+package com.example.thirdtool.UserSchedule.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.UserSchedule.domain.exception.UserScheduleDomainException;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import com.example.thirdtool.UserSchedule.domain.model.LearningModeMappingPolicy;
+import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfig;
+import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfigHistoryAppender;
+import com.example.thirdtool.UserSchedule.infrastructure.persistence.UserScheduleConfigRepository;
+import com.example.thirdtool.UserSchedule.presentation.dto.UserScheduleResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * UserScheduleCommandService.updateDailyTarget — Story 6-2/6-3 매트릭스.
+ */
+@DisplayName("UserScheduleCommandService — updateDailyTarget (Story 6-2/6-3)")
+class UserScheduleCommandServiceUpdateDailyTargetTest {
+
+    private UserScheduleConfigRepository configRepository;
+    private UserScheduleConfigHistoryAppender historyAppender;
+    private LearningModeMappingPolicy mappingPolicy;
+    private UserScheduleCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        configRepository = mock(UserScheduleConfigRepository.class);
+        historyAppender  = mock(UserScheduleConfigHistoryAppender.class);
+        mappingPolicy    = new LearningModeMappingPolicy();
+        service = new UserScheduleCommandService(configRepository, historyAppender, mappingPolicy);
+
+        // save가 호출되면 그대로 반환
+        when(configRepository.save(any(UserScheduleConfig.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("기존 설정 보유: dailyTarget 갱신 + 저장 + history 미발생(mode 미변경)")
+    void updateDailyTarget_existing_updates_noHistory() {
+        UserScheduleConfig config = UserScheduleConfig.create(1L, 10, mappingPolicy);
+        when(configRepository.findByUserId(eq(1L))).thenReturn(Optional.of(config));
+
+        UserScheduleResponse.Save response = service.updateDailyTarget(1L, 35);
+
+        assertThat(config.getDailyTarget()).isEqualTo(35);
+        assertThat(response.schedule().dailyTarget()).isEqualTo(35);
+        verify(configRepository, times(1)).save(config);
+        // mode 변경이 없으므로 history 미발생
+        verify(historyAppender, never()).append(any(), any(), any(), any() == null ? 0 : 0);
+    }
+
+    @Test
+    @DisplayName("미보유 사용자: createDefault 후 dailyTarget만 갱신 + 초기 생성 history 1건")
+    void updateDailyTarget_missing_createsDefault_thenUpdates() {
+        when(configRepository.findByUserId(eq(2L))).thenReturn(Optional.empty());
+
+        UserScheduleResponse.Save response = service.updateDailyTarget(2L, 50);
+
+        assertThat(response.schedule().dailyTarget()).isEqualTo(50);
+        assertThat(response.schedule().mappedMode()).isEqualTo(LearningMode.MODE_10D.name());
+        // createDefault에서 1회, updateDailyTarget 부분에서 추가 save 1회 → 총 2회
+        verify(configRepository, times(2)).save(any(UserScheduleConfig.class));
+        // 초기 생성 history만 1회 (dailyTarget 변경 자체는 mode history 미생성)
+        verify(historyAppender, times(1)).append(any(), eq(null), eq(LearningMode.MODE_10D), eq(10));
+    }
+
+    @Test
+    @DisplayName("dailyTarget 0/음수는 도메인이 INVALID_INPUT 예외 + repository.save 호출 안 됨")
+    void updateDailyTarget_invalid_throwsAndNoSave() {
+        UserScheduleConfig config = UserScheduleConfig.create(1L, 10, mappingPolicy);
+        when(configRepository.findByUserId(eq(1L))).thenReturn(Optional.of(config));
+
+        assertThatThrownBy(() -> service.updateDailyTarget(1L, 0))
+                .isInstanceOf(UserScheduleDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        // 도메인 예외가 save 전에 발생 → repository.save 미호출
+        verify(configRepository, never()).save(config);
+    }
+}


### PR DESCRIPTION
## 개요

product-card.md Epic 6 Story 6-2/6-3 후속 — 사용자가 학습 목표 카드 수(`dailyTarget`)를 직접 조정할 수 있는 `PATCH /api/v1/users/me/schedule/daily-target` 추가. `ScheduleDto`에 `dailyTarget` 필드를 추가해 GET·PUT·PATCH 모든 응답에서 현재값 확인 가능.

## 왜 / 설계 결정

- **별도 PATCH 엔드포인트** — 기존 `PUT /users/me/schedule`는 mode(`inputDays`) 전체 갱신 시맨틱이라 `dailyTarget`만 변경하기엔 시그니처 충돌. PATCH로 부분 갱신 표현이 깔끔.
- **mode history 미생성** — `UserScheduleConfigHistory`는 mode/inputDays 변경 이력이 핵심. `dailyTarget`은 같은 모드 안에서의 미세 조정이라 v1 이력 미기록. (필요 시 v2에서 별도 history 테이블 또는 컬럼 추가)
- **미보유 사용자 자동 생성** — `createDefault`로 MODE_10D 생성 후 `dailyTarget`만 추가 갱신. 초기 생성 history 1건은 정상 기록(`from=null, to=MODE_10D`).
- **`@RequestHeader X-User-Id`** — 기존 컨트롤러와 일관성 유지. `@AuthenticationPrincipal`로의 마이그레이션은 별도 정합 작업.
- **`ScheduleDto.dailyTarget` 노출** — additive change. 기존 호출자 영향 없음. FE가 현재 설정값을 한 화면에서 확인 가능 (mode + dailyTarget).

## 작업 내용

- feat(user-schedule): `UserScheduleCommandService.updateDailyTarget(userId, newDailyTarget)`.
  - 보유: 도메인 `updateDailyTarget` 호출 + save. mode 미변경 → history 미발생.
  - 미보유: `createDefault`(MODE_10D)로 자동 생성 → 추가 save로 dailyTarget 갱신.
- feat(user-schedule): `UserScheduleRequest.UpdateDailyTarget` record(`@NotNull @Min(1)`).
- feat(user-schedule): `UserScheduleController PATCH /api/v1/users/me/schedule/daily-target`.
- feat(user-schedule): `UserScheduleResponse.ScheduleDto`에 `dailyTarget` 필드 추가.
- test(user-schedule): `UserScheduleCommandServiceUpdateDailyTargetTest` (Mockist, 3건) — 보유 갱신 / 미보유 자동 생성 / 도메인 검증 실패 시 save 미발생.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.UserSchedule.application.service.UserScheduleCommandServiceUpdateDailyTargetTest"` → BUILD SUCCESSFUL (3/3)
- `./gradlew test` → BUILD SUCCESSFUL (1m 30s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (기존 record 직접 반환 유지)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (UserSchedule BC 내부 확장, 의존 변경 없음)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — UserSchedule BC 내부
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 6 Story 6-2/6-3 — dailyTarget 수정 API

## Commits in this PR

- `0b310fd` feat(user-schedule): dailyTarget 수정 API + 응답 노출

## 후속 PR 예고

- **Layer 1 한정 필터링** — LearningFacade BC 의존 추가. Spec 6-1 정상 경로 구현 (LearningFacade 보유 사용자는 Layer 1 안의 카드만, 미보유는 전체 카드 fallback).
- **Epic 8 — UI 문구 정책 문서** (`docs/ux/wip-language.md`). docs-only.