### PR TITLE
feat(facade): Suggestion 에러 체계 + Fallback 정책 [Story-1-3]

### DIFF
--- a/docs/adr/ADR010.md
+++ b/docs/adr/ADR010.md
@@ -1,0 +1,81 @@
+# ADR010: AI 제안 호출 실패는 5xx 미노출 — 빈 목록 + suggestionsAvailable 플래그로 변환
+
+- **상태**: Accepted
+- **날짜**: 2026-06-22
+- **관련**: Product 「AI 제안」(`workflow/product/pes/ready/product-aisuggestion.md`), Epic 1, Story 1-3
+
+## 컨텍스트
+
+LearningFacade BC에 AI 제안(Suggestion) outbound Port가 도입되었다 — `AxisSuggestionPort` / `AxisTopicSuggestionPort` (Story 1-1). 구현체는 Static(Story 1-2 / 무장애)과 LLM(Epic 2~4 예정 / Vertex AI Gemini Flash 2.5) 두 갈래다.
+
+LLM 호출은 본질적으로 실패한다.
+
+- 타임아웃 / 네트워크 일시 장애 — 트래픽이나 Gemini 측 부하에 따라 수 % 빈도
+- 응답 형식 불일치 — `BeanOutputConverter` 파싱 실패
+- 인증 실패 — GCP API Key 만료/회수, ADC 설정 누락
+
+AI 제안은 **부가 정보**다. 카드/덱/축의 핵심 기능과 달리, "지금 제안이 안 보임"이 곧 시스템 장애는 아니다. 그러나 응답 처리를 잘못하면 사용자에게 5xx가 그대로 노출되어 학습 흐름이 끊긴다.
+
+또한 후속 Service(Epic 3/4)가 동일한 fallback 규칙을 각자 다르게 구현하면 정책 일관성이 깨진다 — 동일 ErrorCode가 한쪽에서는 5xx로, 다른 쪽에서는 200으로 응답되는 분산을 방지해야 한다.
+
+## 결정
+
+**AI 호출 실패는 사용자에게 5xx로 노출하지 않는다. 상위 Service가 catch하여 빈 목록 + `suggestionsAvailable=false` 플래그로 변환한다.**
+
+대상 ErrorCode 3종 (`Common/Exception/ErrorCode/ErrorCode`):
+
+| 코드 | 이름 | 의미 | 매핑 HttpStatus(우회 호출 시) |
+| --- | --- | --- | --- |
+| `LF_SUGGEST_001` | `LEARNING_FACADE_SUGGESTION_TIMEOUT` | AI 호출 타임아웃 / 네트워크 장애 | 503 |
+| `LF_SUGGEST_002` | `LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE` | 응답 파싱 실패, 규약 불일치 | 502 |
+| `LF_SUGGEST_003` | `LEARNING_FACADE_SUGGESTION_AUTH_FAILED` | API Key 누락/만료/권한 부족 | 503 |
+
+HttpStatus 값은 **fallback이 적용되지 않을 때(예: 운영 디버깅 우회 호출 / 직접 Adapter 테스트)** 의 기본 매핑이다. 정상 응답 경로에서는 Service가 catch하기 전에 GlobalExceptionHandler까지 도달하지 않는다.
+
+### 구현 단일 진입점 — `SuggestionFallbacks.protect`
+
+```java
+SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbacks.protect(
+    () -> axisSuggestionPort.suggest(context, existingNames, limit)
+);
+// result.suggestionsAvailable() / result.suggestions()
+```
+
+- 위치: `LearningFacade.application.port.out.suggestion.SuggestionFallbacks`
+- 위 3종 ErrorCode 예외만 catch — 그 외 모든 예외는 전파 (fail-fast)
+- catch 시 `WARN` 레벨 로그 + `suggestionErrorCode` MDC 키 주입 → ELK / OpenTelemetry로 traceId와 함께 추적 가능
+- 결과 VO `SuggestionFallbackResult<T>`: `suggestions: List<T>` + `suggestionsAvailable: boolean`. 정적 팩토리 `available(list)` / `unavailable()`만으로 생성
+
+### Adapter 측 책임
+
+LLM Adapter(Epic 2/3/4)는 Spring AI / WebClient 예외를 위 3종 ErrorCode로 변환해 `LearningFacadeDomainException`을 던진다. 변환 자체는 Adapter 내부 책임으로 본 ADR의 결정 범위 밖.
+
+## 결과 (Consequences)
+
+**긍정적**
+
+- 사용자에게 LLM 가용성이 노출되지 않는다 — AI 실패 시 "제안 영역만 비어 있는" UX
+- 후속 Service가 동일 유틸을 호출하면 정책이 자동 일관 — 분산 구현 방지
+- AI 호출 실패가 WARN 로그 + MDC로 관측 가능 — 알림(Slack webhook 등)이나 Grafana 대시보드 후속 도입 시 부착 지점 명확
+- Service Layer가 `try-catch` 코드를 직접 짤 필요 없음 — 유틸 호출 한 줄로 압축
+
+**트레이드오프 / 부정적**
+
+- 사용자는 "지금 AI 제안이 왜 안 나오나" 알 수 없다 — `suggestionsAvailable=false`로 응답하지만 UI가 어떻게 표시할지는 FE 선택 (Story 3-3 등에서 결정)
+- 호출자가 fallback을 우회하고 싶을 때(예: 운영 디버깅용 직접 호출) 수단이 없음 — 의도된 제약. 우회가 필요하면 Adapter를 직접 호출
+- `unavailable` 응답을 "정상 0건"과 구분하려면 클라이언트가 `suggestionsAvailable` 플래그를 봐야 함 — 응답 DTO에 플래그 필드가 강제로 포함됨 (Epic 3/4 Endpoint Story에서 반영)
+
+**대안 비교**
+
+| 대안 | 거부 사유 |
+| --- | --- |
+| 5xx 그대로 노출 | LLM 의존성을 사용자에게 노출, 부가 정보 실패가 학습 흐름을 끊음 |
+| 기본 응답(예: "축 제안: 기초/심화/...") 자동 반환 | 사용자가 진짜 LLM 결과로 오인할 위험 — 데이터 진정성 훼손. Static Adapter는 명시적 fallback provider 전환 시점에만 사용 |
+| Service마다 자체 try-catch 구현 | 정책 분산 → 일관성 깨짐. 새 ErrorCode 추가 시 모든 Service 동시 수정 부담 |
+| Spring `@Recover` AOP / Resilience4j Circuit Breaker | 적용 범위가 메서드 단위라 Port 호출만 골라 감싸기 어려움. 의존성 추가 대비 이득 적음. 본 결정은 명시적 유틸 호출 방식 — 의도 가시성 우선 |
+
+**후속 작업**
+
+- Epic 2 Story 2-1: LLM Adapter가 Spring AI 예외 → `LF_SUGGEST_001/002/003` 매핑 책임 구현
+- Epic 3/4 첫 Service Story: `SuggestionFallbacks.protect(...)` 호출 + 응답 DTO에 `suggestionsAvailable` 필드 노출
+- 후속 ADR(별도 필요 시): AI 호출 실패 알림 webhook / Grafana 대시보드 정책

