### PR TITLE
feat(facade): Story 1-2 Static Suggestion Adapter 2종 + 조건부 활성화

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisSuggestionPort.java
@@ -18,6 +18,15 @@ public interface AxisSuggestionPort {
      * <p>구현체는 {@code existingAxisNames}와 중복되는 후보를 제거하고 최대 {@code limit}개까지 반환한다.
      * 호출 실패 시(타임아웃 / 파싱 실패 / 인증 실패)는 구현체별 예외로 던지며, 상위 Service가
      * 빈 목록 + {@code suggestionsAvailable: false}로 변환한다(Fallback 정책).</p>
+     *
+     * <p><b>Port 계약 (구현체 공통)</b>:</p>
+     * <ul>
+     *   <li>{@code existingAxisNames}의 각 원소는 trim 후 비교한다 (conventions.md §1.1 입력 정규화).</li>
+     *   <li>{@code existingAxisNames}가 null이거나 빈 리스트면 중복 제거 없이 후보 전체에서 limit만큼 반환.</li>
+     *   <li>{@code existingAxisNames}의 null 원소는 무시한다 (예외 미발생).</li>
+     *   <li>{@code limit <= 0}이면 빈 목록을 반환하고 예외를 던지지 않는다.</li>
+     *   <li>구현체는 입력 List를 변경해선 안 된다 (read-only contract).</li>
+     * </ul>
      */
     List<AxisSuggestion> suggest(SuggestionConceptContext conceptContext,
                                  List<String> existingAxisNames,

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/AxisTopicSuggestionPort.java
@@ -18,6 +18,16 @@ public interface AxisTopicSuggestionPort {
      * <p>구현체는 {@code existingTopicNames}와 중복되는 후보를 제거하고 최대 {@code limit}개까지 반환한다.
      * 호출 실패 시는 구현체별 예외로 던지며, 상위 Service가 빈 목록 + {@code suggestionsAvailable: false}로
      * 변환한다(Fallback 정책).</p>
+     *
+     * <p><b>Port 계약 (구현체 공통)</b>:</p>
+     * <ul>
+     *   <li>{@code existingTopicNames}의 각 원소는 trim 후 비교한다 (conventions.md §1.1 입력 정규화).</li>
+     *   <li>{@code existingTopicNames}가 null이거나 빈 리스트면 중복 제거 없이 후보 전체에서 limit만큼 반환.</li>
+     *   <li>{@code existingTopicNames}의 null 원소는 무시한다 (예외 미발생).</li>
+     *   <li>{@code limit <= 0}이면 빈 목록을 반환하고 예외를 던지지 않는다.</li>
+     *   <li>구현체는 입력 List를 변경해선 안 된다 (read-only contract).</li>
+     *   <li>Static 구현은 {@code axisName}을 사용하지 않으나, LLM 구현은 축 컨텍스트로 활용한다.</li>
+     * </ul>
      */
     List<AxisTopicSuggestion> suggest(SuggestionConceptContext conceptContext,
                                       String axisName,

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisSuggestionAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisSuggestionAdapter.java
@@ -3,6 +3,9 @@ package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestion;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestionPort;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionConceptContext;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +32,10 @@ import java.util.Set;
 )
 public class StaticAxisSuggestionAdapter implements AxisSuggestionPort {
 
+    private static final Logger log = LoggerFactory.getLogger(StaticAxisSuggestionAdapter.class);
+
+    // 사이즈 = 5. LearningFacade.RECOMMENDED_AXIS_LIMIT(=5)와 의도적으로 정합.
+    // 도메인 권장 한도 변경 시 본 목록도 함께 조정.
     static final List<String> FIXED_AXIS_NAMES = List.of(
             "기초 지식",
             "핵심 방법론",
@@ -36,6 +43,12 @@ public class StaticAxisSuggestionAdapter implements AxisSuggestionPort {
             "실전 응용",
             "심화 주제"
     );
+
+    @PostConstruct
+    void announceActivation() {
+        log.info("StaticAxisSuggestionAdapter activated — LLM-free fallback. "
+                + "운영 환경이면 thirdtool.suggestion.provider=llm 설정 여부 확인 필요.");
+    }
 
     @Override
     public List<AxisSuggestion> suggest(SuggestionConceptContext conceptContext,

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisSuggestionAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisSuggestionAdapter.java
@@ -1,0 +1,67 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestion;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestionPort;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionConceptContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Axis 제안 Static Adapter.
+ *
+ * <p>고정 카테고리 목록에서 {@code existingAxisNames}와 중복되는 항목을 제거한 뒤
+ * {@code limit}만큼 반환한다. LLM 호출이 없어 로컬 개발·통합 테스트·LLM 장애 상황에서도
+ * 유저 입력 흐름이 끊기지 않게 한다.</p>
+ *
+ * <p>{@code thirdtool.suggestion.provider} 미설정 또는 {@code static}일 때 활성화.</p>
+ */
+@Component
+@ConditionalOnProperty(
+        name = "thirdtool.suggestion.provider",
+        havingValue = "static",
+        matchIfMissing = true
+)
+public class StaticAxisSuggestionAdapter implements AxisSuggestionPort {
+
+    static final List<String> FIXED_AXIS_NAMES = List.of(
+            "기초 지식",
+            "핵심 방법론",
+            "도구와 환경",
+            "실전 응용",
+            "심화 주제"
+    );
+
+    @Override
+    public List<AxisSuggestion> suggest(SuggestionConceptContext conceptContext,
+                                        List<String> existingAxisNames,
+                                        int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        Set<String> exclude = toExcludeSet(existingAxisNames);
+        return FIXED_AXIS_NAMES.stream()
+                .filter(name -> !exclude.contains(name))
+                .limit(limit)
+                .map(name -> new AxisSuggestion(name, null))
+                .toList();
+    }
+
+    private Set<String> toExcludeSet(Collection<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> result = new HashSet<>();
+        for (String name : names) {
+            if (name != null) {
+                result.add(name.trim());
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisTopicSuggestionAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisTopicSuggestionAdapter.java
@@ -3,6 +3,9 @@ package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestion;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestionPort;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionConceptContext;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +32,10 @@ import java.util.Set;
 )
 public class StaticAxisTopicSuggestionAdapter implements AxisTopicSuggestionPort {
 
+    private static final Logger log = LoggerFactory.getLogger(StaticAxisTopicSuggestionAdapter.class);
+
+    // 사이즈 = 10. LearningAxis.RECOMMENDED_TOPIC_LIMIT(=10)와 의도적으로 정합.
+    // 도메인 권장 한도 변경 시 본 목록도 함께 조정.
     static final List<String> FIXED_TOPIC_NAMES = List.of(
             "기초 이해",
             "구조 설계",
@@ -41,6 +48,12 @@ public class StaticAxisTopicSuggestionAdapter implements AxisTopicSuggestionPort
             "패턴 인식",
             "비교 검토"
     );
+
+    @PostConstruct
+    void announceActivation() {
+        log.info("StaticAxisTopicSuggestionAdapter activated — LLM-free fallback. "
+                + "운영 환경이면 thirdtool.suggestion.provider=llm 설정 여부 확인 필요.");
+    }
 
     @Override
     public List<AxisTopicSuggestion> suggest(SuggestionConceptContext conceptContext,

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisTopicSuggestionAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisTopicSuggestionAdapter.java
@@ -1,0 +1,73 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestion;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestionPort;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionConceptContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * AxisTopic 제안 Static Adapter.
+ *
+ * <p>고정 주제 목록에서 {@code existingTopicNames}와 중복되는 항목을 제거한 뒤
+ * {@code limit}만큼 반환한다. 축 이름({@code axisName})은 컨텍스트로 받지만 Static 버전에선
+ * 사용하지 않는다 — LLM Adapter에서 실제 컨텍스트로 활용된다.</p>
+ *
+ * <p>{@code thirdtool.suggestion.provider} 미설정 또는 {@code static}일 때 활성화.</p>
+ */
+@Component
+@ConditionalOnProperty(
+        name = "thirdtool.suggestion.provider",
+        havingValue = "static",
+        matchIfMissing = true
+)
+public class StaticAxisTopicSuggestionAdapter implements AxisTopicSuggestionPort {
+
+    static final List<String> FIXED_TOPIC_NAMES = List.of(
+            "기초 이해",
+            "구조 설계",
+            "심화 응용",
+            "도구 활용",
+            "실전 사례",
+            "핵심 개념 정리",
+            "방법론 학습",
+            "사례 분석",
+            "패턴 인식",
+            "비교 검토"
+    );
+
+    @Override
+    public List<AxisTopicSuggestion> suggest(SuggestionConceptContext conceptContext,
+                                             String axisName,
+                                             List<String> existingTopicNames,
+                                             int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        Set<String> exclude = toExcludeSet(existingTopicNames);
+        return FIXED_TOPIC_NAMES.stream()
+                .filter(name -> !exclude.contains(name))
+                .limit(limit)
+                .map(name -> new AxisTopicSuggestion(name, null))
+                .toList();
+    }
+
+    private Set<String> toExcludeSet(Collection<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> result = new HashSet<>();
+        for (String name : names) {
+            if (name != null) {
+                result.add(name.trim());
+            }
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisSuggestionAdapterTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisSuggestionAdapterTest.java
@@ -1,0 +1,120 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestion;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionConceptContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("StaticAxisSuggestionAdapter")
+class StaticAxisSuggestionAdapterTest {
+
+    private final StaticAxisSuggestionAdapter adapter = new StaticAxisSuggestionAdapter();
+    private final SuggestionConceptContext context = new SuggestionConceptContext(
+            List.of("백엔드 개발자"),
+            "구현과 기획을 함께 가져가고 싶어서",
+            "더 설득력 있는 제품"
+    );
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("existing이 빈 리스트면 고정 목록을 limit만큼 순서대로 반환한다")
+        void suggest_existing_빈_limit_5_고정목록_그대로() {
+            List<AxisSuggestion> result = adapter.suggest(context, List.of(), 5);
+
+            assertThat(result).extracting(AxisSuggestion::description)
+                    .containsExactlyElementsOf(StaticAxisSuggestionAdapter.FIXED_AXIS_NAMES);
+            assertThat(result).allSatisfy(s -> assertThat(s.rationale()).isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("existing 1건 포함 시 해당 항목을 제외한 나머지 4개를 반환한다 (AC #2)")
+        void suggest_existing_기초지식_limit_5_4개_반환() {
+            List<AxisSuggestion> result = adapter.suggest(context, List.of("기초 지식"), 5);
+
+            assertThat(result).extracting(AxisSuggestion::description)
+                    .containsExactly("핵심 방법론", "도구와 환경", "실전 응용", "심화 주제");
+        }
+
+        @Test
+        @DisplayName("existing 전체 5건이 겹치면 빈 목록 반환 (AC #3, 예외 X)")
+        void suggest_existing_전체겹침_빈목록() {
+            List<AxisSuggestion> result = adapter.suggest(
+                    context,
+                    StaticAxisSuggestionAdapter.FIXED_AXIS_NAMES,
+                    5
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("limit=0이면 빈 목록 반환 (AC #4)")
+        void suggest_limit_0_빈목록() {
+            List<AxisSuggestion> result = adapter.suggest(context, List.of(), 0);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("limit이 음수이면 빈 목록 반환")
+        void suggest_limit_음수_빈목록() {
+            List<AxisSuggestion> result = adapter.suggest(context, List.of(), -3);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("limit이 가용 후보 수보다 크면 가용 후보 전부 반환")
+        void suggest_limit_가용보다큼_가용전부() {
+            List<AxisSuggestion> result = adapter.suggest(context, List.of(), 100);
+
+            assertThat(result).hasSize(StaticAxisSuggestionAdapter.FIXED_AXIS_NAMES.size());
+        }
+
+        @Test
+        @DisplayName("existing이 null이면 고정 목록을 그대로 반환한다 (방어)")
+        void suggest_existing_null_고정목록_그대로() {
+            List<AxisSuggestion> result = adapter.suggest(context, null, 5);
+
+            assertThat(result).extracting(AxisSuggestion::description)
+                    .containsExactlyElementsOf(StaticAxisSuggestionAdapter.FIXED_AXIS_NAMES);
+        }
+
+        @Test
+        @DisplayName("existing 원소의 앞뒤 공백은 trim 후 비교한다")
+        void suggest_existing_공백포함_trim_비교() {
+            List<AxisSuggestion> result = adapter.suggest(context, List.of("  기초 지식  "), 5);
+
+            assertThat(result).extracting(AxisSuggestion::description)
+                    .doesNotContain("기초 지식")
+                    .hasSize(4);
+        }
+
+        @Test
+        @DisplayName("existing 원소에 null이 섞여 있어도 무시하고 진행한다")
+        void suggest_existing_null원소_무시() {
+            List<String> existing = new java.util.ArrayList<>();
+            existing.add("기초 지식");
+            existing.add(null);
+
+            List<AxisSuggestion> result = adapter.suggest(context, existing, 5);
+
+            assertThat(result).extracting(AxisSuggestion::description)
+                    .doesNotContain("기초 지식")
+                    .hasSize(4);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisTopicSuggestionAdapterTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticAxisTopicSuggestionAdapterTest.java
@@ -1,0 +1,119 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestion;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionConceptContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("StaticAxisTopicSuggestionAdapter")
+class StaticAxisTopicSuggestionAdapterTest {
+
+    private final StaticAxisTopicSuggestionAdapter adapter = new StaticAxisTopicSuggestionAdapter();
+    private final SuggestionConceptContext context = new SuggestionConceptContext(
+            List.of("백엔드 개발자"),
+            "구현과 기획을 함께 가져가고 싶어서",
+            "더 설득력 있는 제품"
+    );
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("existing이 빈 리스트면 고정 목록을 limit만큼 순서대로 반환한다")
+        void suggest_existing_빈_limit_5_고정목록_앞5개() {
+            List<AxisTopicSuggestion> result = adapter.suggest(context, "기초 지식", List.of(), 5);
+
+            assertThat(result).extracting(AxisTopicSuggestion::description)
+                    .containsExactly("기초 이해", "구조 설계", "심화 응용", "도구 활용", "실전 사례");
+            assertThat(result).allSatisfy(s -> assertThat(s.rationale()).isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("existing 1건 포함 시 해당 항목을 제외하고 limit만큼 반환한다")
+        void suggest_existing_기초이해_limit_5_나머지_5개() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context, "기초 지식", List.of("기초 이해"), 5
+            );
+
+            assertThat(result).extracting(AxisTopicSuggestion::description)
+                    .containsExactly("구조 설계", "심화 응용", "도구 활용", "실전 사례", "핵심 개념 정리");
+        }
+
+        @Test
+        @DisplayName("existing 전체가 겹치면 빈 목록 반환 (예외 X)")
+        void suggest_existing_전체겹침_빈목록() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context,
+                    "기초 지식",
+                    StaticAxisTopicSuggestionAdapter.FIXED_TOPIC_NAMES,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("limit=0이면 빈 목록 반환")
+        void suggest_limit_0_빈목록() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context, "기초 지식", List.of(), 0
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("limit이 음수이면 빈 목록 반환")
+        void suggest_limit_음수_빈목록() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context, "기초 지식", List.of(), -1
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("limit이 가용 후보 수보다 크면 가용 후보 전부 반환")
+        void suggest_limit_가용보다큼_가용전부() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context, "기초 지식", List.of(), 100
+            );
+
+            assertThat(result).hasSize(StaticAxisTopicSuggestionAdapter.FIXED_TOPIC_NAMES.size());
+        }
+
+        @Test
+        @DisplayName("existing이 null이면 고정 목록을 그대로 limit만큼 반환한다 (방어)")
+        void suggest_existing_null_방어() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context, "기초 지식", null, 3
+            );
+
+            assertThat(result).extracting(AxisTopicSuggestion::description)
+                    .containsExactly("기초 이해", "구조 설계", "심화 응용");
+        }
+
+        @Test
+        @DisplayName("existing 원소의 앞뒤 공백은 trim 후 비교한다")
+        void suggest_existing_공백포함_trim_비교() {
+            List<AxisTopicSuggestion> result = adapter.suggest(
+                    context, "기초 지식", List.of("  기초 이해  "), 10
+            );
+
+            assertThat(result).extracting(AxisTopicSuggestion::description)
+                    .doesNotContain("기초 이해")
+                    .hasSize(9);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
@@ -3,41 +3,74 @@ package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestionPort;
 import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestionPort;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Story 1-2 AC #1 — {@code thirdtool.suggestion.provider=static} 상태에서 Static Adapter
- * Bean이 활성화되어 Port 주입 시 Static 인스턴스가 반환되는지 검증.
+ * Story 1-2 AC #1 — {@code thirdtool.suggestion.provider}의 양방향 동작 검증.
  *
- * <p>{@code matchIfMissing=true}이므로 미설정 케이스도 본 케이스와 동일하게 동작한다.
- * 다른 값(예: {@code llm}) 케이스의 비활성화 검증은 LLM Adapter가 도입되는 Story 2-1에서
- * 자연스럽게 함께 검증된다.</p>
+ * <ul>
+ *   <li>{@code provider=static} 또는 미설정 → 두 Static Adapter Bean 활성화 (matchIfMissing=true)</li>
+ *   <li>{@code provider=llm} (또는 알 수 없는 값) → 두 Static Adapter Bean 비활성화</li>
+ * </ul>
+ *
+ * <p>현 시점 LLM Adapter는 미구현이라 비활성화 케이스에선 Port Bean이 0개. Application Service가
+ * 아직 Port를 주입받지 않으므로 컨텍스트 로딩은 정상. Story 2-1에서 LLM Adapter가 도입되면
+ * 동일 패턴으로 LLM 활성화 케이스도 함께 검증된다.</p>
  */
-@SpringBootTest(properties = "thirdtool.suggestion.provider=static")
-@ActiveProfiles("dev")
-@DisplayName("Static Suggestion Adapter — provider=static 조건 활성화")
+@DisplayName("Static Suggestion Adapter — provider 조건부 활성화")
 class StaticSuggestionAdapterConditionalTest {
 
-    @Autowired
-    private AxisSuggestionPort axisPort;
+    @Nested
+    @SpringBootTest(properties = "thirdtool.suggestion.provider=static")
+    @ActiveProfiles("dev")
+    @DisplayName("provider=static (또는 미설정 matchIfMissing)")
+    class WhenStaticProvider {
 
-    @Autowired
-    private AxisTopicSuggestionPort axisTopicPort;
+        @Autowired
+        private AxisSuggestionPort axisPort;
 
-    @Test
-    @DisplayName("provider=static 환경에서 AxisSuggestionPort는 Static 구현체로 주입된다")
-    void axisPort_static_구현체_주입() {
-        assertThat(axisPort).isInstanceOf(StaticAxisSuggestionAdapter.class);
+        @Autowired
+        private AxisTopicSuggestionPort axisTopicPort;
+
+        @Test
+        @DisplayName("AxisSuggestionPort는 Static 구현체로 주입된다")
+        void axisPort_static_구현체_주입() {
+            assertThat(axisPort).isInstanceOf(StaticAxisSuggestionAdapter.class);
+        }
+
+        @Test
+        @DisplayName("AxisTopicSuggestionPort는 Static 구현체로 주입된다")
+        void axisTopicPort_static_구현체_주입() {
+            assertThat(axisTopicPort).isInstanceOf(StaticAxisTopicSuggestionAdapter.class);
+        }
     }
 
-    @Test
-    @DisplayName("provider=static 환경에서 AxisTopicSuggestionPort는 Static 구현체로 주입된다")
-    void axisTopicPort_static_구현체_주입() {
-        assertThat(axisTopicPort).isInstanceOf(StaticAxisTopicSuggestionAdapter.class);
+    @Nested
+    @SpringBootTest(properties = "thirdtool.suggestion.provider=llm")
+    @ActiveProfiles("dev")
+    @DisplayName("provider=llm (비-static)")
+    class WhenNonStaticProvider {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @DisplayName("StaticAxisSuggestionAdapter Bean이 컨텍스트에 등록되지 않는다")
+        void staticAxisAdapter_bean_비활성화() {
+            assertThat(context.getBeansOfType(StaticAxisSuggestionAdapter.class)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("StaticAxisTopicSuggestionAdapter Bean이 컨텍스트에 등록되지 않는다")
+        void staticAxisTopicAdapter_bean_비활성화() {
+            assertThat(context.getBeansOfType(StaticAxisTopicSuggestionAdapter.class)).isEmpty();
+        }
     }
 }

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
@@ -1,0 +1,43 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisSuggestionPort;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.AxisTopicSuggestionPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 1-2 AC #1 — {@code thirdtool.suggestion.provider=static} 상태에서 Static Adapter
+ * Bean이 활성화되어 Port 주입 시 Static 인스턴스가 반환되는지 검증.
+ *
+ * <p>{@code matchIfMissing=true}이므로 미설정 케이스도 본 케이스와 동일하게 동작한다.
+ * 다른 값(예: {@code llm}) 케이스의 비활성화 검증은 LLM Adapter가 도입되는 Story 2-1에서
+ * 자연스럽게 함께 검증된다.</p>
+ */
+@SpringBootTest(properties = "thirdtool.suggestion.provider=static")
+@ActiveProfiles("dev")
+@DisplayName("Static Suggestion Adapter — provider=static 조건 활성화")
+class StaticSuggestionAdapterConditionalTest {
+
+    @Autowired
+    private AxisSuggestionPort axisPort;
+
+    @Autowired
+    private AxisTopicSuggestionPort axisTopicPort;
+
+    @Test
+    @DisplayName("provider=static 환경에서 AxisSuggestionPort는 Static 구현체로 주입된다")
+    void axisPort_static_구현체_주입() {
+        assertThat(axisPort).isInstanceOf(StaticAxisSuggestionAdapter.class);
+    }
+
+    @Test
+    @DisplayName("provider=static 환경에서 AxisTopicSuggestionPort는 Static 구현체로 주입된다")
+    void axisTopicPort_static_구현체_주입() {
+        assertThat(axisTopicPort).isInstanceOf(StaticAxisTopicSuggestionAdapter.class);
+    }
+}


### PR DESCRIPTION
## 개요
Story 1-1에서 정의한 `AxisSuggestionPort` / `AxisTopicSuggestionPort`의 첫 구현체로 Static Adapter 2종을 도입한다. LLM 호출 없이 고정 카테고리/주제 목록에서 `existing`을 차감해 `limit`만큼 반환한다. 로컬·통합 테스트·LLM 장애 상황에서 유저 입력 흐름이 끊기지 않는 안전망 + Epic 1의 Port-Adapter 패턴 검증용 reference 구현.

## 왜 / 설계 결정
- **Static 우선 도입 (LLM 후순위)**: `thirdtool.suggestion.provider`가 미설정/`static`일 때 자동 활성화 (`matchIfMissing=true`). LLM 비용 0원으로 PoC 가능, 어떤 환경에서도 유저 흐름이 끊기지 않는 안전 기본값.
- **고정 목록 = 코드 상수**: YAML 외부화는 변경 빈도 대비 인프라 부담만 큼. v1은 코드 상수 + 단위 테스트로 충분.
- **Port 계약 명시**: 모든 Static/LLM Adapter가 따라야 할 정책(trim 비교 / null 원소 무시 / `limit<=0`→빈 목록 / immutable contract)을 Port javadoc에 못박음.
- **거부 대안**: Adapter 내부 결정 분기(LLM Adapter가 다른 정책 가질 위험), YAML 외부화(v1 단계 무의미한 복잡도).
- 결정 근거: `workflow/product/pes/ready/product-aisuggestion.md` 라인 45-48 (matchIfMissing 결정), 596 (코드 상수 결정), 689-746 (Story 1-2 전체).

## 작업 내용
- feat(facade): `LearningFacade/infrastructure/suggestion/` 신설 — `StaticAxisSuggestionAdapter` (Axis 5개) / `StaticAxisTopicSuggestionAdapter` (Topic 10개)
- feat(facade): `@ConditionalOnProperty(matchIfMissing=true)` + `@PostConstruct` INFO 로그 (사일런트 fallback이 prod에 들켜지지 않을 위험 완화)
- refactor(facade): `AxisSuggestionPort` / `AxisTopicSuggestionPort` javadoc에 Port 계약 5종 명시 (trim/null-skip/limit<=0/immutable/axisName 활용 정책)
- test(facade): 단위 16건 + 슬라이스 4건 (`@Nested` 양방향: provider=static 활성 + provider=llm 비활성)

## 변경 유형
- [x] feat  - [ ] fix  - [x] refactor  - [ ] docs  - [ ] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.infrastructure.suggestion.*" --tests "com.example.thirdtool.LearningFacade.application.port.out.suggestion.*"` → **BUILD SUCCESSFUL**
- 검증된 항목:
  - Story AC #1: `provider=static` (또는 미설정) → Static Adapter Bean 활성화. `provider=llm` → Bean 0개
  - Story AC #2: `limit=5, existing=["기초 지식"]` → "기초 지식" 제외 4개 반환
  - Story AC #3: `existing` 전부 겹침 → 빈 목록 (예외 X)
  - Story AC #4: `limit=0` → 빈 목록. 추가로 음수 limit, limit 초과 가용 후보, null existing, null 원소, trim 비교까지 커버

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] BC 간 의존 방향 위반 없음 (Adapter가 다른 BC import 0건 grep 확인)
- [x] 대상 브랜치 = `develop`
- [ ] 모든 응답 `ApiResponse<T>` 래퍼 — **N/A** (Controller/Response DTO 변경 없음)
- [ ] OSIV=false 등 — **N/A** (DB 변경 없음, SpringBootTest는 컨텍스트 활성화 검증용)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 — **Epic 1 종료 시 일괄** (ADR-AI-001 + PACKAGE.md `infrastructure/suggestion/` 패턴 추가)

## Reviewer 세션 결과
5관점 병렬 reviewer 호출 후 Major 2건 + Minor 2건을 두 번째 commit으로 즉시 반영:
- `@PostConstruct` INFO 로그 (사일런트 fallback 위험 완화 — product line 47-48)
- Port javadoc 계약 명시 (후속 LLM Adapter도 동일 정책 강제)
- 슬라이스 테스트 양방향(`@Nested`) 검증 (`provider=llm` Bean 비활성화 케이스 추가)
- 고정 목록 크기 = 도메인 권장 한도(`RECOMMENDED_AXIS_LIMIT=5` / `RECOMMENDED_TOPIC_LIMIT=10`) 정합 의도 주석

Minor/Nit 후속 처리:
- `rationale=null` JSON 직렬화 정책 → Controller 도입 Epic 3/4
- `suggestionsAvailable` 응답 플래그 → Application Service 도입 시점
- `@SpringBootTest` → `ApplicationContextRunner` 마이그레이션 → LLM Adapter 4중복 시 재평가
- PACKAGE.md / ADR-AI-001 → Epic 1 종료 시 일괄

## 관련 이슈
- Product: `workflow/product/pes/ready/product-aisuggestion.md`
- Epic 1: AI 제안 기반 구조 구축 (Port + Static Adapter + 에러 체계)
- Story: Story 1-2 (Static Suggestion Adapter 구현). 선행 Story 1-1 (#162 머지 완료)