### PR TITLE
docs(ux): Epic 8 — WIP 언어 가이드 + CLAUDE.md 진입 표 정합

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 | **Story Reviewer 세션** (5관점 병렬 검토) | [`.claude/rules/review.md`](.claude/rules/review.md) |
 | **브랜치·커밋·push·PR 규칙** | [`.claude/rules/pr-commit.md`](.claude/rules/pr-commit.md) |
 | **ADR 작성 트리거** | [`.claude/rules/adr.md`](.claude/rules/adr.md) |
+| **UI 문구 정책 (WIP 언어 · enum→문구 매핑)** | [`docs/ux/wip-language.md`](docs/ux/wip-language.md) |
 | **현재 진행 중인 Epic / Story** | `workflow/epics/Epic.md` · `workflow/stories/Story.md` |
 
 본 CLAUDE.md의 다른 섹션은 위 룰·문서와 모순될 경우 **룰·문서가 우선**한다 — CLAUDE.md는 빠른 개요이지 단일 진실 소스가 아니다.
@@ -129,31 +130,43 @@ Swagger UI: 실행 후 `http://localhost:8080/swagger-ui.html`.
 
 ### 본문 템플릿
 ```
-## What
-<무엇을 했는가>
+## PR 작성 규칙
 
-## Why
-<왜 했는가 - 이슈/ADR 링크>
+PR 본문은 아래 템플릿을 따른다.
+- 해당 없는 섹션은 삭제하지 말고 `N/A`로 남긴다.
+- 체크박스가 아닌 항목은 선언이 아니라 **사실**(실행 명령·결과·수치·링크)로 채운다.
 
-## How
-<주요 설계 결정 요약>
+---
 
-## Tradeoff
-<작업 중 있었던 트레이드오프>
+## 개요
+<무엇을 / 어떤 어댑터·기능을 구현했는가 2~3줄>
 
-## Reviewer 종합 (review.md §4 결과)
-<Critical/Major 건수 + 사용자 의사결정 결과 1줄>
+## 왜 / 설계 결정
+<왜 이 방식인가 — 핵심 설계 결정 1~3줄. 이슈/ADR 링크>
+<기각한 대안과 그 이유(트레이드오프)가 있으면 1줄>
 
-## Test
-- [ ] 단위 테스트 추가/통과
-- [ ] 통합 테스트 결과
-- [ ] 성능 영향 (해당 시)
+## 작업 내용
+- feat(<scope>): <변경> — <핵심 제약·애너테이션 등>
+- test(<scope>): <테스트 종류 / 케이스 수>
 
-## Checklist
-- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영
+## 변경 유형
+- [ ] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [ ] test  - [ ] chore
+
+## 테스트
+- `./gradlew test --tests "<패턴>"` → <BUILD SUCCESSFUL (n/n)>
+- 통합 / 성능 (해당 시): <결과 · before→after 수치 · Grafana 링크>
+
+## 체크리스트
+- [ ] 빌드 / 테스트 통과
+- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용
+- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 (해당 시)
 - [ ] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
 - [ ] BC 간 의존 방향 위반 없음
-- [ ] Reviewer 세션 통과 (또는 의식적 스킵 사유 명시)
+- [ ] (stacked) 대상 브랜치 = `<base branch>` 확인
+
+## 관련 이슈
+- Product: `<workflows/products/productNN.md>`
+- Epic / Story: <epic> / <story-x-y>
 
 Closes #<이슈번호>
 ```

