### PR TITLE
feat(logging): MdcLoggingFilter 추가 — requestId 부여·MDC 전파·응답 헤더 echo [Story-021]

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.Common.config;
 
 
 import com.example.thirdtool.Common.Util.JWTUtil;
+import com.example.thirdtool.Common.logging.filter.MdcLoggingFilter;
 import com.example.thirdtool.Common.security.auth.JwtAuthenticationEntryPoint;
 import com.example.thirdtool.Common.security.filter.BlockListFilter;
 import com.example.thirdtool.Common.security.filter.JWTFilter;
@@ -182,12 +183,17 @@ public class SecurityConfig {
                                   );
 
         // ==============================
-        // 6️⃣ 악성 URL 차단 필터 (Story 3-3) — JWTFilter 앞단에서 즉시 404
+        // 6️⃣ MDC 로깅 필터 (Story 2-1) — 최선단에서 requestId 부여 + 응답 헤더 echo + MDC clear
+        // ==============================
+        http.addFilterBefore(new MdcLoggingFilter(), BlockListFilter.class);
+
+        // ==============================
+        // 7️⃣ 악성 URL 차단 필터 (Story 3-3) — JWTFilter 앞단에서 즉시 404
         // ==============================
         http.addFilterBefore(new BlockListFilter(), UsernamePasswordAuthenticationFilter.class);
 
         // ==============================
