### PR TITLE
feat(facade): Story 1-1 AI 제안 outbound Port + VO 정의

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestion.java
@@ -1,0 +1,20 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+/**
+ * AI 제안 축 후보.
+ *
+ * <p>{@code description}은 사용자에게 노출될 축 이름(필수).
+ * {@code rationale}은 "왜 이 축을 제안했는지" 설명(선택 — LLM이 안정적으로 생성한다는 보장이 없어 null 허용).</p>
+ */
+public record AxisSuggestion(String description, String rationale) {
+
+    public AxisSuggestion {
+        if (description == null || description.isBlank()) {
+            throw new IllegalArgumentException("description은 blank일 수 없습니다.");
+        }
+        description = description.trim();
+        if (rationale != null) {
+            rationale = rationale.trim();
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestion.java
@@ -14,7 +14,8 @@ public record AxisSuggestion(String description, String rationale) {
         }
         description = description.trim();
         if (rationale != null) {
-            rationale = rationale.trim();
+            String trimmed = rationale.trim();
+            rationale = trimmed.isEmpty() ? null : trimmed;
         }
     }
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionPort.java
@@ -1,0 +1,25 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * AI 제안 — 학습 축(LearningAxis) 후보 생성 outbound Port.
+ *
+ * <p>구현체는 Static(코드 상수 기반 Fallback) / LLM(Vertex AI Gemini) 등으로 교체 가능.
+ * 도메인 레이어는 본 Port를 import하지 않는다 — Application Service만 호출.</p>
+ *
+ * @see AxisTopicSuggestionPort
+ */
+public interface AxisSuggestionPort {
+
+    /**
+     * 사용자의 concept context + 기존 축 이름 목록을 입력으로 축 후보를 반환한다.
+     *
+     * <p>구현체는 {@code existingAxisNames}와 중복되는 후보를 제거하고 최대 {@code limit}개까지 반환한다.
+     * 호출 실패 시(타임아웃 / 파싱 실패 / 인증 실패)는 구현체별 예외로 던지며, 상위 Service가
+     * 빈 목록 + {@code suggestionsAvailable: false}로 변환한다(Fallback 정책).</p>
+     */
+    List<AxisSuggestion> suggest(SuggestionConceptContext conceptContext,
+                                 List<String> existingAxisNames,
+                                 int limit);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestion.java
@@ -14,7 +14,8 @@ public record AxisTopicSuggestion(String description, String rationale) {
         }
         description = description.trim();
         if (rationale != null) {
-            rationale = rationale.trim();
+            String trimmed = rationale.trim();
+            rationale = trimmed.isEmpty() ? null : trimmed;
         }
     }
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestion.java
@@ -1,0 +1,20 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+/**
+ * AI 제안 하위 주제 후보.
+ *
+ * <p>{@code description}은 사용자에게 노출될 주제 이름(필수).
+ * {@code rationale}은 "왜 이 주제를 제안했는지" 설명(선택 — null 허용).</p>
+ */
+public record AxisTopicSuggestion(String description, String rationale) {
+
+    public AxisTopicSuggestion {
+        if (description == null || description.isBlank()) {
+            throw new IllegalArgumentException("description은 blank일 수 없습니다.");
+        }
+        description = description.trim();
+        if (rationale != null) {
+            rationale = rationale.trim();
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionPort.java
@@ -1,0 +1,26 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * AI 제안 — 하위 주제(AxisTopic) 후보 생성 outbound Port.
+ *
+ * <p>축 이름({@code axisName})을 추가 컨텍스트로 받아 해당 축 내부의 주제 후보를 반환한다.
+ * 도메인 레이어는 본 Port를 import하지 않는다 — Application Service만 호출.</p>
+ *
+ * @see AxisSuggestionPort
+ */
+public interface AxisTopicSuggestionPort {
+
+    /**
+     * 사용자의 concept context + 축 이름 + 기존 주제 이름 목록을 입력으로 주제 후보를 반환한다.
+     *
+     * <p>구현체는 {@code existingTopicNames}와 중복되는 후보를 제거하고 최대 {@code limit}개까지 반환한다.
+     * 호출 실패 시는 구현체별 예외로 던지며, 상위 Service가 빈 목록 + {@code suggestionsAvailable: false}로
+     * 변환한다(Fallback 정책).</p>
+     */
+    List<AxisTopicSuggestion> suggest(SuggestionConceptContext conceptContext,
+                                      String axisName,
+                                      List<String> existingTopicNames,
+                                      int limit);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionConceptContext.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionConceptContext.java
@@ -20,7 +20,7 @@ public record SuggestionConceptContext(
         if (conceptSet == null || conceptSet.isEmpty()) {
             throw new IllegalArgumentException("conceptSet은 최소 1개 이상이어야 합니다.");
         }
-        List<String> normalized = conceptSet.stream()
+        conceptSet = conceptSet.stream()
                 .map(value -> {
                     if (value == null || value.isBlank()) {
                         throw new IllegalArgumentException("conceptSet의 각 원소는 blank일 수 없습니다.");
@@ -28,7 +28,6 @@ public record SuggestionConceptContext(
                     return value.trim();
                 })
                 .toList();
-        conceptSet = List.copyOf(normalized);
 
         if (compositionReason == null || compositionReason.isBlank()) {
             throw new IllegalArgumentException("compositionReason은 blank일 수 없습니다.");

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionConceptContext.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionConceptContext.java
@@ -1,0 +1,43 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * AI 제안에 전달되는 사용자 LearningFacade의 조합형 concept context.
+ *
+ * <p>단일 직업 문자열이 아니라 {@code conceptSet(2~3개) + compositionReason + desiredOutcome}로
+ * 사용자의 학습 목표 의도를 압축한다. 빈 입력·blank 입력은 Adapter 도달 전에 차단한다.</p>
+ *
+ * <p>도메인 레이어는 본 VO를 import하지 않는다 — Application Service만 참조.</p>
+ */
+public record SuggestionConceptContext(
+        List<String> conceptSet,
+        String compositionReason,
+        String desiredOutcome
+) {
+
+    public SuggestionConceptContext {
+        if (conceptSet == null || conceptSet.isEmpty()) {
+            throw new IllegalArgumentException("conceptSet은 최소 1개 이상이어야 합니다.");
+        }
+        List<String> normalized = conceptSet.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        throw new IllegalArgumentException("conceptSet의 각 원소는 blank일 수 없습니다.");
+                    }
+                    return value.trim();
+                })
+                .toList();
+        conceptSet = List.copyOf(normalized);
+
+        if (compositionReason == null || compositionReason.isBlank()) {
+            throw new IllegalArgumentException("compositionReason은 blank일 수 없습니다.");
+        }
+        compositionReason = compositionReason.trim();
+
+        if (desiredOutcome == null || desiredOutcome.isBlank()) {
+            throw new IllegalArgumentException("desiredOutcome은 blank일 수 없습니다.");
+        }
+        desiredOutcome = desiredOutcome.trim();
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionTest.java
@@ -1,0 +1,75 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AxisSuggestion")
+class AxisSuggestionTest {
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("description + rationale 정상 입력")
+        void create_valid() {
+            AxisSuggestion suggestion = new AxisSuggestion("아키텍처", "구조적 판단을 정련");
+
+            assertThat(suggestion.description()).isEqualTo("아키텍처");
+            assertThat(suggestion.rationale()).isEqualTo("구조적 판단을 정련");
+        }
+
+        @Test
+        @DisplayName("rationale이 null이어도 생성된다")
+        void create_rationale_null_허용() {
+            AxisSuggestion suggestion = new AxisSuggestion("아키텍처", null);
+
+            assertThat(suggestion.description()).isEqualTo("아키텍처");
+            assertThat(suggestion.rationale()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("description은 trim되어 저장된다")
+        void description_trim() {
+            AxisSuggestion suggestion = new AxisSuggestion("  아키텍처  ", null);
+
+            assertThat(suggestion.description()).isEqualTo("아키텍처");
+        }
+
+        @Test
+        @DisplayName("rationale이 null이 아니면 trim되어 저장된다")
+        void rationale_trim() {
+            AxisSuggestion suggestion = new AxisSuggestion("아키텍처", "  근거  ");
+
+            assertThat(suggestion.rationale()).isEqualTo("근거");
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Exception {
+
+        @Test
+        @DisplayName("description이 null이면 IAE")
+        void create_description_null_예외() {
+            assertThatThrownBy(() -> new AxisSuggestion(null, "rationale"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("description이 blank이면 IAE")
+        void create_description_blank_예외() {
+            assertThatThrownBy(() -> new AxisSuggestion("   ", "rationale"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionTest.java
@@ -52,6 +52,22 @@ class AxisSuggestionTest {
 
             assertThat(suggestion.rationale()).isEqualTo("근거");
         }
+
+        @Test
+        @DisplayName("rationale이 빈 문자열이면 null로 정규화된다")
+        void rationale_empty_string_null로_정규화() {
+            AxisSuggestion suggestion = new AxisSuggestion("아키텍처", "");
+
+            assertThat(suggestion.rationale()).isNull();
+        }
+
+        @Test
+        @DisplayName("rationale이 공백만으로 구성되면 null로 정규화된다")
+        void rationale_blank_null로_정규화() {
+            AxisSuggestion suggestion = new AxisSuggestion("아키텍처", "   \t\n  ");
+
+            assertThat(suggestion.rationale()).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionTest.java
@@ -52,6 +52,22 @@ class AxisTopicSuggestionTest {
 
             assertThat(suggestion.rationale()).isEqualTo("근거");
         }
+
+        @Test
+        @DisplayName("rationale이 빈 문자열이면 null로 정규화된다")
+        void rationale_empty_string_null로_정규화() {
+            AxisTopicSuggestion suggestion = new AxisTopicSuggestion("도메인 모델링", "");
+
+            assertThat(suggestion.rationale()).isNull();
+        }
+
+        @Test
+        @DisplayName("rationale이 공백만으로 구성되면 null로 정규화된다")
+        void rationale_blank_null로_정규화() {
+            AxisTopicSuggestion suggestion = new AxisTopicSuggestion("도메인 모델링", "   \t\n  ");
+
+            assertThat(suggestion.rationale()).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionTest.java
@@ -1,0 +1,75 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AxisTopicSuggestion")
+class AxisTopicSuggestionTest {
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("description + rationale 정상 입력")
+        void create_valid() {
+            AxisTopicSuggestion suggestion = new AxisTopicSuggestion("도메인 모델링", "Aggregate 경계 설정");
+
+            assertThat(suggestion.description()).isEqualTo("도메인 모델링");
+            assertThat(suggestion.rationale()).isEqualTo("Aggregate 경계 설정");
+        }
+
+        @Test
+        @DisplayName("rationale이 null이어도 생성된다")
+        void create_rationale_null_허용() {
+            AxisTopicSuggestion suggestion = new AxisTopicSuggestion("도메인 모델링", null);
+
+            assertThat(suggestion.description()).isEqualTo("도메인 모델링");
+            assertThat(suggestion.rationale()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("description은 trim되어 저장된다")
+        void description_trim() {
+            AxisTopicSuggestion suggestion = new AxisTopicSuggestion("  도메인 모델링  ", null);
+
+            assertThat(suggestion.description()).isEqualTo("도메인 모델링");
+        }
+
+        @Test
+        @DisplayName("rationale이 null이 아니면 trim되어 저장된다")
+        void rationale_trim() {
+            AxisTopicSuggestion suggestion = new AxisTopicSuggestion("도메인 모델링", "  근거  ");
+
+            assertThat(suggestion.rationale()).isEqualTo("근거");
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Exception {
+
+        @Test
+        @DisplayName("description이 null이면 IAE")
+        void create_description_null_예외() {
+            assertThatThrownBy(() -> new AxisTopicSuggestion(null, "rationale"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("description이 blank이면 IAE")
+        void create_description_blank_예외() {
+            assertThatThrownBy(() -> new AxisTopicSuggestion("   ", "rationale"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionConceptContextTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionConceptContextTest.java
@@ -1,0 +1,132 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SuggestionConceptContext")
+class SuggestionConceptContextTest {
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("정상 입력은 그대로 보유된다")
+        void create_valid() {
+            SuggestionConceptContext context = new SuggestionConceptContext(
+                    List.of("백엔드 개발자", "기획자"),
+                    "구현과 문제정의를 함께 가져가고 싶어서",
+                    "더 설득력 있고 실행력 있는 제품"
+            );
+
+            assertThat(context.conceptSet()).containsExactly("백엔드 개발자", "기획자");
+            assertThat(context.compositionReason()).isEqualTo("구현과 문제정의를 함께 가져가고 싶어서");
+            assertThat(context.desiredOutcome()).isEqualTo("더 설득력 있고 실행력 있는 제품");
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("conceptSet 원소·compositionReason·desiredOutcome는 trim되어 저장된다")
+        void create_trim_normalized() {
+            SuggestionConceptContext context = new SuggestionConceptContext(
+                    List.of("  백엔드  ", "\t기획자\n"),
+                    "  reason  ",
+                    "  outcome  "
+            );
+
+            assertThat(context.conceptSet()).containsExactly("백엔드", "기획자");
+            assertThat(context.compositionReason()).isEqualTo("reason");
+            assertThat(context.desiredOutcome()).isEqualTo("outcome");
+        }
+
+        @Test
+        @DisplayName("conceptSet은 immutable로 보호되어 외부 변경이 반영되지 않는다")
+        void conceptSet_immutable() {
+            List<String> mutable = new ArrayList<>(Arrays.asList("백엔드", "기획자"));
+
+            SuggestionConceptContext context = new SuggestionConceptContext(
+                    mutable, "reason", "outcome"
+            );
+            mutable.add("디자이너");
+
+            assertThat(context.conceptSet()).hasSize(2);
+            assertThatThrownBy(() -> context.conceptSet().add("PM"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Exception {
+
+        @Test
+        @DisplayName("conceptSet이 null이면 IAE")
+        void create_conceptSet_null_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(null, "r", "o"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("conceptSet이 빈 리스트이면 IAE")
+        void create_conceptSet_empty_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(List.of(), "r", "o"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("conceptSet 원소가 null이면 IAE")
+        void create_conceptSet_원소_null_예외() {
+            List<String> conceptSet = Arrays.asList("백엔드", null);
+
+            assertThatThrownBy(() -> new SuggestionConceptContext(conceptSet, "r", "o"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("conceptSet 원소가 blank이면 IAE")
+        void create_conceptSet_원소_blank_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(List.of("백엔드", "   "), "r", "o"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("compositionReason이 null이면 IAE")
+        void create_compositionReason_null_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(List.of("백엔드"), null, "o"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("compositionReason이 blank이면 IAE")
+        void create_compositionReason_blank_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(List.of("백엔드"), "  ", "o"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("desiredOutcome이 null이면 IAE")
+        void create_desiredOutcome_null_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(List.of("백엔드"), "r", null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("desiredOutcome이 blank이면 IAE")
+        void create_desiredOutcome_blank_예외() {
+            assertThatThrownBy(() -> new SuggestionConceptContext(List.of("백엔드"), "r", "\t\n"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionPortDomainIsolationTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionPortDomainIsolationTest.java
@@ -1,0 +1,61 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 도메인 계층이 Suggestion Port·VO에 의존하지 않음을 검증한다.
+ *
+ * <p>ArchUnit 의존 미설치 — Story 1-1 DoD가 허용하는 grep 기반 검증으로 대체.
+ * Hexagonal 원칙: 도메인은 외부 시스템(LLM 등)의 존재를 모른다.</p>
+ */
+@DisplayName("Suggestion Port 도메인 격리 (grep 기반)")
+class SuggestionPortDomainIsolationTest {
+
+    private static final Path DOMAIN_ROOT = Path.of(
+            "src", "main", "java",
+            "com", "example", "thirdtool",
+            "LearningFacade", "domain"
+    );
+
+    private static final Pattern FORBIDDEN = Pattern.compile(
+            "AxisSuggestionPort|AxisTopicSuggestionPort|SuggestionConceptContext|AxisSuggestion|AxisTopicSuggestion"
+    );
+
+    @Test
+    @DisplayName("LearningFacade/domain/ 하위 어떤 .java 파일에도 Suggestion Port·VO 참조가 없다")
+    void domain_layer_has_no_suggestion_reference() throws IOException {
+        assertThat(DOMAIN_ROOT).exists();
+
+        List<String> violations = new ArrayList<>();
+        Files.walkFileTree(DOMAIN_ROOT, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (!file.toString().endsWith(".java")) {
+                    return FileVisitResult.CONTINUE;
+                }
+                String content = Files.readString(file);
+                if (FORBIDDEN.matcher(content).find()) {
+                    violations.add(file.toString());
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        assertThat(violations)
+                .as("도메인 계층은 Suggestion Port·VO를 import/참조하지 않아야 한다.")
+                .isEmpty();
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionPortDomainIsolationTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionPortDomainIsolationTest.java
@@ -31,7 +31,7 @@ class SuggestionPortDomainIsolationTest {
     );
 
     private static final Pattern FORBIDDEN = Pattern.compile(
-            "AxisSuggestionPort|AxisTopicSuggestionPort|SuggestionConceptContext|AxisSuggestion|AxisTopicSuggestion"
+            "\\b(AxisSuggestionPort|AxisTopicSuggestionPort|SuggestionConceptContext|AxisSuggestion|AxisTopicSuggestion)\\b"
     );
 
     @Test


### PR DESCRIPTION
## 개요
LearningFacade BC에 AI 제안 outbound Port 패턴을 처음 도입한다. `AxisSuggestionPort` / `AxisTopicSuggestionPort` 인터페이스와 그 입출력 VO 3종(`SuggestionConceptContext`, `AxisSuggestion`, `AxisTopicSuggestion`)을 정의해 후속 Static/LLM Adapter(Story 1-2 / 3-1 / 4-1)의 의존 기반을 마련한다.

## 왜 / 설계 결정
- **도메인 격리**: 도메인 엔티티(`LearningFacade`, `LearningAxis`, `AxisTopic`)는 Port/VO를 import하지 않는다 — Application Service만 참조. grep 기반 단위 테스트로 강제.
- **VO 위치 = `application/port/out/suggestion/`**: 도메인이 Port의 반환 타입조차 모르도록 분리. Repository Port가 `infrastructure/persistence/`에 있는 것과 별개의 outbound 패턴 (인바운드 영속성 vs 아웃바운드 외부 서비스).
- **`rationale = nullable`**: LLM이 안정적으로 rationale을 생성한다는 보장이 없어 누락 허용. 빈 문자열/공백 입력은 `null`로 정규화 (conventions.md §1.1 선택적 nullable String 정책 일치).
- **거부 대안**: 도메인 Service에서 `ChatClient` 직접 주입 (도메인↔Spring AI 강결합), 단일 `SuggestionPort` (Axis/AxisTopic 시그니처가 다른데 강제 결합).
- 기각 사유 / Epic 결정 메모: `workflow/product/pes/ready/product-aisuggestion.md` §대안 검토 + §Epic 1 기술 결정.

## 작업 내용
- feat(facade): `application/port/out/suggestion/` 신설 — `AxisSuggestionPort`, `AxisTopicSuggestionPort` 인터페이스 + `SuggestionConceptContext`, `AxisSuggestion`, `AxisTopicSuggestion` record VO
- feat(facade): Compact constructor 검증 — 필수 필드 trim + blank 거부, `conceptSet` immutable 보장, `rationale` "" / blank → null 정규화
- test(facade): VO 단위 테스트 3건 (해피/엣지/예외 3구분) + 도메인 격리 grep 테스트 1건 (word boundary 적용)

## 변경 유형
- [x] feat  - [ ] fix  - [x] refactor  - [ ] docs  - [ ] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.application.port.out.suggestion.*"` → **BUILD SUCCESSFUL**
- 검증된 항목: VO 불변식(해피/엣지/예외), trim 정규화, rationale null 허용 + 빈문자열→null 정규화, 도메인 계층 격리(grep 0건)

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] BC 간 의존 방향 위반 없음 (도메인 → Port import 0건 grep 검증)
- [x] 대상 브랜치 = `develop`
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 사용 — **N/A** (Controller/Response DTO 변경 없음)
- [ ] OSIV=false, READ_COMMITTED 등 — **N/A** (DB·트랜잭션 변경 없음)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 — **Epic 1 종료 시 일괄** (ADR-AI-001, PACKAGE.md `application/port/out/` 패턴 추가)

## Reviewer 세션 결과
5관점 병렬 reviewer (Domain / Architecture / API/Exception / Test / Sceptical) 호출 후 Major 2건 + Nit 1건을 두 번째 commit으로 즉시 반영:
- `rationale` 빈 문자열/공백 → null 정규화 (conventions.md §1.1)
- 도메인 격리 grep 패턴에 word boundary 추가 (false positive 차단)
- `Stream.toList()` 결과의 중복 `List.copyOf()` 제거

Minor 4건(Port javadoc 보강 / product AC docs 정정 / SuggestionConceptContext 필수 필드 명시 / 상대 경로)은 후속 Story 1-2 또는 Epic 1 종료 시 일괄 처리.

## 관련 이슈
- Product: `workflow/product/pes/ready/product-aisuggestion.md`
- Epic 1: AI 제안 기반 구조 구축 (Port + Static Adapter + 에러 체계)
- Story: Story 1-1 (SuggestionPort 인터페이스 정의)