--- a/docs/ux/wip-language.md
+++ b/docs/ux/wip-language.md
@@ -1,0 +1,163 @@
+# WIP 언어 가이드 (UI 문구 정책)
+
+> Card 운영 위치(ON_FIELD/ARCHIVE)·자동 만료·Soft Schedule·ReviewSession이 사용자에게 **"지금 몇 장을 얼마 동안 붙잡고 있는가"** 라는 WIP 언어로 일관되게 전달되도록 BE 응답 enum과 FE 노출 문구의 매핑을 정의한다.
+>
+> 단일 진실 소스. 새 ErrorCode·상태 enum·이벤트를 추가할 때마다 본 문서의 매핑 표를 함께 갱신한다.
+
+`product-card.md` Epic 8 "WIP 모델 기반 사용자 설명 체계"의 DoD 항목.
+
+---
+
+## 1. 원칙
+
+### 1.1 WIP 운영 위치 어휘 (도메인 의도)
+
+| 도메인 개념 | 사용자 노출 표현 | 금지 표현 |
+| --- | --- | --- |
+| `ON_FIELD` | "현재 학습 중", "지금 보는 카드" | "활성", "활성화된 카드" |
+| `ARCHIVE` | "보관됨", "배경 지식", "잠시 쉬는 중" | "**실패**", "탈락", "비활성", "삭제" |
+| `archive()` | "보관하기", "잠시 쉬게 두기" | "**실패 처리**", "탈락시키기" |
+| `returnToField()` | "다시 학습하기", "꺼내오기" | "복구", "활성화" |
+| `MAX_VIEW` 도달 | "충분히 노출되었습니다" | "**한도 초과**", "**실패 횟수 초과**" |
+| `MAX_DURATION` 도달 | "순환을 완료했습니다" | "**기한 초과**", "**만료**" |
+| `viewCount` | "본 횟수", "노출 횟수" | "시도 횟수", "실패 횟수" |
+| `lastViewedAt` | "마지막으로 본 때" | "마지막 시도" |
+| `dailyTarget` | "오늘 학습 목표" | "할당량", "강제 학습 수" |
+| `SoftScheduleState` `INTERVAL_*D` | "오랜만에 만나는 카드", "N일째 카드" | "지연된 카드", "밀린 카드" |
+| `NOT_YET` | (응답에서 제외 — 화면 미노출) | — |
+
+**핵심 규칙**: "실패" 어휘는 도메인 전반에서 사용자 노출 문구 어디에도 들어가지 않는다. 운영 위치 전환은 모두 "순환" / "이동" 언어로.
+
+### 1.2 책임 분리 (Spec Option B)
+
+- **BE** — `ArchiveReason` / `CardStatus` / `SoftScheduleState` enum 코드 문자열만 응답에 포함.
+- **FE** — 메시지 번들에서 enum → 사용자 문구 매핑. 본 문서가 그 번들의 출처.
+- **변경 영향**: PO/디자이너 문구 수정은 FE PR 1건. BE 도메인 변경 없음. 다국어 확장 시도 FE 번들만 추가.
+
+---
+
+## 2. enum → 사용자 노출 문구 매핑 (FE 번들 원본)
+
+### 2.1 카드 퇴장 (`ArchiveReason`)
+
+| Enum 값 | 사용자 노출 문구 (단건) | 묶음 노출 문구 (N건) | 발생 경로 |
+| --- | --- | --- | --- |
+| `MANUAL` | "카드를 보관했어요. 필요하면 언제든 다시 꺼낼 수 있어요." | "{N}개 카드를 보관했어요." | `CardCommandService.archive` (사용자 명시 액션) |
+| `MAX_VIEW` | "이 카드는 충분히 노출되었어요. 배경 지식으로 이동합니다." | "{N}개 카드의 노출이 완료되어 배경 지식으로 이동했어요." | `ReviewCommandService` 노출 경로(`recordView` 후 `isLastView`) |
+| `MAX_DURATION` | "이 카드는 순환을 완료했어요. 잠시 후 다시 만나요 👋" | "{N}개 카드가 순환을 완료했어요. 잠시 후 다시 만나요 👋" | `CardExpiryBatchService` 야간 03:00 배치 |
+
+**문구 작성 원칙**:
+- 첫 문장 종결: "~했어요" / "~합니다" 톤 통일.
+- 이모지는 `MANUAL` 외에는 자제 — 묶음 안내(MAX_*)에만 👋 1개. 단건 안내는 무이모지.
+- 사용자 직접 액션(MANUAL) → "되돌릴 수 있다"는 안전 신호를 같이 노출.
+
+### 2.2 운영 위치 (`CardStatus`)
+
+| Enum 값 | 뱃지 라벨 | 카드 목록 헤더 |
+| --- | --- | --- |
+| `ON_FIELD` | "학습 중" | "지금 보는 카드" |
+| `ARCHIVE` | "보관됨" | "보관된 카드" |
+
+### 2.3 Soft Schedule 상태 (`SoftScheduleState`)
+
+| Enum 값 | 사용자 노출 표현 | 화면 사용 위치 |
+| --- | --- | --- |
+| `FRESH` | "처음 보는 카드" | ReviewSession 후보 섹션 헤더 |
+| `INTERVAL_1D` | "어제 본 카드" | 〃 |
+| `INTERVAL_3D` | "3일 전 본 카드" | 〃 |
+| `INTERVAL_7D` | "일주일 전 본 카드" | 〃 |
+| `INTERVAL_14D` | "2주 전 본 카드" | 〃 |
+| `INTERVAL_21D` | "3주 전 본 카드" | 〃 |
+| `NOT_YET` | (응답에서 제외) | — |
+
+응답 DTO `ReviewResponse.TodayCandidates.byState` / `recommendedByState`의 키 enum을 그대로 매핑.
+
+### 2.4 ReviewSession 추천 메시지
+
+| 응답 필드 | 사용자 노출 문구 예시 | 비고 |
+| --- | --- | --- |
+| `recommendedTotal == dailyTarget` (정확히 매칭) | "오늘은 {dailyTarget}장 학습을 추천해요." | 기본 정상 상태 |
+| `recommendedTotal < target` (풀 소진) | "오늘 학습 가능한 카드는 {recommendedTotal}장이에요. 모두 완료하면 오늘 학습 끝!" | Story 6-3 "+N장" 응답 |
+| `total == 0` (후보 0건) | "오늘은 학습할 카드가 없어요. 새 카드를 추가하거나 내일 다시 만나요." | 신규 사용자 / 모든 카드 NOT_YET |
+| `+N장` 액션 라벨 | "+{count}장 더 학습" | Story 6-3 기본 N=10 |
+
+### 2.5 Deck 진행 상태 (`DeckProgressStatus`)
+
+| Enum 값 | 뱃지 라벨 |
+| --- | --- |
+| `NOT_STARTED` | "시작 전" |
+| `IN_PROGRESS` | "학습 중" |
+| `COMPLETED` | "순환 완료" |
+
+`COMPLETED`는 "끝" 인상이 강해 "**순환** 완료"로 표현해 다시 시작할 수 있음을 암시한다.
+
+---
+
+## 3. 묶음 안내 정책 (Spec Epic 8 Alternative B)
+
+- **트리거**: 일정 시간(예: 5분) 안에 동일 사용자의 동일 `reason` 자동 퇴장이 2건 이상 발생.
+- **대상**: `MAX_DURATION`(야간 배치) / `MAX_VIEW`(연속 리뷰 세션). `MANUAL`은 사용자 명시 액션이라 단건 안내.
+- **표현**: 위 §2.1 묶음 노출 문구 컬럼.
+- **구현 위치**: FE 알림 큐 또는 push 통합 시점. BE는 알림 발행을 책임지지 않는다 (이벤트만 노출 — v2 `card_state_transition` Metric 합류).
+
+---
+
+## 4. "실패" 어휘 차단 CI 규약 (Spec Epic 8 Alternative B)
+
+> 본 절은 FE 메시지 번들에 적용. BE Java 소스에는 도메인 enum/ErrorCode만 있어 별도 grep 불요.
+
+- FE 빌드 파이프라인에 다음 단계 추가 권장:
+  ```
+  grep -rE "(실패|탈락|만료)" frontend/src/messages/ && exit 1 || exit 0
+  ```
+  매치되면 빌드 실패. 도메인 외 문맥(예: "비밀번호 입력 실패")은 별도 디렉토리로 격리.
+- 신규 ErrorCode·도메인 메시지 추가 시 본 문서 §2의 표를 함께 갱신해 누락 차단.
+- 성공 지표(`product-card.md` §성공 지표 — "퇴장 메시지 '실패' 어휘 = 0건") 자동 검증의 단일 진실 소스.
+
+---
+
+## 5. 운영 규칙 요약 페이지 가이드 (Story 8-2)
+
+FE에서 작성할 "운영 규칙 보기" 한 페이지의 권장 섹션 구조.
+
+1. **이 시스템이 돌아가는 방식 (3줄)**
+   - 카드를 만들면 "학습 중(ON_FIELD)"에 올라가요.
+   - 일정 기간/노출 횟수를 채우면 자동으로 "보관됨(ARCHIVE)"으로 이동해요.
+   - 보관된 카드는 언제든 다시 꺼낼 수 있어요.
+2. **왜 카드가 자동으로 이동하나요?**
+   - "완벽히 외울 때까지 반복"이 아니라 "WIP 예산 안에서 순환"이 이 시스템의 철학입니다.
+   - 한 번에 너무 많은 카드를 붙잡지 않아야 학습 에너지가 분산되지 않아요.
+3. **내 학습 모드 (MODE_10D / 20D / 30D)**
+   - maxDuration 입력값에 따라 자동 매핑돼요.
+   - 각 모드의 `maxView` / soft schedule 간격을 표로 (Story 4-1 모드 표 그대로).
+4. **ReviewSession은 어떻게 카드를 골라주나요?**
+   - 본인 직업 컨셉(Layer 1) 안의 모든 Deck에서 수집해요.
+   - 오늘 학습 가능한(soft schedule 통과) 카드를 모은 뒤, state별 비율로 `dailyTarget`만큼 추천해요.
+   - 예: dailyTarget 20장 + 풀이 1일/3일/7일 각 10·5·5장이면 → 추천도 10·5·5.
+5. **묶음 안내**
+   - 야간 03:00 자동 만료 시 N장이 한 번에 보관되면 묶음 안내 1건으로 받아요. 알림 폭주 없음.
+6. **링크**
+   - 학습 모드 설정 → `PATCH /api/v1/users/me/schedule` (FE 라우트로 매핑).
+   - 일일 학습 목표 설정 → `PATCH /api/v1/users/me/schedule/daily-target`.
+
+---
+
+## 6. 변경 트리거
+
+다음 영역에 변경이 생길 때 본 문서를 같이 갱신한다 (CI grep과는 별개의 컨벤션).
+
+- 새 `ArchiveReason` enum 값 추가 → §2.1 표 갱신.
+- 새 `CardStatus` 값 추가 → §2.2 표 갱신.
+- 새 `SoftScheduleState` 값 추가 (예: `INTERVAL_30D`) → §2.3 표 갱신.
+- `LearningMode` 추가/분기점 변경 → §5.3 (운영 규칙 요약) 모드 표 갱신.
+- 새 사용자 노출 ErrorCode 추가 → 본 문서에 매핑이 필요한지 검토.
+- 응답 DTO 추가 (`ReviewResponse.*` / `CardResponse.*`)로 사용자 노출 문구 자리가 생기면 §2 / §4에 매핑 추가.
+
+---
+
+## 7. 관련 문서
+
+- `workflow/product/pes/ready/product-card.md` Epic 8 (Spec 원본)
+- `docs/DOMAIN.md` § Card / ReviewSession (도메인 어휘 사전)
+- `docs/PACKAGE.md` §6 (BC 의존 — Review → Card·UserSchedule·LearningFacade)
+- `Common/Exception/ErrorCode/ErrorCode` (사용자 노출 에러 코드 enum, 메시지는 같은 enum 한국어 그대로)


