### PR TITLE
feat(review): Story 6-1 정상 경로 — Layer 1 한정 카드 후보 (Review → LearningFacade)

### DIFF
--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -192,6 +192,7 @@ public LearningFacadeResponse.UpdateAxisName updateAxisName(
 | `Deck → User` (`UserEntity` 참조) | ✅ | Deck이 소유 유저 보유 |
 | `Review → Card, Deck` | ✅ | ReviewSession이 카드를 순회 (ID 참조 권장, Aggregate 직접 포함 지양) |
 | `Review → UserSchedule` (Application 경유 read) | ✅ | `ReviewCommandService` / `ReviewQueryService`가 `UserScheduleQueryService.resolveOnFieldBudget(userId)`를 호출해 사용자별 maxView/maxDuration을 매 호출 주입(Story 2-1/2-3, Epic 4 합류). UserSchedule 엔티티는 BC 경계 밖으로 노출하지 않고 `OnFieldBudget`(Card 도메인 VO)만 반환 |
+| `Review → LearningFacade` (Application 경유 read) | ✅ | `ReviewQueryService.getTodayCandidates`가 `LearningFacadeQueryService.findAxisIdsByUserId(userId)`를 호출해 사용자 Layer 1(직업 컨셉) 안의 axes 범위로 카드 후보를 한정한다(Story 6-1). LearningFacade 엔티티는 BC 경계 밖으로 노출하지 않고 axis ID 리스트만 반환. 미보유 사용자는 빈 리스트 → 전체 카드 fallback |
 | `Deck → LearningFacade` (이벤트 import) | ✅ | `LearningMaterialCreatedEvent` / `LearningMaterialDeletedEvent` 수신 — 동기 도메인 이벤트 협력 ([ADR007](adr/ADR007.md)) |
 | `LearningFacade → Deck` (Application 경유 read) | ✅ | `LearningFacadeQueryService`가 `DeckQueryService.findByAxisIds(...)` 호출 — facade 응답의 축별 linkedDecks 매핑(Story-005-2). **Repository 직접 호출 금지** — Application Service 경유만. presentation DTO(`AxisItem.linkedDecks`, `DeckItem`)는 Deck 도메인 객체 import 허용 |
 | `Card → Deck` 도메인 행위 호출 | ✅ | `CardCommandService` / `ReviewCommandService`가 카드 추가/archive 후 `deck.markInProgress()` / `recalculateProgressStatus()` 호출 (Story-005-2). Card 도메인 자체는 Deck 상태를 직접 변경하지 않음 |

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -116,4 +116,23 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
             @Param("userId") Long userId,
             @Param("threshold") java.time.LocalDateTime threshold
                                           );