--- a/docs/adr/ADR010.md
+++ b/docs/adr/ADR010.md
@@ -74,8 +74,18 @@ LLM Adapter(Epic 2/3/4)는 Spring AI / WebClient 예외를 위 3종 ErrorCode로
 | Service마다 자체 try-catch 구현 | 정책 분산 → 일관성 깨짐. 새 ErrorCode 추가 시 모든 Service 동시 수정 부담 |
 | Spring `@Recover` AOP / Resilience4j Circuit Breaker | 적용 범위가 메서드 단위라 Port 호출만 골라 감싸기 어려움. 의존성 추가 대비 이득 적음. 본 결정은 명시적 유틸 호출 방식 — 의도 가시성 우선 |
 
+### ErrorCode 코드 문자열 패턴 (`LF_SUGGEST_xxx`) 정당화
+
+기존 LearningFacade BC ErrorCode는 `LF001~LF004` 형태(5자리 고정 prefix+seq)다. 본 결정의 3종은 의도적으로 `LF_SUGGEST_001~003` segment 형태를 채택했다 — 다음 두 이유에서.
+
+1. **카테고리 구분의 가시성** — `LF001~004`는 LearningFacade 도메인 자체의 사용자 입력/상태 오류다. 본 3종은 **외부 의존(LLM Vertex AI) 실패**로, 의미 카테고리가 다르다. 운영 알림·대시보드에서 패턴 매치(`LF_SUGGEST_*`)로 그룹화하기 쉽다.
+2. **후속 외부 의존 ErrorCode와의 일관성** — Epic 5(관측성)에서 외부 의존 실패 코드가 추가될 가능성이 높다(`LF_SUGGEST_004` 한도 초과 등). segment 형태가 새 외부 의존 카테고리 추가 시 더 자연스럽다.
+
+컨벤션 §2.4 본 패턴 위반이 아닌 **확장 적용**으로 해석한다 — `{BC_PREFIX}_{도메인_요소}_{상태}`에서 `도메인_요소 = SUGGEST`, `상태 = 001/002/003 시퀀스`. 추후 컨벤션 §2.4에 "5xx 외부 의존 실패 매핑 규칙"이 정식화되면 본 결정을 그 사례로 인용한다.
+
 **후속 작업**
 
 - Epic 2 Story 2-1: LLM Adapter가 Spring AI 예외 → `LF_SUGGEST_001/002/003` 매핑 책임 구현
 - Epic 3/4 첫 Service Story: `SuggestionFallbacks.protect(...)` 호출 + 응답 DTO에 `suggestionsAvailable` 필드 노출
