### PR TITLE
feat(learning-facade): Story 2-3·3-3 — TopicItem isFocused·isRefinementSuggested 노출

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -31,6 +31,13 @@ public class LearningAxis {
 
     private static final int RECOMMENDED_TOPIC_LIMIT = 10;
 
+    /**
+     * Story 2-3 — 상위 N개 주제에 "지금 집중 중" 뱃지를 표시할 때 사용하는 임계값.
+     * {@link AxisTopic#isFocused(int)}가 displayOrder ≤ 이 값일 때 true를 반환한다.
+     * 주제 3개 미만이면 모든 주제가 자동으로 focused (displayOrder 1, 2, 3 모두 임계값 이하).
+     */
+    public static final int FOCUS_TOP_N = 3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "learning_axis_id")

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
@@ -92,6 +92,8 @@ public class LearningFacadeResponse {
             int displayOrder,
             String coverageStatus,
             boolean isUncovered,
+            boolean isFocused,                 // Story 2-3
+            boolean isRefinementSuggested,     // Story 3-3
             MaterialBreakdown materialBreakdown
     ) {
         public static TopicItem of(AxisTopic topic) {
@@ -106,6 +108,8 @@ public class LearningFacadeResponse {
                     topic.getDisplayOrder(),
                     topic.getCoverageStatus().name(),
                     topic.isUncovered(),
+                    topic.isFocused(LearningAxis.FOCUS_TOP_N),
+                    topic.isRefinementSuggested(),
                     materialBreakdown
             );
         }
@@ -345,6 +349,8 @@ public class LearningFacadeResponse {
             int displayOrder,
             String coverageStatus,
             boolean needsMaterialPrompt,
+            boolean isFocused,                 // Story 2-3 — 신규 추가된 주제가 상위 N에 들어가는지
+            boolean isRefinementSuggested,     // Story 3-3 — 새 주제는 항상 false (revisionCount=0)
             List<LinkableMaterialItem> linkableMaterials
     ) {
         public static AddTopic of(AxisTopic topic) {
@@ -360,6 +366,8 @@ public class LearningFacadeResponse {
                     topic.getDisplayOrder(),
                     topic.getCoverageStatus().name(),
                     topic.isUncovered(),
+                    topic.isFocused(LearningAxis.FOCUS_TOP_N),
+                    topic.isRefinementSuggested(),
                     linkableMaterials == null ? List.of() : linkableMaterials
             );
         }
@@ -378,6 +386,7 @@ public class LearningFacadeResponse {
             String coverageStatus,
             int revisionCount,
             boolean isRefinementSuggested,
+            boolean isFocused,                 // Story 2-3 — 수정 후에도 priority 표시 일관성
             LocalDateTime updatedAt
     ) {
         public static UpdateTopic of(AxisTopic topic) {
@@ -390,6 +399,7 @@ public class LearningFacadeResponse {
                     topic.getCoverageStatus().name(),
                     topic.getRevisionCount(),
                     topic.isRefinementSuggested(),
+                    topic.isFocused(LearningAxis.FOCUS_TOP_N),
                     topic.getUpdatedAt()
             );
         }

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisTopicTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisTopicTest.java
@@ -183,7 +183,7 @@ class AxisTopicTest {
     }
 
     @Nested
-    @DisplayName("isFocused")
+    @DisplayName("isFocused (Story 2-3)")
     class IsFocused {
 
         @Test
@@ -203,6 +203,12 @@ class AxisTopicTest {
             for (int i = 1; i <= 4; i++) axis.addTopic("주제 " + i, null);
             AxisTopic last = axis.getTopics().get(3);
             assertThat(last.isFocused(3)).isFalse();
+        }
+
+        @Test
+        @DisplayName("LearningAxis.FOCUS_TOP_N 상수가 도메인에 노출된다 (DTO mapper 참조용)")
+        void focusTopNConstantExposed() {
+            assertThat(LearningAxis.FOCUS_TOP_N).isEqualTo(3);
         }
     }
 
@@ -318,4 +324,5 @@ class AxisTopicTest {
             assertThat(topic.isUncovered()).isFalse();
         }
     }
+
 }

--- a/src/test/java/com/example/thirdtool/LearningFacade/integration/LearningFacadeQueryFocusedFlagsIntegrationTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/integration/LearningFacadeQueryFocusedFlagsIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.example.thirdtool.LearningFacade.integration;
+
+import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeQuery;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
+import com.example.thirdtool.LearningFacade.domain.model.AxisTopic;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.presentation.dto.LearningFacadeResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * product-learningFacade.md Story 2-3 + 3-3 — getFacade 응답에 isFocused·isRefinementSuggested
+ * 두 flag가 정합하게 노출되는지 통합 검증.
+ *
+ * <p>단위 테스트는 도메인 boolean을 직접 확인하지만, DTO mapper가 LearningAxis.FOCUS_TOP_N(=3)
+ * 상수를 올바르게 전달하는지·복수 topic을 정렬 + flag 매핑까지 컨텍스트에서 정합한지는 통합 테스트
+ * 범위.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("LearningFacade getFacade 응답 — isFocused / isRefinementSuggested 통합")
+class LearningFacadeQueryFocusedFlagsIntegrationTest {
+
+    @Autowired LearningFacadeQueryService learningFacadeQueryService;
+
+    @PersistenceContext EntityManager em;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("owner", "encoded-pw", "닉네임", "owner@example.com");
+        em.persist(user);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("주제 5개 — 상위 3개만 isFocused=true (FOCUS_TOP_N=3 적용)")
+    void focusFlag_topThreeOfFive() {
+        // given — facade 1개 + axis 1개 + topic 5개
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        LearningAxis axis = facade.addAxis("Spring");
+        for (int i = 1; i <= 5; i++) {
+            axis.addTopic("주제 " + i, null);
+        }
+        em.persist(facade);
+        em.flush();
+        em.clear();
+
+        // when
+        LearningFacadeResponse.FacadeDetail response = learningFacadeQueryService.getFacade(
+                new LearningFacadeQuery.GetFacade(user.getId())
+        );
+
+        // then — displayOrder 1·2·3은 focused, 4·5는 not
+        List<LearningFacadeResponse.TopicItem> topics = response.axes().get(0).topics();
+        assertThat(topics).hasSize(5);
+        assertThat(topics).extracting(LearningFacadeResponse.TopicItem::isFocused)
+                .containsExactly(true, true, true, false, false);
+    }
+
+    @Test
+    @DisplayName("주제 2개 (3개 미만) — 모든 주제가 isFocused=true (Spec 엣지 케이스)")
+    void focusFlag_allFocusedWhenFewerThanThree() {
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        LearningAxis axis = facade.addAxis("Spring");
+        axis.addTopic("주제 1", null);
+        axis.addTopic("주제 2", null);
+        em.persist(facade);
+        em.flush();
+        em.clear();
+
+        LearningFacadeResponse.FacadeDetail response = learningFacadeQueryService.getFacade(
+                new LearningFacadeQuery.GetFacade(user.getId())
+        );
+
+        List<LearningFacadeResponse.TopicItem> topics = response.axes().get(0).topics();
+        assertThat(topics).extracting(LearningFacadeResponse.TopicItem::isFocused)
+                .containsExactly(true, true);
+    }
+
+    @Test
+    @DisplayName("이름 3회 수정한 주제는 isRefinementSuggested=true (REFINEMENT_THRESHOLD=3 적용)")
+    void refinementFlag_afterThreeNameUpdates() {
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        LearningAxis axis = facade.addAxis("Spring");
+        AxisTopic topic = axis.addTopic("v0", null);
+        topic.updateName("v1");
+        topic.updateName("v2");
+        topic.updateName("v3");
+        em.persist(facade);
+        em.flush();
+        em.clear();
+
+        LearningFacadeResponse.FacadeDetail response = learningFacadeQueryService.getFacade(
+                new LearningFacadeQuery.GetFacade(user.getId())
+        );
+
+        LearningFacadeResponse.TopicItem topicItem = response.axes().get(0).topics().get(0);
+        assertThat(topicItem.isRefinementSuggested()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이름 미수정 신규 주제는 isRefinementSuggested=false")
+    void refinementFlag_freshTopicFalse() {
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        LearningAxis axis = facade.addAxis("Spring");
+        axis.addTopic("새 주제", null);
+        em.persist(facade);
+        em.flush();
+        em.clear();
+
+        LearningFacadeResponse.FacadeDetail response = learningFacadeQueryService.getFacade(
+                new LearningFacadeQuery.GetFacade(user.getId())
+        );
+
+        LearningFacadeResponse.TopicItem topicItem = response.axes().get(0).topics().get(0);
+        assertThat(topicItem.isRefinementSuggested()).isFalse();
+        assertThat(topicItem.isFocused()).isTrue(); // displayOrder=1
+    }
+}


### PR DESCRIPTION
## 개요

product-learningFacade.md Story 2-3(FOCUS_TOP_N=3 "지금 집중 중") + Story 3-3(REFINEMENT_THRESHOLD=3 "단련 안내") — 도메인 boolean 메서드는 이미 존재했지만 응답 DTO에서 부분만 노출돼 FE 표시가 불가능했다. `TopicItem` 응답에 두 flag 모두 노출하고 신규 `LearningAxis.FOCUS_TOP_N=3` 상수를 DTO mapper가 참조하도록 정합화. `AddTopic` / `UpdateTopic` 응답에도 동일 두 flag 추가해 응답 형식 일관성 확보.

## 왜 / 설계 결정

- **갭 식별** — LearningFacade BC가 100% 구현된 상태에서 BE 측 유일 갭이 본 두 응답 flag. 도메인 `AxisTopic.isFocused(focusThreshold)` / `.isRefinementSuggested()` 메서드는 존재했고 `UpdateTopic` 응답에 `isRefinementSuggested`만 부분 노출돼 있었다. `TopicItem`(facade 트리 조회의 핵심)에 두 flag 모두 없어 FE 뱃지·안내 메시지 표시 불가.
- **Story 2-3 + 3-3 한 PR로 묶음** — 두 Story 모두 "도메인 boolean → TopicItem DTO 노출" 동일 패턴. PR 단위는 Story 단위가 기본이지만 두 Story 모두 같은 DTO 한 record를 수정해 응집이 강함 + 각 Story가 독립적으로는 PR이 너무 작음 → 묶는 게 자연스러움.
- **`LearningAxis.FOCUS_TOP_N=3` 상수 위치** — `AxisTopic.isFocused(int)`가 인자로 받는 임계값을 상수로 박는다. `LearningAxis`에 두는 이유: Axis가 topics 컬렉션을 관리하는 Aggregate. 상수 외부 재정의를 방지해 DTO mapper가 직접 `LearningAxis.FOCUS_TOP_N`을 전달.
- **`AddTopic`·`UpdateTopic` 응답에도 추가** — 신규 추가된 주제의 isRefinementSuggested는 항상 false (revisionCount=0)이지만 응답 형식 일관성을 위해 포함. FE가 단건 응답·전체 응답을 동일 모델로 처리 가능.

## 작업 내용

- feat(learning-facade): `LearningAxis.FOCUS_TOP_N = 3` public static 상수 신설. Story 2-3 임계값 도메인 노출.
- feat(learning-facade): `LearningFacadeResponse`의 3개 record 확장 — `TopicItem` / `AddTopic` / `UpdateTopic`. 각 record의 of() factory에서 도메인 `isFocused(LearningAxis.FOCUS_TOP_N)`·`isRefinementSuggested()` 호출.
- test(learning-facade): `AxisTopicTest.IsFocused`에 `FOCUS_TOP_N=3` 상수 노출 검증 1건 추가. 기존 경계값(within/above threshold) 매트릭스 유지. isRefinementSuggested 매트릭스는 기존 `RevisionCount` + `IsRefinementSuggested` 블록(Story 3-3)이 이미 완전 커버.
- test(learning-facade): `LearningFacadeQueryFocusedFlagsIntegrationTest`(@SpringBootTest, 4건) — getFacade 응답 매핑 사슬 (Service → AxisItem.of → TopicItem.of) 정합 검증. 주제 5개·2개·3회 수정·신규 4 시나리오.

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- `./gradlew test --tests "com.example.thirdtool.LearningFacade.integration.LearningFacadeQueryFocusedFlagsIntegrationTest"` → BUILD SUCCESSFUL (4/4)
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.domain.model.AxisTopicTest"` → BUILD SUCCESSFUL
- `./gradlew test` → BUILD SUCCESSFUL (1m 34s, 전체 통과)
- 통합 / 성능: N/A

## 체크리스트

- [x] 빌드 / 테스트 통과
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (LearningFacade BC는 기존 record 직접 반환 형식 유지)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — N/A (도메인 boolean 노출 보강, 의도 변경 없음)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — LearningFacade BC 내부
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-learningFacade.md`
- Epic / Story: Epic 2 Story 2-3 (FOCUS_TOP_N) + Epic 3 Story 3-3 (REFINEMENT_THRESHOLD)

## Commits in this PR

- `6297ebf` feat(learning-facade): LearningAxis.FOCUS_TOP_N=3 상수 신설
- `887f0ac` feat(learning-facade): TopicItem·AddTopic·UpdateTopic 응답에 isFocused/isRefinementSuggested 노출
- `c8241f5` test(learning-facade): AxisTopicTest IsFocused에 FOCUS_TOP_N 상수 노출 검증 추가
- `1c1744e` test(learning-facade): getFacade isFocused·isRefinementSuggested 통합 검증

## product-learningFacade.md BE 현황

| Epic | BE 상태 |
| --- | --- |
| 1. Layer 1 컨셉 설정 | ✅ |
| 2. Axis·Topic 구성 (Story 2-1·2-2 ✅ · 2-3 본 PR) | ✅ |
| 3. Topic 단련 이력 (Story 3-1·3-2 ✅ · 3-3 본 PR) | ✅ |
| 4. 학습 자료 + 4종 타입 | ✅ |
| 5. 커버리지 공백 시각화 | ✅ |
| 6. LearningFacade ↔ Deck 자동 연결 | ✅ |

본 PR로 LearningFacade BC 측 6 Epic 모두 핵심 갭 해소.

## 후속 PR 예고

- **product-aisuggestion 또는 product-auth 진입** — LearningFacade 완료 후 다음 Product. 사용자 선택에 따라.
- **LearningFacade 추가 통합 보강** — Story 2-2 batch topic add 통합, Story 6-1 material→Deck event 통합 등 (선택).