+
+    /**
+     * Story 6-1 Layer 1 한정 — 사용자의 LearningFacade(Layer 1)에 속한 axes에 연결된 Deck의
+     * ON_FIELD 활성 카드만 반환. axisIds 빈 입력은 Port/Adapter에서 단락(빈 리스트 반환).
+     */
+    @Query("""
+            SELECT c FROM Card c
+            JOIN FETCH c.deck d
+            WHERE d.user.id = :userId
+              AND d.axisId IN :axisIds
+              AND c.status = com.example.thirdtool.Card.domain.model.CardStatus.ON_FIELD
+              AND c.deleted = false
+              AND (c.lastViewedAt IS NULL OR c.lastViewedAt <= :threshold)
+            """)
+    List<Card> findOnFieldEligibleByUserIdAndAxisIds(
+            @Param("userId") Long userId,
+            @Param("threshold") java.time.LocalDateTime threshold,
+            @Param("axisIds") List<Long> axisIds
+                                                    );
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
@@ -52,6 +52,12 @@ public interface CardRepository {
     List<Card> findOnFieldEligibleByUserId(Long userId, LocalDateTime threshold);
 
     /**
+     * Story 6-1 Layer 1 한정 — 사용자의 LearningFacade에 속한 axes에 연결된 Deck 한정 후보.
+     * axisIds null/빈 입력은 Adapter에서 빈 리스트로 단락.
+     */
+    List<Card> findOnFieldEligibleByUserIdAndAxisIds(Long userId, LocalDateTime threshold, List<Long> axisIds);
+
+    /**
      * ON_FIELD 만료 배치용 카드 조회.
      * 주어진 CardStatus를 가진 활성 카드 목록을 반환한다.
      */

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
@@ -84,4 +84,11 @@ public class CardRepositoryAdapter implements CardRepository {
         return cardJpaRepository.findOnFieldEligibleByUserId(userId, threshold);
     }
 
+    @Override
+    public List<Card> findOnFieldEligibleByUserIdAndAxisIds(
+            Long userId, LocalDateTime threshold, List<Long> axisIds) {
+        if (axisIds == null || axisIds.isEmpty()) return List.of();
+        return cardJpaRepository.findOnFieldEligibleByUserIdAndAxisIds(userId, threshold, axisIds);
+    }
+
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryService.java
@@ -31,6 +31,24 @@ public class LearningFacadeQueryService {
     private final TopicMaterialRepository topicMaterialRepository;
     private final DeckQueryService deckQueryService;
 
+    /**
+     * Cross-BC inbound (Story 6-1 Layer 1 한정) — 사용자 LearningFacade가 보유한 모든 axis ID를 반환.
+     *
+     * <p>Review BC가 오늘 학습 후보 수집 시 Layer 1(사용자 직업 컨셉) 범위로 카드를 좁히기 위해 호출한다.
+     * 사용자에게 LearningFacade가 아예 없으면 빈 리스트 — 호출 측은 fallback으로 사용자 전체 카드를 본다
+     * (Spec 6-1 엣지 케이스).
+     *
+     * <p>도메인 행위 메서드(LearningFacade)를 노출하지 않고 ID 리스트만 반환해 BC 경계 유지.
+     */
+    @Transactional(readOnly = true)
+    public List<Long> findAxisIdsByUserId(Long userId) {
+        return facadeRepository.findByUserId(userId)
+                .map(facade -> facade.getAxes().stream()
+                        .map(LearningAxis::getId)
+                        .toList())
+                .orElseGet(List::of);
+    }
+
     @Transactional(readOnly = true)
     public FacadeDetail getFacade(LearningFacadeQuery.GetFacade query) {
         LearningFacade facade = facadeRepository.findByUserId(query.userId())

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -7,6 +7,7 @@ import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
 import com.example.thirdtool.Review.domain.model.ReviewSession;
 import com.example.thirdtool.Review.domain.model.StateRecommendationDistributor;
 import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
@@ -34,6 +35,7 @@ public class ReviewQueryService {
     private final UserScheduleQueryService userScheduleQueryService;
     private final CardRepository cardRepository;
     private final StateRecommendationDistributor stateRecommendationDistributor;
+    private final LearningFacadeQueryService learningFacadeQueryService;
 
     // Story-5-2: Long userId → UserEntity user 시그니처 통일.
 
@@ -108,7 +110,12 @@ public class ReviewQueryService {
         Duration minInterval = template.getIntervalSteps().get(0).minDuration();
         LocalDateTime threshold = LocalDateTime.now().minus(minInterval);
 
-        List<Card> candidates = cardRepository.findOnFieldEligibleByUserId(userId, threshold);
+        // Story 6-1 Layer 1 한정: 사용자의 LearningFacade(직업 컨셉) 안의 axes 범위로만 수집.
+        // LearningFacade 미보유 사용자는 axisIds 빈 리스트 → 전체 카드 fallback (Spec 6-1 엣지 케이스).
+        List<Long> axisIds = learningFacadeQueryService.findAxisIdsByUserId(userId);
+        List<Card> candidates = axisIds.isEmpty()
+                ? cardRepository.findOnFieldEligibleByUserId(userId, threshold)
+                : cardRepository.findOnFieldEligibleByUserIdAndAxisIds(userId, threshold, axisIds);
 
         Map<SoftScheduleState, List<ReviewResponse.TodayCandidates.CandidateItem>> byState =
                 candidates.stream()

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
@@ -5,6 +5,7 @@ import com.example.thirdtool.Card.domain.model.MainNote;
 import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
 import com.example.thirdtool.Review.domain.model.StateRecommendationDistributor;
 import com.example.thirdtool.Common.Exception.BusinessException;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
@@ -54,7 +55,8 @@ class ReviewQueryServiceTest {
         cardRepository           = mock(CardRepository.class);
         service = new ReviewQueryService(
                 sessionRepository, userScheduleQueryService, cardRepository,
-                new StateRecommendationDistributor()
+                new StateRecommendationDistributor(),
+                mock(LearningFacadeQueryService.class)
         );
 
         owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
@@ -7,6 +7,7 @@ import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
 import com.example.thirdtool.Review.domain.model.StateRecommendationDistributor;
 import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
@@ -38,6 +39,7 @@ class ReviewQueryServiceTodayCandidatesTest {
     private ReviewSessionRepository sessionRepository;
     private UserScheduleQueryService userScheduleQueryService;
     private CardRepository cardRepository;
+    private LearningFacadeQueryService learningFacadeQueryService;
     private ReviewQueryService service;
 
     private UserEntity user;
@@ -45,12 +47,14 @@ class ReviewQueryServiceTodayCandidatesTest {
 
     @BeforeEach
     void setUp() {
-        sessionRepository        = mock(ReviewSessionRepository.class);
-        userScheduleQueryService = mock(UserScheduleQueryService.class);
-        cardRepository           = mock(CardRepository.class);
+        sessionRepository           = mock(ReviewSessionRepository.class);
+        userScheduleQueryService    = mock(UserScheduleQueryService.class);
+        cardRepository              = mock(CardRepository.class);
+        learningFacadeQueryService  = mock(LearningFacadeQueryService.class);
         service = new ReviewQueryService(
                 sessionRepository, userScheduleQueryService, cardRepository,
-                new StateRecommendationDistributor()
+                new StateRecommendationDistributor(),
+                learningFacadeQueryService
         );
 
         user = UserEntity.ofLocal("u", "pw", "n", "u@e.com");
@@ -60,6 +64,8 @@ class ReviewQueryServiceTodayCandidatesTest {
 
         // 기본 dailyTarget stub — 각 테스트가 override 가능
         when(userScheduleQueryService.resolveDailyTarget(eq(1L))).thenReturn(20);
+        // 기본 — LearningFacade 미보유로 fallback 경로 (기존 테스트 호환)
+        when(learningFacadeQueryService.findAxisIdsByUserId(eq(1L))).thenReturn(List.of());
     }
 
     private Card cardWith(Long id, LocalDateTime lastViewedAt) {
@@ -213,6 +219,46 @@ class ReviewQueryServiceTodayCandidatesTest {
 
         assertThat(result.total()).isEqualTo(2);
         assertThat(result.recommendedTotal()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Story 6-1 Layer 1 한정 — facade axes 보유 시 axisIds 적용 메서드 호출")
+    void getTodayCandidates_withFacade_usesAxisFilteredQuery() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        // facade에 axis 2개 보유 — Layer 1 한정 경로
+        when(learningFacadeQueryService.findAxisIdsByUserId(eq(1L)))
+                .thenReturn(List.of(10L, 20L));
+
+        Card card = cardWith(1000L, null);
+        when(cardRepository.findOnFieldEligibleByUserIdAndAxisIds(eq(1L), any(), eq(List.of(10L, 20L))))
+                .thenReturn(List.of(card));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isEqualTo(1);
+        // fallback 메서드는 호출되지 않아야 함
+        org.mockito.Mockito.verify(cardRepository, org.mockito.Mockito.never())
+                .findOnFieldEligibleByUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("Story 6-1 Layer 1 미보유 — fallback으로 전체 카드 메서드 호출")
+    void getTodayCandidates_withoutFacade_fallbackQuery() {
+        when(userScheduleQueryService.resolveSoftScheduleTemplate(eq(1L)))
+                .thenReturn(SoftScheduleTemplate.DEFAULT);
+        // facade 미보유 (기본 setUp 동작)
+
+        Card card = cardWith(1000L, null);
+        when(cardRepository.findOnFieldEligibleByUserId(eq(1L), any()))
+                .thenReturn(List.of(card));
+
+        ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
+
+        assertThat(result.total()).isEqualTo(1);
+        // axisIds 적용 메서드는 호출되지 않아야 함
+        org.mockito.Mockito.verify(cardRepository, org.mockito.Mockito.never())
+                .findOnFieldEligibleByUserIdAndAxisIds(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 개요

product-card.md Epic 6 Story 6-1 정상 경로 — `ReviewQueryService.getTodayCandidates`가 사용자 `LearningFacade`(직업 컨셉 = Layer 1) 안의 `axes`에 연결된 Deck 카드만 후보로 수집한다. `LearningFacade` 미보유 사용자는 빈 axisIds로 fallback — 기존 전체 카드 경로 그대로 (Spec 엣지 케이스 유지).

## 왜 / 설계 결정

- **Spec 정상 경로 마무리** — Story 6-1 정상 시나리오는 Layer 1 한정 수집. 직전 PR(#153) fallback 경로 한정에서 정상 경로 도입으로 Story 6-1 BE 완성.
- **Cross-BC 통신은 axis ID 리스트로** — `LearningFacadeQueryService.findAxisIdsByUserId(userId): List<Long>`. LearningFacade 엔티티는 BC 경계 밖으로 노출하지 않고 ID만 반환 (UserSchedule의 `OnFieldBudget`/`SoftScheduleTemplate` 노출 패턴과 일관).
- **두 메서드 분기** — `findOnFieldEligibleByUserId`(기존, fallback)와 `findOnFieldEligibleByUserIdAndAxisIds`(신규, Layer 1 한정)로 분리. JPQL `IN :axisIds`에서 빈 컬렉션 처리는 dialect 의존적이라 Adapter에서 단락하는 게 안전. 기각: 단일 메서드 + nullable axisIds (JPQL 조건 분기가 어렵고 가독성 떨어짐).
- **`Deck.axisId` 컬럼 활용** — Story-005-2(PR #006 이후) 도입된 `axis_id` 컬럼이 자료 삭제와 무관하게 보존되므로 그대로 사용. axis → topic → material → deck 다단계 JOIN 불필요.
- **docs/PACKAGE.md 갱신** — Review → LearningFacade Application read 협력 의존을 §6에 명시. Review → UserSchedule과 동일 패턴.

## 작업 내용

- feat(learning-facade): `LearningFacadeQueryService.findAxisIdsByUserId(userId)` cross-BC inbound. 미보유 시 빈 리스트.
- feat(card): `CardJpaRepository.findOnFieldEligibleByUserIdAndAxisIds(userId, threshold, axisIds)` — JOIN FETCH deck + `d.axisId IN :axisIds` 필터. Adapter는 빈 axisIds 단락.
- feat(card): `CardRepository` Port + Adapter 동기. 기존 fallback 메서드는 유지.
- feat(review): `ReviewQueryService.collectToday` — `findAxisIdsByUserId` 호출 → 빈 리스트면 fallback / 비면 axisIds 적용 메서드로 분기.
- chore(test): 기존 `ReviewQueryServiceTest` / `ReviewQueryServiceTodayCandidatesTest` 생성자에 `LearningFacadeQueryService` Mock 추가. 기본 동작은 빈 리스트(fallback 호환).
- test(review): `ReviewQueryServiceTodayCandidatesTest` 2건 추가 — Layer 1 한정 분기 / fallback 분기 검증(중복 호출 방지).
- docs(package): `docs/PACKAGE.md` §6 BC 의존 규칙 표에 `Review → LearningFacade` Application read 행 추가.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [x] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test` → BUILD SUCCESSFUL (1m 34s, 전체 통과)
- 통합 / 성능: N/A. Layer 1 한정 + soft schedule + state 분류 흐름 통합 검증은 후속 `@SpringBootTest`로 보강 가능.

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 (PACKAGE.md §6)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Review → LearningFacade Application read 단방향 추가
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 6 Story 6-1 정상 경로 (Layer 1 기준 오늘 학습 가능한 카드 수집)

## Commits in this PR

- `70de33a` feat(review): Layer 1 한정 카드 후보 — Review → LearningFacade 의존

## 후속 PR 예고

- **Epic 8 — UI 문구 정책 문서** (`docs/ux/wip-language.md`). BE 영향 없는 docs-only.
- **Epic 6 통합 테스트 보강** — Layer 1 한정 + budget + state 분류 흐름을 `@SpringBootTest`로 e2e 검증.
- **본 Product BE DoD 점검** — 8 Epic 중 Epic 1·2·3·5·6·7 BE 핵심 완료. Epic 4(maxDuration 입력 + 모드 매핑)는 기존 UserSchedule BC + 직전 PR들로 거의 완료. Epic 8(UI 문구)만 남음.