-- 후속 ADR(별도 필요 시): AI 호출 실패 알림 webhook / Grafana 대시보드 정책
+- Epic 5 관측성 Story: `logback-spring.xml`의 MDC 화이트리스트(ADR008)에 `suggestionErrorCode` 키 등록 + AI 호출 실패 알림 webhook / Grafana 대시보드 정책. 본 Story 1-3 시점에서 MDC put/remove 코드는 들어가 있으나 LogstashEncoder 화이트리스트 미등록 상태라 ELK에 키가 실리지 않을 수 있다 — 의도된 보류이며 Epic 5에서 처리.
+- 컨벤션 보강: `.claude/rules/conventions.md` §2.4 HTTP 상태 매핑 표에 "5xx 외부 의존 실패" 행 추가 (별도 Story로 분리하거나 후속 ErrorCode 추가 시 함께 갱신)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -11,3 +11,4 @@
 | [ADR007](ADR007.md) | BC 간 협력에 동기 도메인 이벤트를 도입한다 | Accepted | 2026-05-14 |
 | [ADR008](ADR008.md) | 로깅 인프라 — profile별 Appender 분기 + LogstashEncoder + MDC 화이트리스트 | Accepted | 2026-05-17 |
 | [ADR009](ADR009.md) | Access Token은 HttpOnly Cookie, Refresh Token은 React 메모리에 저장한다 | Accepted | 2026-05-27 |