### PR DESCRIPTION
## 개요

product-card.md Epic 8 (WIP 모델 기반 사용자 설명 체계)의 DoD 항목 `docs/ux/wip-language.md`를 신설. Card 운영 위치·자동 만료·Soft Schedule·ReviewSession 관련 도메인 enum과 FE 노출 문구의 매핑 단일 진실 소스. CLAUDE.md 진입 표에도 신규 영역 라우팅 추가.

## 왜 / 설계 결정

- **Spec Option B 채택** — 도메인 코드는 `ArchiveReason` / `CardStatus` / `SoftScheduleState` enum 코드만 응답하고, FE 메시지 번들이 본 문서를 출처로 한국어 매핑. 기각: BE 응답에 한국어 직접 포함 (다국어 확장 비용·PO 문구 변경마다 BE PR 발생).
- **본 문서를 단일 진실 소스로** — Spec 성공 지표("퇴장 메시지 '실패' 어휘 = 0건")의 FE CI grep 검증이 의지할 출처. 새 enum/ErrorCode 추가 시 본 문서 표를 함께 갱신 (§6 변경 트리거).
- **CLAUDE.md 진입 표 갱신** — 신규 `docs/ux/` 영역이 단순한 docs 폴더가 아니라 BE↔FE 협업의 진실 소스이므로 진입 표에서 발견 가능해야 함.
- **PR 템플릿 변경 동반** — CLAUDE.md의 PR 본문 템플릿(`## 개요` / `## 왜·설계 결정` / `## 작업 내용` / `## 변경 유형` / ...)이 working tree에 사전 수정되어 있어 본 docs PR에 함께 합류. 별도 PR로 분리하지 않고 같은 docs-only 변경 묶음에 포함.