-        // 7️⃣ JWT 인증 필터 추가
+        // 8️⃣ JWT 인증 필터 추가
         // ==============================
         http.addFilterBefore(new JWTFilter(userRepository, jwtUtil, jwtAuthenticationEntryPoint),
                 UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
@@ -9,6 +9,7 @@ import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -16,15 +17,21 @@ import java.util.UUID;
  *
  * <p>SecurityFilterChain 가장 앞단에서 동작하며 다음을 보장한다.
  * <ul>
- *   <li>X-Request-Id 헤더가 정상이면 그대로 사용, 없거나 blank/{@value #MAX_LEN}자 초과면 서버가 UUID 생성</li>
+ *   <li>X-Request-Id 헤더가 정상이면 그대로 사용, 없거나 trim 후 blank/{@value #MAX_LEN}자 초과면 서버가 UUID 생성</li>
  *   <li>MDC 키 4종(requestId, traceId(=requestId), method, path)을 logback-spring.xml 화이트리스트와 정합하게 주입</li>
  *   <li>응답 헤더 X-Request-Id echo back — 클라이언트가 동일 ID로 문의·추적 가능</li>
  *   <li>request.start / request.end 로그 INFO + status + durationMs</li>
  *   <li>예외 경로 포함 finally 블록에서 {@link MDC#clear()} — 스레드 풀 재사용 시 누수 차단</li>
+ *   <li>{@code /actuator/health} · {@code /health} 경로는 노이즈 차단을 위해 필터 자체 스킵</li>
+ *   <li>ERROR dispatch 재진입 차단({@link #shouldNotFilterErrorDispatch()}) — 요청당 단일 로그·헤더 보장</li>
  * </ul>
  *
- * <p>userId 주입은 Story 2-2 별도 처리. traceId == requestId는 v1 단순화 — 분산 트레이싱
- * 도입 시 분리. 자세한 결정 배경은 ADR008.
+ * <p>{@code clientIp}는 {@code X-Forwarded-For} 우선·{@code RemoteAddr} fallback. <b>신뢰 경계는
+ * ALB/CloudFront/Nginx 등 신뢰 LB 뒤 배포를 가정</b> — LB 없는 직접 노출 환경에서는 spoofing 위험으로
+ * 로그 신뢰도가 떨어진다. Product 5/6 인프라 배포 후 활용도 상승.
+ *
+ * <p>userId 주입은 Story 2-2 별도 처리(logback 화이트리스트엔 등록되어 있으나 본 Story 단계엔 주입자 없음).
+ * traceId == requestId는 v1 단순화 — 분산 트레이싱 도입 시 분리. 자세한 결정 배경은 ADR008.
  */
 @Slf4j
 public class MdcLoggingFilter extends OncePerRequestFilter {
@@ -35,6 +42,23 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     static final String MDC_METHOD = "method";
     static final String MDC_PATH = "path";
     static final int MAX_LEN = 64;
+
+    private static final Set<String> SKIP_PATHS = Set.of("/actuator/health", "/health");
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return SKIP_PATHS.contains(request.getRequestURI());
+    }
+
+    /**
+     * ERROR dispatch(예: {@code sendError(403)} 결과의 컨테이너 재dispatch) 시 필터 재진입을 차단한다.
+     * 재진입을 허용하면 요청당 request.start/end 로그가 2배로 출력되고, 응답 헤더 X-Request-Id가
+     * 새 UUID로 덮어씌워질 위험이 있다.
+     */
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return true;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -60,10 +84,14 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     }
 
     private String resolveRequestId(String incoming) {
-        if (incoming == null || incoming.isBlank() || incoming.length() > MAX_LEN) {
+        if (incoming == null) {
             return UUID.randomUUID().toString();
         }
-        return incoming;
+        String trimmed = incoming.trim();
+        if (trimmed.isEmpty() || trimmed.length() > MAX_LEN) {
+            return UUID.randomUUID().toString();
+        }
+        return trimmed;
     }
 
     private String clientIp(HttpServletRequest request) {

--- a/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
@@ -1,0 +1,77 @@
+package com.example.thirdtool.Common.logging.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 모든 HTTP 요청에 requestId를 부여하고 MDC·응답 헤더로 전파하는 필터 (Story 2-1).
+ *
+ * <p>SecurityFilterChain 가장 앞단에서 동작하며 다음을 보장한다.
+ * <ul>
+ *   <li>X-Request-Id 헤더가 정상이면 그대로 사용, 없거나 blank/{@value #MAX_LEN}자 초과면 서버가 UUID 생성</li>
+ *   <li>MDC 키 4종(requestId, traceId(=requestId), method, path)을 logback-spring.xml 화이트리스트와 정합하게 주입</li>
+ *   <li>응답 헤더 X-Request-Id echo back — 클라이언트가 동일 ID로 문의·추적 가능</li>
+ *   <li>request.start / request.end 로그 INFO + status + durationMs</li>
+ *   <li>예외 경로 포함 finally 블록에서 {@link MDC#clear()} — 스레드 풀 재사용 시 누수 차단</li>
+ * </ul>
+ *
+ * <p>userId 주입은 Story 2-2 별도 처리. traceId == requestId는 v1 단순화 — 분산 트레이싱
+ * 도입 시 분리. 자세한 결정 배경은 ADR008.
+ */
+@Slf4j
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    static final String HEADER = "X-Request-Id";
+    static final String MDC_REQUEST_ID = "requestId";
+    static final String MDC_TRACE_ID = "traceId";
+    static final String MDC_METHOD = "method";
+    static final String MDC_PATH = "path";
+    static final int MAX_LEN = 64;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestId = resolveRequestId(request.getHeader(HEADER));
+        long startedAt = System.currentTimeMillis();
+        try {
+            MDC.put(MDC_REQUEST_ID, requestId);
+            MDC.put(MDC_TRACE_ID, requestId);
+            MDC.put(MDC_METHOD, request.getMethod());
+            MDC.put(MDC_PATH, request.getRequestURI());
+            response.setHeader(HEADER, requestId);
+
+            log.info("request.start clientIp={}", clientIp(request));
+
+            filterChain.doFilter(request, response);
+        } finally {
+            long durationMs = System.currentTimeMillis() - startedAt;
+            log.info("request.end status={} durationMs={}", response.getStatus(), durationMs);
+            MDC.clear();
+        }
+    }
+
+    private String resolveRequestId(String incoming) {
+        if (incoming == null || incoming.isBlank() || incoming.length() > MAX_LEN) {
+            return UUID.randomUUID().toString();
+        }
+        return incoming;
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            int comma = xff.indexOf(',');
+            return (comma > 0 ? xff.substring(0, comma) : xff).trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterConcurrencyTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterConcurrencyTest.java
@@ -53,7 +53,7 @@ class MdcLoggingFilterConcurrencyTest {
             doAnswer(inv -> {
                 seen.set(MDC.get(MdcLoggingFilter.MDC_REQUEST_ID));
                 bothInsideChain.countDown();
-                releaseChain.await(2, TimeUnit.SECONDS);
+                releaseChain.await(10, TimeUnit.SECONDS);
                 return null;
             }).when(chain).doFilter(any(), any());
 
@@ -66,12 +66,12 @@ class MdcLoggingFilterConcurrencyTest {
             Future<String> a = pool.submit(task);
             Future<String> b = pool.submit(task);
 
-            assertThat(bothInsideChain.await(2, TimeUnit.SECONDS))
+            assertThat(bothInsideChain.await(10, TimeUnit.SECONDS))
                     .as("두 스레드가 동시에 chain 내부에 진입").isTrue();
             releaseChain.countDown();
 
-            String idA = a.get(3, TimeUnit.SECONDS);
-            String idB = b.get(3, TimeUnit.SECONDS);
+            String idA = a.get(10, TimeUnit.SECONDS);
+            String idB = b.get(10, TimeUnit.SECONDS);
 
             assertThat(idA).isNotBlank();
             assertThat(idB).isNotBlank();

--- a/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterConcurrencyTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterConcurrencyTest.java
@@ -1,0 +1,134 @@
+package com.example.thirdtool.Common.logging.filter;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * MdcLoggingFilter의 동시성·MDC 누수 회귀 테스트.
+ * AC: "동시 요청 requestId 충돌 없음" + "스레드 풀 재사용 시 이전 MDC 누수 없음".
+ */
+@DisplayName("MdcLoggingFilter 동시성")
+class MdcLoggingFilterConcurrencyTest {
+
+    private final MdcLoggingFilter filter = new MdcLoggingFilter();
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("두 스레드에서 동시 요청해도 각자 고유한 requestId를 받는다")
+    void 두_스레드에서_동시_요청해도_각자_고유한_requestId를_받는다() throws Exception {
+        CountDownLatch bothInsideChain = new CountDownLatch(2);
+        CountDownLatch releaseChain = new CountDownLatch(1);
+
+        Callable<String> task = () -> {
+            MockHttpServletRequest req = new MockHttpServletRequest("GET", "/concurrent");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            AtomicReference<String> seen = new AtomicReference<>();
+            FilterChain chain = mock(FilterChain.class);
+            doAnswer(inv -> {
+                seen.set(MDC.get(MdcLoggingFilter.MDC_REQUEST_ID));
+                bothInsideChain.countDown();
+                releaseChain.await(2, TimeUnit.SECONDS);
+                return null;
+            }).when(chain).doFilter(any(), any());
+
+            filter.doFilter(req, res, chain);
+            return seen.get();
+        };
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<String> a = pool.submit(task);
+            Future<String> b = pool.submit(task);
+
+            assertThat(bothInsideChain.await(2, TimeUnit.SECONDS))
+                    .as("두 스레드가 동시에 chain 내부에 진입").isTrue();
+            releaseChain.countDown();
+
+            String idA = a.get(3, TimeUnit.SECONDS);
+            String idB = b.get(3, TimeUnit.SECONDS);
+
+            assertThat(idA).isNotBlank();
+            assertThat(idB).isNotBlank();
+            assertThat(idA).isNotEqualTo(idB);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("100회 연속 요청해도 모든 requestId가 유일하다 (서버 생성 UUID 충돌 회귀)")
+    void 백회_연속_요청해도_모든_requestId가_유일하다() throws Exception {
+        Set<String> collected = Collections.synchronizedSet(new HashSet<>());
+
+        for (int i = 0; i < 100; i++) {
+            MockHttpServletRequest req = new MockHttpServletRequest("GET", "/loop/" + i);
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            FilterChain chain = mock(FilterChain.class);
+            doAnswer(inv -> {
+                collected.add(MDC.get(MdcLoggingFilter.MDC_REQUEST_ID));
+                return null;
+            }).when(chain).doFilter(any(), any());
+
+            filter.doFilter(req, res, chain);
+        }
+
+        assertThat(collected).hasSize(100);
+    }
+
+    @Test
+    @DisplayName("동일 스레드에서 연속 요청 시 이전 요청의 MDC가 다음 요청에 누수되지 않는다")
+    void 동일_스레드에서_연속_요청_시_이전_요청의_MDC가_다음_요청에_누수되지_않는다() throws Exception {
+        // 1차 요청: chain 내부에서 화이트리스트 외 임의 키까지 추가하고 정상 종료
+        MockHttpServletRequest first = new MockHttpServletRequest("GET", "/first");
+        first.addHeader(MdcLoggingFilter.HEADER, "first-request");
+        FilterChain firstChain = mock(FilterChain.class);
+        doAnswer(inv -> {
+            MDC.put("legacyKey", "leakCandidate");
+            return null;
+        }).when(firstChain).doFilter(any(), any());
+        filter.doFilter(first, new MockHttpServletResponse(), firstChain);
+
+        // 2차 요청: chain 진입 시점의 MDC 스냅샷을 캡처
+        AtomicReference<Map<String, String>> secondSnapshot = new AtomicReference<>();
+        MockHttpServletRequest second = new MockHttpServletRequest("GET", "/second");
+        second.addHeader(MdcLoggingFilter.HEADER, "second-request");
+        FilterChain secondChain = mock(FilterChain.class);
+        doAnswer(inv -> {
+            secondSnapshot.set(MDC.getCopyOfContextMap());
+            return null;
+        }).when(secondChain).doFilter(any(), any());
+        filter.doFilter(second, new MockHttpServletResponse(), secondChain);
+
+        Map<String, String> captured = secondSnapshot.get();
+        assertThat(captured).isNotNull();
+        assertThat(captured.get(MdcLoggingFilter.MDC_REQUEST_ID)).isEqualTo("second-request");
+        assertThat(captured.get(MdcLoggingFilter.MDC_PATH)).isEqualTo("/second");
+        assertThat(captured).doesNotContainKey("legacyKey");
+    }
+}

--- a/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterTest.java
@@ -179,6 +179,17 @@ class MdcLoggingFilterTest {
     }
 
     @Test
+    @DisplayName("X-Forwarded-For 헤더에 단일 IP만 있으면 콤마 없이 그대로 사용한다")
+    void X_Forwarded_For_헤더에_단일_IP만_있으면_콤마_없이_그대로_사용한다() throws Exception {
+        request.addHeader("X-Forwarded-For", "203.0.113.5");
+
+        filter.doFilter(request, response, chain);
+
+        ILoggingEvent startEvent = findEventStartingWith("request.start");
+        assertThat(startEvent.getFormattedMessage()).contains("clientIp=203.0.113.5");
+    }
+
+    @Test
     @DisplayName("X-Forwarded-For 헤더가 없으면 clientIp는 remoteAddr를 사용한다")
     void X_Forwarded_For_헤더가_없으면_clientIp는_remoteAddr를_사용한다() throws Exception {
         request.setRemoteAddr("10.0.0.42");
@@ -187,6 +198,51 @@ class MdcLoggingFilterTest {
 
         ILoggingEvent startEvent = findEventStartingWith("request.start");
         assertThat(startEvent.getFormattedMessage()).contains("clientIp=10.0.0.42");
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 앞뒤 공백을 포함하면 trim 후 사용한다")
+    void 유입된_X_Request_Id가_앞뒤_공백을_포함하면_trim_후_사용한다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "  client-id-42  ");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isEqualTo("client-id-42");
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 탭·개행 등 공백만이면 서버 UUID로 대체한다")
+    void 유입된_X_Request_Id가_탭_개행_등_공백만이면_서버_UUID로_대체한다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "\t\n  \t");
+
+        filter.doFilter(request, response, chain);
+
+        String echoed = response.getHeader(MdcLoggingFilter.HEADER);
+        assertThat(echoed).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    @DisplayName("/actuator/health 경로는 필터가 스킵되어 MDC도 응답 헤더도 주입되지 않는다")
+    void actuator_health_경로는_필터가_스킵되어_MDC도_응답_헤더도_주입되지_않는다() throws Exception {
+        request.setRequestURI("/actuator/health");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isNull();
+        Map<String, String> remaining = MDC.getCopyOfContextMap();
+        assertThat(remaining == null || remaining.isEmpty()).isTrue();
+        assertThat(logAppender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("/health 경로도 필터가 스킵된다")
+    void health_경로도_필터가_스킵된다() throws Exception {
+        request.setRequestURI("/health");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isNull();
+        assertThat(logAppender.list).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterTest.java
@@ -1,0 +1,247 @@
+package com.example.thirdtool.Common.logging.filter;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("MdcLoggingFilter")
+class MdcLoggingFilterTest {
+
+    private MdcLoggingFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private FilterChain chain;
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger filterLogger;
+
+    @BeforeEach
+    void setUp() {
+        filter = new MdcLoggingFilter();
+        request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setRequestURI("/api/v1/cards");
+        response = new MockHttpServletResponse();
+        chain = mock(FilterChain.class);
+
+        filterLogger = (Logger) LoggerFactory.getLogger(MdcLoggingFilter.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        filterLogger.addAppender(logAppender);
+
+        MDC.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        filterLogger.detachAppender(logAppender);
+        logAppender.stop();
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("요청에 X-Request-Id 헤더가 없으면 서버가 UUID를 생성해 응답에 echo한다")
+    void 요청에_X_Request_Id_헤더가_없으면_서버가_UUID를_생성해_응답에_echo한다() throws Exception {
+        filter.doFilter(request, response, chain);
+
+        String echoed = response.getHeader(MdcLoggingFilter.HEADER);
+        assertThat(echoed).isNotBlank();
+        assertThat(echoed).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 정상이면 그대로 사용하고 응답에 echo한다")
+    void 유입된_X_Request_Id가_정상이면_그대로_사용하고_응답에_echo한다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "client-abc-123");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isEqualTo("client-abc-123");
+    }
+
+    @Test
+    @DisplayName("MDC에 requestId·traceId·method·path가 모두 주입되고 traceId는 requestId와 같다")
+    void MDC에_requestId_traceId_method_path가_모두_주입되고_traceId는_requestId와_같다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "req-99");
+        AtomicReference<Map<String, String>> snapshot = new AtomicReference<>();
+        doAnswer(captureMdcSnapshot(snapshot)).when(chain).doFilter(request, response);
+
+        filter.doFilter(request, response, chain);
+
+        Map<String, String> captured = snapshot.get();
+        assertThat(captured).isNotNull();
+        assertThat(captured.get(MdcLoggingFilter.MDC_REQUEST_ID)).isEqualTo("req-99");
+        assertThat(captured.get(MdcLoggingFilter.MDC_TRACE_ID)).isEqualTo("req-99");
+        assertThat(captured.get(MdcLoggingFilter.MDC_METHOD)).isEqualTo("GET");
+        assertThat(captured.get(MdcLoggingFilter.MDC_PATH)).isEqualTo("/api/v1/cards");
+    }
+
+    @Test
+    @DisplayName("chain doFilter 호출 후 MDC가 clear된다")
+    void chain_doFilter_호출_후_MDC가_clear된다() throws Exception {
+        filter.doFilter(request, response, chain);
+
+        Map<String, String> remaining = MDC.getCopyOfContextMap();
+        assertThat(remaining == null || remaining.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("request.end 로그에 status와 durationMs가 INFO 레벨로 포함된다")
+    void request_end_로그에_status와_durationMs가_INFO_레벨로_포함된다() throws Exception {
+        response.setStatus(200);
+
+        filter.doFilter(request, response, chain);
+
+        ILoggingEvent endEvent = findEventStartingWith("request.end");
+        assertThat(endEvent.getLevel()).isEqualTo(Level.INFO);
+        String formatted = endEvent.getFormattedMessage();
+        assertThat(formatted).contains("status=200");
+        assertThat(formatted).containsPattern("durationMs=\\d+");
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 빈 문자열이면 서버 UUID로 대체한다")
+    void 유입된_X_Request_Id가_빈_문자열이면_서버_UUID로_대체한다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "");
+
+        filter.doFilter(request, response, chain);
+
+        String echoed = response.getHeader(MdcLoggingFilter.HEADER);
+        assertThat(echoed).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 공백만 있으면 서버 UUID로 대체한다")
+    void 유입된_X_Request_Id가_공백만_있으면_서버_UUID로_대체한다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "   ");
+
+        filter.doFilter(request, response, chain);
+
+        String echoed = response.getHeader(MdcLoggingFilter.HEADER);
+        assertThat(echoed).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 정확히 64자이면 그대로 사용한다 (경계값)")
+    void 유입된_X_Request_Id가_정확히_64자이면_그대로_사용한다() throws Exception {
+        String boundary = "a".repeat(MdcLoggingFilter.MAX_LEN);
+        request.addHeader(MdcLoggingFilter.HEADER, boundary);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isEqualTo(boundary);
+    }
+
+    @Test
+    @DisplayName("유입된 X-Request-Id가 65자이면 서버 UUID로 대체한다 (경계값 +1)")
+    void 유입된_X_Request_Id가_65자이면_서버_UUID로_대체한다() throws Exception {
+        String overflow = "a".repeat(MdcLoggingFilter.MAX_LEN + 1);
+        request.addHeader(MdcLoggingFilter.HEADER, overflow);
+
+        filter.doFilter(request, response, chain);
+
+        String echoed = response.getHeader(MdcLoggingFilter.HEADER);
+        assertThat(echoed).isNotEqualTo(overflow);
+        assertThat(echoed).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 있으면 clientIp는 가장 좌측 IP를 사용한다")
+    void X_Forwarded_For_헤더가_있으면_clientIp는_가장_좌측_IP를_사용한다() throws Exception {
+        request.addHeader("X-Forwarded-For", "1.2.3.4, 5.6.7.8, 9.9.9.9");
+
+        filter.doFilter(request, response, chain);
+
+        ILoggingEvent startEvent = findEventStartingWith("request.start");
+        assertThat(startEvent.getFormattedMessage()).contains("clientIp=1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 없으면 clientIp는 remoteAddr를 사용한다")
+    void X_Forwarded_For_헤더가_없으면_clientIp는_remoteAddr를_사용한다() throws Exception {
+        request.setRemoteAddr("10.0.0.42");
+
+        filter.doFilter(request, response, chain);
+
+        ILoggingEvent startEvent = findEventStartingWith("request.start");
+        assertThat(startEvent.getFormattedMessage()).contains("clientIp=10.0.0.42");
+    }
+
+    @Test
+    @DisplayName("chain doFilter에서 예외가 throw되어도 MDC가 clear된다")
+    void chain_doFilter에서_예외가_throw되어도_MDC가_clear된다() throws Exception {
+        doThrow(new ServletException("boom")).when(chain).doFilter(request, response);
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, chain))
+                .isInstanceOf(ServletException.class)
+                .hasMessage("boom");
+
+        Map<String, String> remaining = MDC.getCopyOfContextMap();
+        assertThat(remaining == null || remaining.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("chain doFilter에서 예외가 throw되어도 응답 헤더 X-Request-Id는 set된다")
+    void chain_doFilter에서_예외가_throw되어도_응답_헤더_X_Request_Id는_set된다() throws Exception {
+        request.addHeader(MdcLoggingFilter.HEADER, "preserve-id");
+        doThrow(new ServletException("boom")).when(chain).doFilter(request, response);
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, chain))
+                .isInstanceOf(ServletException.class);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isEqualTo("preserve-id");
+    }
+
+    @Test
+    @DisplayName("chain doFilter에서 예외가 throw되어도 request.end 로그가 INFO로 남는다")
+    void chain_doFilter에서_예외가_throw되어도_request_end_로그가_INFO로_남는다() throws Exception {
+        doThrow(new ServletException("boom")).when(chain).doFilter(request, response);
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, chain))
+                .isInstanceOf(ServletException.class);
+
+        ILoggingEvent endEvent = findEventStartingWith("request.end");
+        assertThat(endEvent.getLevel()).isEqualTo(Level.INFO);
+        assertThat(endEvent.getFormattedMessage()).containsPattern("durationMs=\\d+");
+    }
+
+    // ---- helpers ----
+
+    private static org.mockito.stubbing.Answer<Void> captureMdcSnapshot(AtomicReference<Map<String, String>> sink) {
+        return (InvocationOnMock invocation) -> {
+            sink.set(MDC.getCopyOfContextMap());
+            return null;
+        };
+    }
+
+    private ILoggingEvent findEventStartingWith(String prefix) {
+        List<ILoggingEvent> events = logAppender.list;
+        return events.stream()
+                .filter(e -> e.getFormattedMessage().startsWith(prefix))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "기대한 로그(" + prefix + ")가 캡처되지 않음. captured=" + events));
+    }
+}


### PR DESCRIPTION
## 개요
모든 HTTP 요청에 X-Request-Id를 부여하고 MDC(requestId/traceId/method/path)와 응답 헤더로 전파하는 `MdcLoggingFilter`를 신설했다. SecurityFilterChain 최선단(BlockListFilter 앞)에 배치해 차단된 요청까지 관찰성 범위에 포함시키고, finally의 `MDC.clear()`로 스레드 풀 재사용 시 누수를 차단한다.

## 왜 / 설계 결정
ADR008(로깅 인프라)이 logback-spring.xml의 MDC 화이트리스트 5개(traceId/requestId/userId/method/path)를 이미 깔아두었으나 키를 채워주는 주체가 없었다. 본 PR은 그 중 4개(userId 제외, Story 2-2로 위임)를 OncePerRequestFilter로 주입한다.

설계 결정:
- `Common/logging/filter/` 신규 패키지 — 보안(`Common/security/filter`)과 관찰성 책임 분리
- BlockListFilter 앞단 배치 — 차단 요청도 추적 가능 + finally의 `MDC.clear()` 보장
- `traceId == requestId` v1 단순화 — 분산 트레이싱 도입 시 분리(ADR008 follow-up)
- 헤더 길이 64자 제한 + blank/공백 입력은 서버 UUID로 silent fallback — 로깅 인프라는 항상 ID를 가져야 한다는 운영 신뢰성 우선
- `shouldNotFilterErrorDispatch()=true` — `sendError(403)` 결과 컨테이너 ERROR dispatch 재진입 차단(요청당 단일 로그·헤더 보장)
- `/actuator/health`·`/health` 경로 스킵 — probe 노이즈 차단

기각 대안: 별도 `MdcKeys` 상수 클래스 분리는 Story 2-2(JWTFilter의 userId 주입)에서 외부 참조 필요성이 확인된 시점에 결정.

## 작업 내용
- feat(logging): `MdcLoggingFilter` 신규(`OncePerRequestFilter` 상속, 105줄) — X-Request-Id 해석/생성, MDC 4키 주입, X-Forwarded-For 우선 clientIp, `request.start`/`request.end` INFO 로그
- feat(security): `SecurityConfig`에 필터 등록(`addFilterBefore(_, BlockListFilter.class)`) + 섹션 번호 6→7→8 재정렬
- test(logging): `MdcLoggingFilterTest` 19건 — 해피 5(헤더 없음/정상/MDC 4키/clear/end 로그) + 엣지 11(blank/공백/64자 경계/65자/trim/탭개행/XFF 다중·단일·없음/health 스킵 2건) + 예외 3(chain throw 시 MDC clear·헤더 유지·end 로그)
- test(logging): `MdcLoggingFilterConcurrencyTest` 3건 — 2 thread 격리(CountDownLatch chain 내부 동시 진입) + 100회 연속 유일성 + 동일 thread 재사용 시 화이트리스트 외 키 누수 차단
- fix(logging): Reviewer 5관점 지적 보강 — ERROR dispatch 차단, health probe 스킵, trim, XFF 신뢰경계 javadoc, XFF 단일 IP 테스트, concurrency timeout 상향

## 변경 유형
- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.Common.logging.filter.*"` → BUILD SUCCESSFUL (22/22)
  - `MdcLoggingFilterTest` 19건 PASS
  - `MdcLoggingFilterConcurrencyTest` 3건 PASS
- `./gradlew test --tests "com.example.thirdtool.Common.logging.*" --tests "com.example.thirdtool.Common.security.filter.*"` → BUILD SUCCESSFUL
  - 회귀: `LogbackJsonFormatTest` 8건 + `BlockListFilterTest` 5건 정상

## Reviewer 5관점 결과
본 PR 머지 전 Story Reviewer 세션(Domain·Architecture·API·Test·Sceptical) 1회 수행. Critical·Major 6건은 본 PR에서 보강 commit(`c47a608`)으로 반영. 미반영 후속 사항:
- **@RestControllerAdvice 정상 처리 경로 통합 테스트** — 본 Story 단위 테스트는 chain.doFilter throw 시나리오로 MDC clear를 검증. 실제 @RestControllerAdvice가 예외를 catch하여 정상 응답을 반환하는 경로의 MDC clear는 Story 3-1(GlobalExceptionHandler 로그 레벨 분리) 또는 별도 Slice/통합 테스트로 보강 예정.
- **PACKAGE.md "Common 내 cross 패키지 의존 규칙" 보강** — `Common/config → Common/logging` import 패턴이 PACKAGE.md에 명시 없음. 별도 PR로 보강 권장.

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (Controller 변경 없음)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — ADR008 기반 구현이라 신규 ADR 트리거 없음. PACKAGE.md 보강은 별도 PR
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Common 내 변경만, 다른 BC 영향 없음
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 의도된 후속 (Story 2-2 위임)
- userId MDC 주입: logback-spring.xml 화이트리스트에는 `userId` 키가 등록되어 있으나 본 PR 머지 직후엔 주입자 없음(의도적). Story 2-2(JWTFilter 인증 성공 분기에서 `MDC.put("userId", ...)`)에서 채워질 예정.

## 관련 이슈
- Product: `workflow/product/pes/ready/product-log.md` (Product 0-a 로깅)
- Epic: Epic 2 — MDC 요청 컨텍스트 전파
- Story: Story 2-1 — MdcLoggingFilter 구현(requestId 생성·전파·응답 헤더 echo·MDC clear)
- 마일스톤: `workflow/product/milestones/version/0.0.1v/milestone.md` Tier 1 #2
- 관련 ADR: [ADR008](docs/adr/ADR008.md) — 로깅 인프라(profile별 Appender + LogstashEncoder + MDC 화이트리스트)