+| [ADR010](ADR010.md) | AI 제안 호출 실패는 5xx 미노출 — 빈 목록 + suggestionsAvailable 플래그로 변환 | Accepted | 2026-06-22 |

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -102,6 +102,17 @@ public enum ErrorCode {
     // ─── TopicRevision (Epic-003) ─────────────────────────
     REVISION_REASON_NOT_FOUND("TR001",              "선택한 수정 이유를 찾을 수 없거나 비활성 상태입니다.", HttpStatus.NOT_FOUND),
 
+    // ─── LearningFacade Suggestion (AI) ───────────────────
+    // Story 1-3: AI 호출 실패는 사용자에게 5xx로 노출되지 않고
+    // 상위 Service가 catch → 빈 목록 + suggestionsAvailable=false로 변환한다(ADR010).
+    // HttpStatus 값은 fallback이 적용되지 않을 때(예: 운영 디버깅 우회 호출)의 기본 매핑.
+    LEARNING_FACADE_SUGGESTION_TIMEOUT("LF_SUGGEST_001",
+            "AI 제안 요청이 시간 내 완료되지 않았습니다.",                HttpStatus.SERVICE_UNAVAILABLE),
+    LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE("LF_SUGGEST_002",
+            "AI 응답 형식이 유효하지 않습니다.",                          HttpStatus.BAD_GATEWAY),
+    LEARNING_FACADE_SUGGESTION_AUTH_FAILED("LF_SUGGEST_003",
+            "AI 인증 정보가 유효하지 않습니다.",                          HttpStatus.SERVICE_UNAVAILABLE),
+
     // ─── Deck (확장) ──────────────────────────────────────
     DECK_HIERARCHY_CYCLE("DECK006", "덱 계층 구조에 순환 참조가 발생했습니다.", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbackResult.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbackResult.java
@@ -1,0 +1,32 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * AI 제안 호출의 결과를 표현하는 VO.
+ *
+ * <p>정상 호출이면 {@link #available(List)}로 결과 목록을 감싸고,
+ * AI 호출 실패(타임아웃 / 파싱 실패 / 인증 실패)로 Fallback이 발동하면
+ * {@link #unavailable()}로 빈 목록 + {@code suggestionsAvailable=false}를 반환한다.</p>
+ *
+ * <p>{@link SuggestionFallbacks}가 본 VO를 생성한다 — 직접 생성자 호출은 권장되지 않는다.</p>
+ *
+ * @param <T> 제안 원소 타입(AxisSuggestion / AxisTopicSuggestion 등).
+ */
+public record SuggestionFallbackResult<T>(List<T> suggestions, boolean suggestionsAvailable) {
+
+    public SuggestionFallbackResult {
+        Objects.requireNonNull(suggestions, "suggestions는 null일 수 없습니다.");
+        suggestions = List.copyOf(suggestions);
+    }
+
+    public static <T> SuggestionFallbackResult<T> available(List<T> items) {
+        Objects.requireNonNull(items, "items는 null일 수 없습니다.");
+        return new SuggestionFallbackResult<>(items, true);
+    }
+
+    public static <T> SuggestionFallbackResult<T> unavailable() {
+        return new SuggestionFallbackResult<>(List.of(), false);
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacks.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacks.java
@@ -16,6 +16,12 @@ import org.slf4j.MDC;
  *
  * <p>대상 ErrorCode 3종(타임아웃 / 응답 형식 오류 / 인증 실패)에 대해서만 fallback을 적용한다.
  * 그 외 ErrorCode는 호출자가 처리하도록 원본 예외를 그대로 전파한다 — fail-fast.</p>
+ *
+ * <p><b>GlobalExceptionHandler 단일 진입점 원칙(conventions.md §2.3)에 대한 의도된 예외</b>:
+ * 일반적으로 BusinessException 변환은 GlobalExceptionHandler가 단독 책임이지만, AI 호출 실패는
+ * "사용자에게 5xx 미노출 + 부가 정보 영역만 비움"이라는 정책(ADR010)을 따르므로 Application Service
+ * 계층에서 선제 catch한다. 본 유틸이 그 단일 변환점이며, 후속 Service들이 동일 정책을 분산 구현하지
+ * 않도록 설계되었다. GlobalExceptionHandler는 Suggestion 외 모든 예외의 진입점으로 유지된다.</p>
  */
 public final class SuggestionFallbacks {
 

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacks.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacks.java
@@ -1,0 +1,53 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+/**
+ * AI 제안 호출에서 발생하는 사전 정의된 실패만 catch하여 빈 결과로 변환하는 Fallback 유틸 (ADR010).
+ *
+ * <p>대상 ErrorCode 3종(타임아웃 / 응답 형식 오류 / 인증 실패)에 대해서만 fallback을 적용한다.
+ * 그 외 ErrorCode는 호출자가 처리하도록 원본 예외를 그대로 전파한다 — fail-fast.</p>
+ */
+public final class SuggestionFallbacks {
+
+    private static final Logger log = LoggerFactory.getLogger(SuggestionFallbacks.class);
+
+    private static final String MDC_KEY = "suggestionErrorCode";
+
+    private static final Set<ErrorCode> SUGGESTION_FAILURE_CODES = EnumSet.of(
+            ErrorCode.LEARNING_FACADE_SUGGESTION_TIMEOUT,
+            ErrorCode.LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE,
+            ErrorCode.LEARNING_FACADE_SUGGESTION_AUTH_FAILED
+    );
+
+    private SuggestionFallbacks() {
+    }
+
+    public static <T> SuggestionFallbackResult<T> protect(Supplier<List<T>> portCall) {
+        Objects.requireNonNull(portCall, "portCall은 null일 수 없습니다.");
+        try {
+            return SuggestionFallbackResult.available(portCall.get());
+        } catch (LearningFacadeDomainException ex) {
+            ErrorCode code = ex.getErrorCode();
+            if (!SUGGESTION_FAILURE_CODES.contains(code)) {
+                throw ex;
+            }
+            try {
+                MDC.put(MDC_KEY, code.getCode());
+                log.warn("AI 제안 호출 실패 — fallback 활성화: code={} message={}", code.getCode(), ex.getMessage());
+            } finally {
+                MDC.remove(MDC_KEY);
+            }
+            return SuggestionFallbackResult.unavailable();
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbackResultTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbackResultTest.java
@@ -1,0 +1,94 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SuggestionFallbackResult")
+class SuggestionFallbackResultTest {
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("available로 감싸면 suggestionsAvailable=true + 목록 보존")
+        void available_정상() {
+            List<AxisSuggestion> items = List.of(
+                    new AxisSuggestion("기초", null),
+                    new AxisSuggestion("심화", "근거")
+            );
+
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbackResult.available(items);
+
+            assertThat(result.suggestions()).hasSize(2);
+            assertThat(result.suggestions()).extracting(AxisSuggestion::description)
+                    .containsExactly("기초", "심화");
+            assertThat(result.suggestionsAvailable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("unavailable은 빈 목록 + suggestionsAvailable=false")
+        void unavailable_정상() {
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbackResult.unavailable();
+
+            assertThat(result.suggestions()).isEmpty();
+            assertThat(result.suggestionsAvailable()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("available 입력이 빈 목록이면 suggestionsAvailable=true + 빈 목록")
+        void available_빈목록_정상() {
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbackResult.available(List.of());
+
+            assertThat(result.suggestions()).isEmpty();
+            assertThat(result.suggestionsAvailable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("available 입력 리스트를 외부에서 변경해도 결과에 반영되지 않는다 (방어 복사)")
+        void available_방어복사() {
+            List<AxisSuggestion> mutable = new ArrayList<>();
+            mutable.add(new AxisSuggestion("기초", null));
+
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbackResult.available(mutable);
+            mutable.add(new AxisSuggestion("이후에추가", null));
+
+            assertThat(result.suggestions()).hasSize(1);
+            assertThat(result.suggestions().get(0).description()).isEqualTo("기초");
+        }
+
+        @Test
+        @DisplayName("결과의 suggestions는 불변(읽기 전용)이다")
+        void suggestions_불변() {
+            SuggestionFallbackResult<AxisSuggestion> result =
+                    SuggestionFallbackResult.available(List.of(new AxisSuggestion("기초", null)));
+
+            assertThatThrownBy(() -> result.suggestions().add(new AxisSuggestion("추가", null)))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Exception {
+
+        @Test
+        @DisplayName("available에 null 입력 시 NPE")
+        void available_null_예외() {
+            assertThatThrownBy(() -> SuggestionFallbackResult.available(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacksTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacksTest.java
@@ -15,6 +15,32 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class SuggestionFallbacksTest {
 
     @Nested
+    @DisplayName("ErrorCode 계약 회귀 안전망")
+    class ErrorCodeContract {
+
+        @Test
+        @DisplayName("LEARNING_FACADE_SUGGESTION_TIMEOUT의 code는 LF_SUGGEST_001")
+        void LEARNING_FACADE_SUGGESTION_TIMEOUT_code_LF_SUGGEST_001() {
+            assertThat(ErrorCode.LEARNING_FACADE_SUGGESTION_TIMEOUT.getCode())
+                    .isEqualTo("LF_SUGGEST_001");
+        }
+
+        @Test
+        @DisplayName("LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE의 code는 LF_SUGGEST_002")
+        void LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE_code_LF_SUGGEST_002() {
+            assertThat(ErrorCode.LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE.getCode())
+                    .isEqualTo("LF_SUGGEST_002");
+        }
+
+        @Test
+        @DisplayName("LEARNING_FACADE_SUGGESTION_AUTH_FAILED의 code는 LF_SUGGEST_003")
+        void LEARNING_FACADE_SUGGESTION_AUTH_FAILED_code_LF_SUGGEST_003() {
+            assertThat(ErrorCode.LEARNING_FACADE_SUGGESTION_AUTH_FAILED.getCode())
+                    .isEqualTo("LF_SUGGEST_003");
+        }
+    }
+
+    @Nested
     @DisplayName("해피")
     class Happy {
 

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacksTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionFallbacksTest.java
@@ -1,0 +1,116 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SuggestionFallbacks")
+class SuggestionFallbacksTest {
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("정상 Supplier → available + 결과 목록 보존")
+        void protect_정상_available() {
+            List<AxisSuggestion> items = List.of(
+                    new AxisSuggestion("기초", null),
+                    new AxisSuggestion("심화", "근거")
+            );
+
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbacks.protect(() -> items);
+
+            assertThat(result.suggestionsAvailable()).isTrue();
+            assertThat(result.suggestions()).extracting(AxisSuggestion::description)
+                    .containsExactly("기초", "심화");
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지")
+    class Edge {
+
+        @Test
+        @DisplayName("Supplier가 빈 목록을 반환해도 available=true")
+        void protect_빈목록_available() {
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbacks.protect(List::of);
+
+            assertThat(result.suggestionsAvailable()).isTrue();
+            assertThat(result.suggestions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("LF_SUGGEST_001(타임아웃) 예외 → unavailable + 빈 목록")
+        void protect_LF_SUGGEST_001_unavailable() {
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbacks.protect(() -> {
+                throw LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_SUGGESTION_TIMEOUT);
+            });
+
+            assertThat(result.suggestionsAvailable()).isFalse();
+            assertThat(result.suggestions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("LF_SUGGEST_002(응답 형식 오류) 예외 → unavailable + 빈 목록")
+        void protect_LF_SUGGEST_002_unavailable() {
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbacks.protect(() -> {
+                throw LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE);
+            });
+
+            assertThat(result.suggestionsAvailable()).isFalse();
+            assertThat(result.suggestions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("LF_SUGGEST_003(인증 실패) 예외 → unavailable + 빈 목록")
+        void protect_LF_SUGGEST_003_unavailable() {
+            SuggestionFallbackResult<AxisSuggestion> result = SuggestionFallbacks.protect(() -> {
+                throw LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_SUGGESTION_AUTH_FAILED);
+            });
+
+            assertThat(result.suggestionsAvailable()).isFalse();
+            assertThat(result.suggestions()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("예외")
+    class Exception {
+
+        @Test
+        @DisplayName("Suggestion 외 ErrorCode 예외는 그대로 전파된다")
+        void protect_다른ErrorCode_전파() {
+            assertThatThrownBy(() -> SuggestionFallbacks.protect(() -> {
+                throw LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND);
+            }))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting(ex -> ((LearningFacadeDomainException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.LEARNING_FACADE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("일반 RuntimeException은 catch하지 않고 전파된다")
+        void protect_RuntimeException_전파() {
+            assertThatThrownBy(() -> SuggestionFallbacks.protect(() -> {
+                throw new IllegalStateException("boom");
+            }))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("boom");
+        }
+
+        @Test
+        @DisplayName("portCall이 null이면 NPE")
+        void protect_null_예외() {
+            assertThatThrownBy(() -> SuggestionFallbacks.protect(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

LearningFacade BC에 AI 제안 호출 실패용 ErrorCode 3종(`LF_SUGGEST_001~003`)을 등록하고, Service Layer가 동일 정책으로 fallback할 수 있는 유틸(`SuggestionFallbacks`) + 결과 VO(`SuggestionFallbackResult<T>`)를 추가한다. ADR010이 정책 근거를 박는다.

## 왜 / 설계 결정

- LLM(Vertex AI Gemini) 호출은 본질적으로 실패한다(타임아웃·파싱·인증). 부가 정보인 AI 제안 실패가 5xx로 노출되면 학습 흐름이 끊긴다.
- 후속 Service(Epic 3/4)가 동일 fallback 규칙을 각자 다르게 구현하면 정책 일관성이 깨진다 → 변환 진입점 1개(`SuggestionFallbacks.protect`)로 강제.
- `GlobalExceptionHandler` 단일 진입점 원칙(conventions.md §2.3)에 대한 의도된 예외 — ADR010이 명시화.

## 작업 내용

- feat(common): `ErrorCode` enum 3종 등록
  - `LEARNING_FACADE_SUGGESTION_TIMEOUT`(`LF_SUGGEST_001`, 503)
  - `LEARNING_FACADE_SUGGESTION_INVALID_RESPONSE`(`LF_SUGGEST_002`, 502)
  - `LEARNING_FACADE_SUGGESTION_AUTH_FAILED`(`LF_SUGGEST_003`, 503)
- feat(facade): `SuggestionFallbackResult<T>` record + 정적 팩토리(`available`/`unavailable`) — 방어 복사 + 불변
- feat(facade): `SuggestionFallbacks.protect(Supplier<List<T>>)` static utility — 3종 ErrorCode catch → 빈 목록 + `suggestionsAvailable=false`. WARN 로그 + `suggestionErrorCode` MDC 주입(remove 보장). 외 ErrorCode·RuntimeException 전파.
- test(facade): 단위 테스트 2종 — 총 17 케이스 (ErrorCode 계약 회귀 안전망 3 + 해피 4 + 엣지 7 + 예외 3)
- docs(adr): ADR010 작성 + index 갱신

## 변경 유형

- [x] feat  - [ ] fix  - [x] refactor  - [x] docs  - [x] test  - [ ] chore

## 테스트

- ``./gradlew test --tests "*Suggestion*"`` → BUILD SUCCESSFUL
- ``./gradlew build`` → BUILD SUCCESSFUL (전체 회귀 없음)
- 명시 검증 케이스
  - ErrorCode 코드 문자열(`LF_SUGGEST_001~003`) 회귀 안전망 3건 — 외부 API 계약 보호
  - 3종 ErrorCode 각각 → `suggestionsAvailable=false` + 빈 목록
  - 외 ErrorCode·일반 RuntimeException → 그대로 전파
  - 방어 복사 — 외부 list 변조가 결과에 미반영
  - 결과 list 불변(UnsupportedOperationException)

## Story AC 충족 범위 (Sceptical Reviewer 지적 반영)

본 PR은 Epic 1의 **인프라 정의** Story다. AC 5건 중 본 PR 단독 충족 가능 항목:

- ✅ ErrorCode 3종 등록 + 변환 유틸 정의 + 정책 ADR
- ⏸ AC1~3 (Adapter 측 매핑) — Epic 2 Story 2-1 LLM Adapter 진입 시 충족
- ⏸ AC4 (Service Layer 5xx→200 변환) — Epic 3/4 첫 Service Story에서 충족 (호출 Service 부재 → 단위 유틸 테스트로 정책 정합성만 확보)
- ⏸ AC5 (MDC traceId 추적) — 코드는 들어갔으나 `logback-spring.xml` MDC 화이트리스트(ADR008) 미등록 상태. Epic 5 관측성 Story에서 등록 (ADR010 "후속 작업"에 명시)

## Reviewer 세션 결과 (review.md 5관점)

- Critical: 0건
- Major 3건 조치 완료 (마지막 commit)
  - `SuggestionFallbacks` Javadoc에 GlobalExceptionHandler 우회 정당화 추가
  - ADR010에 코드 패턴(`LF_SUGGEST_xxx`) 정당화 + MDC 화이트리스트 후속 작업 명시
  - `SuggestionFallbacksTest`에 ErrorCode 값 회귀 안전망 3 케이스 추가
- Major 2건 + Minor·Nit는 후속 Story 이연 (PR 본문 한계 명시 / MDC 검증 테스트는 Epic 5 / 메서드명 일관성)

## 체크리스트

- [x] 빌드 / 테스트 통과
- [x] `ApiResponse<T>` 래퍼 사용 — 본 PR엔 신규 endpoint 없음 (N/A)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 (ADR010 신규)
- [x] BC 간 의존 방향 위반 없음 (Common→BC 역의존 없음, application→domain 단방향)
- [x] 대상 브랜치 = `develop` 확인

## 관련 이슈

- Product: `workflow/product/pes/ready/product-aisuggestion.md`
- Epic 1: AI 제안 outbound Port 인터페이스 + Fallback 정책
- Story: Story 1-3
- ADR: ADR010