## 작업 내용

- docs(ux): `docs/ux/wip-language.md` 신설 (163줄)
  - §1 원칙 — 도메인 어휘 ↔ 사용자 노출 표현 + "실패" 어휘 금지 + BE/FE 책임 분리
  - §2 enum → 문구 매핑 — ArchiveReason / CardStatus / SoftScheduleState / DeckProgressStatus / ReviewSession 추천 메시지
  - §3 묶음 안내 정책 (Spec Alternative B)
  - §4 "실패" 어휘 차단 CI 규약 (FE 빌드 grep)
  - §5 운영 규칙 요약 페이지 가이드 (Story 8-2 FE 화면 구조 제안)
  - §6 변경 트리거 — 새 enum/ErrorCode 추가 시 동기화 규약
- docs(claude): CLAUDE.md 진입 표에 "UI 문구 정책" 행 추가 + PR 본문 템플릿 갱신 (working tree 사전 수정분 합류)

## 변경 유형

- [ ] feat  - [ ] fix  - [ ] refactor  - [x] docs  - [ ] test  - [ ] chore

## 테스트

- N/A (docs-only PR). 본 문서의 enum 매핑은 BE 코드에서 enum이 그대로 응답되는지가 검증 책임이며 기존 단위·슬라이스 테스트로 커버됨.
- `./gradlew test` → BUILD SUCCESSFUL (직전 PR #158 머지 시점 기준 그대로, 본 PR은 docs만 변경).

## 체크리스트

- [x] 빌드 / 테스트 통과 (코드 변경 없음)
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — CLAUDE.md 진입 표 갱신
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 (docs only)
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-card.md`
- Epic / Story: Epic 8 / Story 8-1 + Story 8-2 (BE 측 DoD 항목 `docs/ux/wip-language.md` 등록 완료)

## Commits in this PR

- `1b6c541` docs(ux): wip-language.md — WIP 언어 가이드 신설
- `9a0aae1` docs(claude): 진입 표에 UI 문구 정책 추가

## product-card.md BE DoD 현황

| Epic | BE 상태 |
| --- | --- |
| 1. Card 상태 ON_FIELD/Archive | ✅ |
| 2. ON_field 무한 반복 방지 | ✅ |
| 3. Soft Schedule | ✅ |
| 4. 사용자별 maxDuration·dailyTarget | ✅ |
| 5. Tag 관리·탐색·연결 후보 | ✅ |
| 6. ReviewSession Layer 1 수집·비율 추천·+N장 | ✅ |
| 7. Archive → ON_field 복귀 | ✅ |
| 8. UI 문구 정책 (본 PR) | ✅ |

BE 측 책임 범위 완료. FE 화면·메시지 번들·CI grep·디자인 QA 등 FE 작업이 남음 (본 PR이 그 작업의 BE 측 입력 사양).