### PR TITLE
feat(logging): GlobalExceptionHandler 예외별 로그 레벨 분리 + 민감정보 차단 [Story-031]

### DIFF
--- a/docs/adr/ADR011.md
+++ b/docs/adr/ADR011.md
@@ -1,0 +1,90 @@
+# ADR011: MDC 화이트리스트에 `errorCode` 키를 추가한다
+
+- **상태**: Accepted
+- **날짜**: 2026-06-23
+- **관련**: Product 0-a 로깅 Epic 3, Story 3-1 (`GlobalExceptionHandler` 예외 유형별 로그 레벨 분리 + 민감정보 차단), [ADR008](ADR008.md) (로깅 인프라 — 화이트리스트 5개 키 정의)
+
+## 컨텍스트
+
+ADR008은 `logback-spring.xml`의 MDC 화이트리스트를 5개 키로 고정했다 — `traceId`, `requestId`, `userId`, `method`, `path`. 화이트리스트 외 키는 JSON 로그에 노출되지 않는다(보안 기본값).
+
+Story 3-1에서 `GlobalExceptionHandler`를 예외 유형별 로그 레벨로 분리하면서, 각 핸들러 진입 직후 `MDC.put("errorCode", ec.getCode())`로 ErrorCode를 MDC 필드로 주입하기로 결정했다. 이유:
+
+1. **로그 수집기 집계 가능** — `errorCode`별로 발생 빈도·시간 분포를 별도 인덱스 없이 그룹화. `message` 안 인라인 문자열은 정규식 추출이 필요해 비용·정확도 모두 손실.
+2. **메시지 vs 메타데이터 분리** — `message`는 사람이 읽는 텍스트, `errorCode`는 기계가 처리하는 식별자. 한 필드에 합치면 둘 다 손상.
+3. **Product 1 알림(v2) 연결 기반** — "특정 ErrorCode가 5분 안에 N건 이상 발생하면 알림" 같은 룰을 수집기 측에서 작성 가능.
+
+그러나 `errorCode`가 화이트리스트에 등록되지 않으면 LogstashEncoder가 JSON 라인에 필드를 노출하지 않는다 — Story 3-1의 핸들러 코드가 `MDC.put`을 호출해도 효과 무효.
+
+ADR008의 "알려진 follow-up" §"MDC 화이트리스트 운영 정책 재정의"가 본 결정을 예고한 항목이다.
+
+## 결정
+
+**`errorCode`를 MDC 화이트리스트에 추가해 6번째 키로 정착**한다.
+
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+    <customFields>{"application":"thirdtool"}</customFields>
+    <includeMdcKeyName>traceId</includeMdcKeyName>
+    <includeMdcKeyName>requestId</includeMdcKeyName>
+    <includeMdcKeyName>userId</includeMdcKeyName>
+    <includeMdcKeyName>method</includeMdcKeyName>
+    <includeMdcKeyName>path</includeMdcKeyName>
+    <includeMdcKeyName>errorCode</includeMdcKeyName>   <!-- ADR011 -->
+    <includeContext>false</includeContext>
+</encoder>
+```
+
+### 값 규약
+
+| 출처 | MDC 값 |
+| --- | --- |
+| `BusinessException` | `ec.getCode()` (예: `CARD_NOT_FOUND`, `AUTH005`) |
+| `MethodArgumentNotValidException` · `ConstraintViolationException` | `ErrorCode.INVALID_INPUT.getCode()` = `C001` |
+| `AuthenticationException` | `ErrorCode.UNAUTHORIZED.getCode()` = `USER002` |
+| `AccessDeniedException` | `ErrorCode.AUTH_FORBIDDEN.getCode()` = `AUTH005` |
+| `MaxUploadSizeExceededException` | 리터럴 `"PAYLOAD_TOO_LARGE"` (ErrorCode enum 미등록) |
+| fallback `Exception` | 리터럴 `"INTERNAL_ERROR"` (ErrorCode enum 미등록) |
+
+ErrorCode enum 미등록 리터럴(`PAYLOAD_TOO_LARGE`, `INTERNAL_ERROR`)은 본 PR 범위 외로 ErrorCode 등록을 미루며, 향후 enum 통합이 결정되면 별도 Story로 이관한다. 수집기 측에서 `errorCode in ("PAYLOAD_TOO_LARGE","INTERNAL_ERROR")`로 별도 알림 룰 작성 가능하므로 운영 영향 없음.
+
+### MDC clear 책임
+
+`errorCode`는 핸들러 진입 직후 `MDC.put`되고, `MdcLoggingFilter.finally`의 `MDC.clear()`가 단일 책임으로 정리한다. ADR008·Story 2-1 결정 그대로.
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- 수집기에서 `errorCode` 기준 집계·알림 룰 작성 가능.
+- 핸들러 코드는 `MDC.put` 한 줄 추가로 끝. 응답 객체·예외 직렬화에 손대지 않는다.
+- 미래의 신규 핸들러 추가 시 동일 패턴(`MDC.put(MDC_ERROR_CODE, ...)`)으로 일관성 유지.
+
+### 트레이드오프 / 부정적
+
+- 화이트리스트 키가 5→6개로 증가. 정책 운영 비용(새 키 추가 시 ADR 절차) 누적.
+- ErrorCode enum 미등록 리터럴(`PAYLOAD_TOO_LARGE`, `INTERNAL_ERROR`)은 코드 검색 시 enum 매칭이 아니라 문자열 grep으로만 추적된다. 별도 Story로 enum 흡수 권장.
+- 일부 ErrorCode(예: `AUTH005`)는 SCREAMING_SNAKE_CASE 코드값이라 가독성 손해. 코드값 명명 규칙(`Common/Exception/ErrorCode`)은 본 ADR 범위 외.
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| 로그 메시지에 `code={}` 인라인 | 화이트리스트 변경 불요 | 수집기에서 정규식 추출 필요 — 비용·정확도 손실. 다중 패턴 (`code=` vs `errorCode=`) 혼재 위험 |
+| `customFields`에 정적 등록 | 한 곳에서 관리 | 요청별 다른 값을 가지는 동적 필드를 정적 필드로 둘 수 없음 |
+| 별도 `errorLogger` 분리 (`com.example.thirdtool.error`) | 에러 로그만 다른 인코더로 인덱스 | 인프라 복잡도 급증. 단일 logger·인코더로 풍부한 MDC를 흘리는 게 더 단순 |
+| MDC 화이트리스트 폐기·블랙리스트로 전환 | 새 키 추가 시 ADR 절차 불요 | 블랙리스트는 누락 시 누출. 본 프로젝트의 PII 방어 기본값 위반. ADR008 결정과 모순 |
+| 응답 본문의 `code` 필드를 수집기 측에서 파싱 | MDC 변경 불요 | 응답 본문은 status 200 정상 응답에도 포함될 수 있어 시그널이 흐려짐. 예외 경로의 `errorCode`와 정상 경로의 `code`(예: 비즈니스 도메인 코드) 의미 충돌 |
+
+## 알려진 follow-up
+
+- `ErrorCode` enum에 `PAYLOAD_TOO_LARGE`·`INTERNAL_ERROR` 등록 검토 — 현재는 핸들러 내부 리터럴. enum 통합 시 본 ADR의 값 규약 표를 갱신.
+- `errorCode` MDC 키 누수 검증 — `GlobalExceptionHandler` 외 임의 코드가 `MDC.put("errorCode", ...)`를 호출하면 화이트리스트 노출. 컨벤션상 본 핸들러 단일 책임이지만 정적 분석(예: ArchUnit) 도입 시점에 강제.
+- 핸들러별 ERROR/WARN/INFO 비율 모니터링 — Product 1 모니터링 도입 시 `errorCode` 기준 알림 임계값 설계.
+- `MaxUploadSizeExceededException` 응답 포맷 통일 — 현재 `Map<String, String>` 응답이 다른 핸들러의 `ErrorResponse` 포맷과 불일치. 별도 정비 Story 필요.
+
+## 다시 검토할 시점
+
+- 화이트리스트 키가 8개 이상으로 확장되는 시점 — 카테고리 기반 재정의(`request-scoped`, `user identifier`, `HTTP context`, `error metadata`) 또는 PII 블랙리스트 명시.
+- 외부 수집기(CloudWatch Logs / Loki / OpenSearch) 도입 시점 — `errorCode` 필드 인덱싱 정책 및 카디널리티 한계 점검.
+- `ErrorCode` enum이 100개 이상으로 늘어나는 시점 — 코드값 명명 규칙·카테고리 prefix 재정의 ADR.

--- a/docs/adr/ADR011.md
+++ b/docs/adr/ADR011.md
@@ -41,16 +41,17 @@ ADR008의 "알려진 follow-up" §"MDC 화이트리스트 운영 정책 재정�
 | --- | --- |
 | `BusinessException` | `ec.getCode()` (예: `CARD_NOT_FOUND`, `AUTH005`) |
 | `MethodArgumentNotValidException` · `ConstraintViolationException` | `ErrorCode.INVALID_INPUT.getCode()` = `C001` |
-| `AuthenticationException` | `ErrorCode.UNAUTHORIZED.getCode()` = `USER002` |
+| `AuthenticationException` (Controller throw 케이스) | `ErrorCode.UNAUTHORIZED.getCode()` = `USER002` |
+| `JwtAuthenticationEntryPoint` (Spring Security 필터 단의 정상 인증 실패 경로) | `auth.error` attribute의 ErrorCode 또는 fallback `AUTH_TOKEN_MISSING` |
 | `AccessDeniedException` | `ErrorCode.AUTH_FORBIDDEN.getCode()` = `AUTH005` |
-| `MaxUploadSizeExceededException` | 리터럴 `"PAYLOAD_TOO_LARGE"` (ErrorCode enum 미등록) |
-| fallback `Exception` | 리터럴 `"INTERNAL_ERROR"` (ErrorCode enum 미등록) |
+| `MaxUploadSizeExceededException` | `ErrorCode.PAYLOAD_TOO_LARGE.getCode()` = `FILE005` |
+| fallback `Exception` | `ErrorCode.INTERNAL_ERROR.getCode()` = `C500` |
 
-ErrorCode enum 미등록 리터럴(`PAYLOAD_TOO_LARGE`, `INTERNAL_ERROR`)은 본 PR 범위 외로 ErrorCode 등록을 미루며, 향후 enum 통합이 결정되면 별도 Story로 이관한다. 수집기 측에서 `errorCode in ("PAYLOAD_TOO_LARGE","INTERNAL_ERROR")`로 별도 알림 룰 작성 가능하므로 운영 영향 없음.
+`PAYLOAD_TOO_LARGE`(FILE005, 413)와 `INTERNAL_ERROR`(C500, 500)는 Story-031 본 PR에서 ErrorCode enum에 정식 등록되었다. 모든 MDC errorCode 값은 enum 매칭으로 추적된다.
 
 ### MDC clear 책임
 
-`errorCode`는 핸들러 진입 직후 `MDC.put`되고, `MdcLoggingFilter.finally`의 `MDC.clear()`가 단일 책임으로 정리한다. ADR008·Story 2-1 결정 그대로.
+`errorCode`는 핸들러 진입 직후 `try { MDC.put }` 블록에서 주입되고, `finally { MDC.remove(MDC_ERROR_CODE) }`로 즉시 정리된다. `MdcLoggingFilter.finally`의 `MDC.clear()`가 HTTP 경로의 최종 안전망이나, 비-HTTP 경로(@Scheduled·@Async·테스트)에서도 누수가 없도록 핸들러 자체에서 책임을 단축한다. `JwtAuthenticationEntryPoint`도 동일 try-finally 패턴.
 
 ## 결과 (Consequences)
 
@@ -78,10 +79,12 @@ ErrorCode enum 미등록 리터럴(`PAYLOAD_TOO_LARGE`, `INTERNAL_ERROR`)은 본
 
 ## 알려진 follow-up
 
-- `ErrorCode` enum에 `PAYLOAD_TOO_LARGE`·`INTERNAL_ERROR` 등록 검토 — 현재는 핸들러 내부 리터럴. enum 통합 시 본 ADR의 값 규약 표를 갱신.
-- `errorCode` MDC 키 누수 검증 — `GlobalExceptionHandler` 외 임의 코드가 `MDC.put("errorCode", ...)`를 호출하면 화이트리스트 노출. 컨벤션상 본 핸들러 단일 책임이지만 정적 분석(예: ArchUnit) 도입 시점에 강제.
+- `errorCode` MDC 키 누수 검증 — `GlobalExceptionHandler`·`JwtAuthenticationEntryPoint` 외 임의 코드가 `MDC.put("errorCode", ...)`를 호출하면 화이트리스트 노출. 컨벤션상 본 두 클래스 단일 책임이지만 정적 분석(예: ArchUnit) 도입 시점에 강제.
+- MDC 키 상수 중앙 집중 — 현재 `GlobalExceptionHandler.MDC_ERROR_CODE`(package-private) + `JwtAuthenticationEntryPoint.MDC_ERROR_CODE`(private) + `MdcLoggingFilter.MDC_*` 4개로 분산. `Common/logging/MdcKeys` 통합 클래스 신설 검토 (별도 Story).
 - 핸들러별 ERROR/WARN/INFO 비율 모니터링 — Product 1 모니터링 도입 시 `errorCode` 기준 알림 임계값 설계.
-- `MaxUploadSizeExceededException` 응답 포맷 통일 — 현재 `Map<String, String>` 응답이 다른 핸들러의 `ErrorResponse` 포맷과 불일치. 별도 정비 Story 필요.
+- @WebMvcTest/@SpringBootTest 통합 검증 — 단위 테스트는 핸들러 메서드 호출만 검증. SecurityFilterChain + DispatcherServlet + GlobalExceptionHandler + MdcLoggingFilter 전 경로의 errorCode JSON 출력 회귀 안전망은 별도 Slice/통합 테스트 Story.
+- ✅ ~~`ErrorCode` enum에 `PAYLOAD_TOO_LARGE`·`INTERNAL_ERROR` 등록~~ — Story-031 본 PR에서 등록 완료 (`FILE005`, `C500`).
+- ✅ ~~`MaxUploadSizeExceededException` 응답 포맷 통일~~ — Story-031 본 PR에서 `ErrorResponse`로 통일 완료.
 
 ## 다시 검토할 시점
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -12,3 +12,4 @@
 | [ADR008](ADR008.md) | 로깅 인프라 — profile별 Appender 분기 + LogstashEncoder + MDC 화이트리스트 | Accepted | 2026-05-17 |
 | [ADR009](ADR009.md) | Access Token은 HttpOnly Cookie, Refresh Token은 React 메모리에 저장한다 | Accepted | 2026-05-27 |
 | [ADR010](ADR010.md) | AI 제안 호출 실패는 5xx 미노출 — 빈 목록 + suggestionsAvailable 플래그로 변환 | Accepted | 2026-06-22 |
+| [ADR011](ADR011.md) | MDC 화이트리스트에 errorCode 키를 추가한다 (Story 3-1) | Accepted | 2026-06-23 |

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -125,10 +125,14 @@ public enum ErrorCode {
     FILE_UNSUPPORTED_EXTENSION("FILE002",   "지원하지 않는 확장자입니다.",        HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_FAIL("FILE003",             "파일 업로드에 실패했습니다.",         HttpStatus.SERVICE_UNAVAILABLE),
     FILE_DELETE_FAIL("FILE004",             "파일 삭제에 실패했습니다.",           HttpStatus.SERVICE_UNAVAILABLE),
+    PAYLOAD_TOO_LARGE("FILE005",            "허용된 최대 업로드 크기를 초과했습니다.", HttpStatus.PAYLOAD_TOO_LARGE),
 
     // ─── Library ──────────────────────────────────────────
     // Story-5-3: ACCESS_DENIED("LIBRARY002") 제거 — 사용처 0건 + AUTH_FORBIDDEN(AUTH005)과 의미 중복.
-    ALREADY_EXISTS("LIBRARY001",  "이미 존재하는 리소스입니다.",  HttpStatus.CONFLICT);
+    ALREADY_EXISTS("LIBRARY001",  "이미 존재하는 리소스입니다.",  HttpStatus.CONFLICT),
+
+    // ─── 공통 fallback (Story 3-1) ────────────────────────
+    INTERNAL_ERROR("C500",        "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     // ─── 필드 ─────────────────────────────────────────────
     private final String     code;

--- a/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
@@ -3,38 +3,58 @@ package com.example.thirdtool.Common.Exception;
 
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.dao.DataIntegrityViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * 전역 예외 핸들러 — 예외 유형별 로그 레벨을 명시 분리한다 (Story 3-1, ADR009 참조).
+ *
+ * <p>매핑 표:
+ * <ul>
+ *   <li>{@link BusinessException} → WARN, stack trace 미포함 (예상 가능한 비정상)</li>
+ *   <li>{@link MethodArgumentNotValidException}, {@link ConstraintViolationException} → INFO (4xx 검증)</li>
+ *   <li>{@link AuthenticationException} → INFO (인증 실패는 빈번한 정상 분기)</li>
+ *   <li>{@link AccessDeniedException} → WARN (보안 추적 가치 — Story 5-3 결정 유지)</li>
+ *   <li>{@link MaxUploadSizeExceededException} → INFO (4xx 검증의 일종)</li>
+ *   <li>{@link Exception} fallback → ERROR + stack trace (예상치 못한 5xx)</li>
+ * </ul>
+ *
+ * <p>핸들러 진입 직후 {@code MDC.put("errorCode", ...)}로 로그 수집기의 집계 키를 주입한다.
+ * MDC clear는 {@code MdcLoggingFilter.finally}가 책임진다.
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    static final String MDC_ERROR_CODE = "errorCode";
+    static final String INTERNAL_ERROR_CODE = "INTERNAL_ERROR";
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusiness(BusinessException ex,
                                                         HttpServletRequest req) {
-
         ErrorCode ec = ex.getErrorCode();
-
+        MDC.put(MDC_ERROR_CODE, ec.getCode());
+        log.warn("business.exception code={} message={}", ec.getCode(), ex.getMessage());
         return ResponseEntity
                 .status(ec.getStatus())
                 .body(new ErrorResponse(
                         ec.getCode(),
-                        ex.getMessage(),   // detail 포함된 메시지 사용
+                        ex.getMessage(),
                         req.getRequestURI(),
                         OffsetDateTime.now()
                 ));
@@ -43,6 +63,8 @@ public class GlobalExceptionHandler {
     //파일 관련 예외 처리
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<Map<String, String>> handleMaxSizeException(MaxUploadSizeExceededException e) {
+        MDC.put(MDC_ERROR_CODE, "PAYLOAD_TOO_LARGE");
+        log.info("upload.size.exceeded maxSize={}", e.getMaxUploadSize());
         Map<String, String> response = new HashMap<>();
         response.put("error", "파일 용량 초과");
         response.put("message", "허용된 최대 업로드 크기를 초과했습니다.");
@@ -51,9 +73,35 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest req) {
+        MDC.put(MDC_ERROR_CODE, ErrorCode.INVALID_INPUT.getCode());
+        log.info("validation.failed errors={}", ex.getBindingResult().getAllErrors().size());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getCode(),
                                      ErrorCode.INVALID_INPUT.getMessage(), req.getRequestURI(), OffsetDateTime.now()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex,
+                                                                   HttpServletRequest req) {
+        MDC.put(MDC_ERROR_CODE, ErrorCode.INVALID_INPUT.getCode());
+        log.info("validation.constraint.violation violations={}", ex.getConstraintViolations().size());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getCode(),
+                                     ErrorCode.INVALID_INPUT.getMessage(), req.getRequestURI(), OffsetDateTime.now()));
+    }
+
+    /**
+     * Spring Security의 {@link AuthenticationException} — 토큰 없음·만료·서명 불일치 등.
+     * 인증 실패는 빈번한 정상 분기이므로 INFO. stack trace 미포함.
+     */
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex, HttpServletRequest req) {
+        ErrorCode ec = ErrorCode.UNAUTHORIZED;
+        MDC.put(MDC_ERROR_CODE, ec.getCode());
+        log.info("authentication.failed type={} message={}", ex.getClass().getSimpleName(), ex.getMessage());
+        return ResponseEntity.status(ec.getStatus())
+                             .body(new ErrorResponse(ec.getCode(), ec.getMessage(),
+                                                     req.getRequestURI(), OffsetDateTime.now()));
     }
 
     /**
@@ -69,14 +117,32 @@ public class GlobalExceptionHandler {
      *
      * <p>응답 메시지는 보안상 ErrorCode enum 메시지("접근 권한이 없습니다.")로 통일하며,
      * Controller에서 던진 구체 메시지는 서버 로그에만 기록.
+     *
+     * <p>로그 레벨은 WARN — 권한 거부는 4xx지만 보안 추적 가치가 높아 INFO보다 격상
+     * (Epic 3 결정).
      */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest req) {
-        log.warn("[AccessDenied] {} {} - {}", req.getMethod(), req.getRequestURI(), ex.getMessage());
         ErrorCode ec = ErrorCode.AUTH_FORBIDDEN;
+        MDC.put(MDC_ERROR_CODE, ec.getCode());
+        log.warn("access.denied method={} path={} detail={}", req.getMethod(), req.getRequestURI(), ex.getMessage());
         return ResponseEntity.status(ec.getStatus())
                              .body(new ErrorResponse(ec.getCode(), ec.getMessage(),
                                                      req.getRequestURI(), OffsetDateTime.now()));
+    }
+
+    /**
+     * fallback — 명시 매핑되지 않은 모든 예외. ERROR 레벨 + stack trace.
+     * Product 1의 알림(v2) 채널 구독 대상은 본 핸들러가 출력하는 ERROR 로그.
+     * 신규 예외 추가 시 본 fallback에 의존하지 말고 명시 핸들러를 추가 (Epic 3 결정).
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnknown(Exception ex, HttpServletRequest req) {
+        MDC.put(MDC_ERROR_CODE, INTERNAL_ERROR_CODE);
+        log.error("unexpected.exception type={}", ex.getClass().getName(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                             .body(new ErrorResponse(INTERNAL_ERROR_CODE,
+                                     "서버 내부 오류가 발생했습니다.", req.getRequestURI(), OffsetDateTime.now()));
     }
 
     @Getter

--- a/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
@@ -8,7 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
@@ -18,8 +17,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.OffsetDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 전역 예외 핸들러 — 예외 유형별 로그 레벨을 명시 분리한다 (Story 3-1, ADR011 참조).
@@ -28,80 +25,90 @@ import java.util.Map;
  * <ul>
  *   <li>{@link BusinessException} → WARN, stack trace 미포함 (예상 가능한 비정상)</li>
  *   <li>{@link MethodArgumentNotValidException}, {@link ConstraintViolationException} → INFO (4xx 검증)</li>
- *   <li>{@link AuthenticationException} → INFO (인증 실패는 빈번한 정상 분기)</li>
+ *   <li>{@link AuthenticationException} → INFO (Controller 내부 throw 케이스. 정상 경로는 JwtAuthenticationEntryPoint)</li>
  *   <li>{@link AccessDeniedException} → WARN (보안 추적 가치 — Story 5-3 결정 유지)</li>
  *   <li>{@link MaxUploadSizeExceededException} → INFO (4xx 검증의 일종)</li>
  *   <li>{@link Exception} fallback → ERROR + stack trace (예상치 못한 5xx)</li>
  * </ul>
  *
- * <p>핸들러 진입 직후 {@code MDC.put("errorCode", ...)}로 로그 수집기의 집계 키를 주입한다.
- * MDC clear는 {@code MdcLoggingFilter.finally}가 책임진다.
+ * <p>핸들러 진입 직후 {@code MDC.put("errorCode", ...)}로 로그 수집기의 집계 키를 주입하고,
+ * {@code try-finally}에서 {@link MDC#remove(String)}로 정리한다. {@code MdcLoggingFilter}의
+ * {@code MDC.clear()}가 단일 책임이지만, 비-HTTP 경로(@Scheduled·@Async·테스트)에서도
+ * 누수가 없도록 핸들러 자체에서 즉시 정리.
+ *
+ * <p>응답 {@code message}는 {@code ErrorCode} enum 정적 메시지만 노출한다 — detail은 로그에만.
+ * 사용자 입력값이 detail로 흘러들어와 응답 body로 reflected되는 정보 누출을 차단.
  */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     static final String MDC_ERROR_CODE = "errorCode";
-    static final String INTERNAL_ERROR_CODE = "INTERNAL_ERROR";
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusiness(BusinessException ex,
                                                         HttpServletRequest req) {
         ErrorCode ec = ex.getErrorCode();
-        MDC.put(MDC_ERROR_CODE, ec.getCode());
-        log.warn("business.exception code={} message={}", ec.getCode(), ex.getMessage());
-        return ResponseEntity
-                .status(ec.getStatus())
-                .body(new ErrorResponse(
-                        ec.getCode(),
-                        ex.getMessage(),
-                        req.getRequestURI(),
-                        OffsetDateTime.now()
-                ));
+        try {
+            MDC.put(MDC_ERROR_CODE, ec.getCode());
+            log.warn("business.exception code={} message={}", ec.getCode(), ex.getMessage());
+            return errorResponse(ec, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     //파일 관련 예외 처리
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<Map<String, String>> handleMaxSizeException(MaxUploadSizeExceededException e) {
-        MDC.put(MDC_ERROR_CODE, "PAYLOAD_TOO_LARGE");
-        log.info("upload.size.exceeded maxSize={}", e.getMaxUploadSize());
-        Map<String, String> response = new HashMap<>();
-        response.put("error", "파일 용량 초과");
-        response.put("message", "허용된 최대 업로드 크기를 초과했습니다.");
-        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(response);
+    public ResponseEntity<ErrorResponse> handleMaxSizeException(MaxUploadSizeExceededException ex,
+                                                                HttpServletRequest req) {
+        try {
+            MDC.put(MDC_ERROR_CODE, ErrorCode.PAYLOAD_TOO_LARGE.getCode());
+            log.info("upload.size.exceeded maxSize={}", ex.getMaxUploadSize());
+            return errorResponse(ErrorCode.PAYLOAD_TOO_LARGE, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest req) {
-        MDC.put(MDC_ERROR_CODE, ErrorCode.INVALID_INPUT.getCode());
-        log.info("validation.failed errors={}", ex.getBindingResult().getAllErrors().size());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                             .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getCode(),
-                                     ErrorCode.INVALID_INPUT.getMessage(), req.getRequestURI(), OffsetDateTime.now()));
+        try {
+            MDC.put(MDC_ERROR_CODE, ErrorCode.INVALID_INPUT.getCode());
+            log.info("validation.failed errors={}", ex.getBindingResult().getAllErrors().size());
+            return errorResponse(ErrorCode.INVALID_INPUT, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex,
                                                                    HttpServletRequest req) {
-        MDC.put(MDC_ERROR_CODE, ErrorCode.INVALID_INPUT.getCode());
-        log.info("validation.constraint.violation violations={}", ex.getConstraintViolations().size());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                             .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getCode(),
-                                     ErrorCode.INVALID_INPUT.getMessage(), req.getRequestURI(), OffsetDateTime.now()));
+        try {
+            MDC.put(MDC_ERROR_CODE, ErrorCode.INVALID_INPUT.getCode());
+            log.info("validation.constraint.violation violations={}", ex.getConstraintViolations().size());
+            return errorResponse(ErrorCode.INVALID_INPUT, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     /**
-     * Spring Security의 {@link AuthenticationException} — 토큰 없음·만료·서명 불일치 등.
-     * 인증 실패는 빈번한 정상 분기이므로 INFO. stack trace 미포함.
+     * Controller 내부에서 직접 throw된 {@link AuthenticationException} 처리용.
+     * Spring Security 필터 단의 인증 실패는 {@code JwtAuthenticationEntryPoint}가 처리하므로
+     * 본 핸들러는 보안망(fallback) 역할. 두 경로 모두 INFO + MDC errorCode 정책.
      */
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex, HttpServletRequest req) {
         ErrorCode ec = ErrorCode.UNAUTHORIZED;
-        MDC.put(MDC_ERROR_CODE, ec.getCode());
-        log.info("authentication.failed type={} message={}", ex.getClass().getSimpleName(), ex.getMessage());
-        return ResponseEntity.status(ec.getStatus())
-                             .body(new ErrorResponse(ec.getCode(), ec.getMessage(),
-                                                     req.getRequestURI(), OffsetDateTime.now()));
+        try {
+            MDC.put(MDC_ERROR_CODE, ec.getCode());
+            log.info("authentication.failed type={} message={}", ex.getClass().getSimpleName(), ex.getMessage());
+            return errorResponse(ec, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     /**
@@ -115,20 +122,18 @@ public class GlobalExceptionHandler {
      *       후속 Story에서 본 핸들러 응답 형식과 통일 예정)</li>
      * </ul>
      *
-     * <p>응답 메시지는 보안상 ErrorCode enum 메시지("접근 권한이 없습니다.")로 통일하며,
-     * Controller에서 던진 구체 메시지는 서버 로그에만 기록.
-     *
-     * <p>로그 레벨은 WARN — 권한 거부는 4xx지만 보안 추적 가치가 높아 INFO보다 격상
-     * (Epic 3 결정).
+     * <p>로그 레벨은 WARN — 권한 거부는 4xx지만 보안 추적 가치가 높아 INFO보다 격상 (Epic 3 결정).
      */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest req) {
         ErrorCode ec = ErrorCode.AUTH_FORBIDDEN;
-        MDC.put(MDC_ERROR_CODE, ec.getCode());
-        log.warn("access.denied method={} path={} detail={}", req.getMethod(), req.getRequestURI(), ex.getMessage());
-        return ResponseEntity.status(ec.getStatus())
-                             .body(new ErrorResponse(ec.getCode(), ec.getMessage(),
-                                                     req.getRequestURI(), OffsetDateTime.now()));
+        try {
+            MDC.put(MDC_ERROR_CODE, ec.getCode());
+            log.warn("access.denied method={} path={} detail={}", req.getMethod(), req.getRequestURI(), ex.getMessage());
+            return errorResponse(ec, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     /**
@@ -138,11 +143,27 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnknown(Exception ex, HttpServletRequest req) {
-        MDC.put(MDC_ERROR_CODE, INTERNAL_ERROR_CODE);
-        log.error("unexpected.exception type={}", ex.getClass().getName(), ex);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                             .body(new ErrorResponse(INTERNAL_ERROR_CODE,
-                                     "서버 내부 오류가 발생했습니다.", req.getRequestURI(), OffsetDateTime.now()));
+        ErrorCode ec = ErrorCode.INTERNAL_ERROR;
+        try {
+            MDC.put(MDC_ERROR_CODE, ec.getCode());
+            log.error("unexpected.exception type={}", ex.getClass().getName(), ex);
+            return errorResponse(ec, req);
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
+    }
+
+    /**
+     * 모든 핸들러의 응답 빌더 — 응답 message는 ErrorCode enum 정적 메시지로 고정.
+     * detail(BusinessException.withDetail의 인자)은 로그에만 남고 응답 body에 노출되지 않는다.
+     */
+    private ResponseEntity<ErrorResponse> errorResponse(ErrorCode ec, HttpServletRequest req) {
+        return ResponseEntity.status(ec.getStatus())
+                             .body(new ErrorResponse(
+                                     ec.getCode(),
+                                     ec.getMessage(),
+                                     req.getRequestURI(),
+                                     OffsetDateTime.now()));
     }
 
     @Getter

--- a/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 전역 예외 핸들러 — 예외 유형별 로그 레벨을 명시 분리한다 (Story 3-1, ADR009 참조).
+ * 전역 예외 핸들러 — 예외 유형별 로그 레벨을 명시 분리한다 (Story 3-1, ADR011 참조).
  *
  * <p>매핑 표:
  * <ul>

--- a/src/main/java/com/example/thirdtool/Common/logging/util/SensitiveLogMasker.java
+++ b/src/main/java/com/example/thirdtool/Common/logging/util/SensitiveLogMasker.java
@@ -1,0 +1,39 @@
+package com.example.thirdtool.Common.logging.util;
+
+/**
+ * 로그 출력 시 민감정보를 마스킹하는 유틸 (Story 3-1).
+ *
+ * <p>비밀번호·access token·refresh token·OAuth 인가 코드 등 원문이 로그에 그대로
+ * 노출되면 prod JSON 스트림 유출 시 즉시 사고로 이어진다. 본 유틸은 디버깅 식별성을
+ * 유지하면서 원문을 차단하기 위해 <b>prefix 8자 + {@value #MASK_SUFFIX}</b> 패턴을 사용한다.
+ *
+ * <p>자동 마스킹(Loggable 어노테이션·리플렉션 기반 PII 필터)은 v2 도입 예정. 현 단계는
+ * 호출자가 명시적으로 본 유틸을 거치는 컨벤션.
+ */
+public final class SensitiveLogMasker {
+
+    static final String MASK_SUFFIX = "***";
+    static final int PREFIX_LEN = 8;
+    static final String NULL_REPRESENTATION = "null";
+    static final String BLANK_REPRESENTATION = "blank";
+
+    private SensitiveLogMasker() {
+    }
+
+    /**
+     * 토큰·시크릿류 문자열을 prefix 8자 + "***"로 마스킹한다.
+     * 원문 길이가 8자 이하이면 전부 마스킹("***").
+     */
+    public static String maskToken(String value) {
+        if (value == null) {
+            return NULL_REPRESENTATION;
+        }
+        if (value.isBlank()) {
+            return BLANK_REPRESENTATION;
+        }
+        if (value.length() <= PREFIX_LEN) {
+            return MASK_SUFFIX;
+        }
+        return value.substring(0, PREFIX_LEN) + MASK_SUFFIX;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Common/security/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/JwtAuthenticationEntryPoint.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -19,13 +20,18 @@ import java.util.Map;
  * 인증 실패 시 응답을 GlobalExceptionHandler와 동일한 {code, message, path, timestamp} 형식으로 통일한다 (Story 3-1).
  *
  * JWTFilter는 인증 실패 사유를 request attribute "auth.error" 에 ErrorCode로 저장하고
- * 본 EntryPoint가 그 ErrorCode를 꺼내 응답을 작성한다. attribute가 없으면 기본 UNAUTHORIZED.
+ * 본 EntryPoint가 그 ErrorCode를 꺼내 응답을 작성한다. attribute가 없으면 기본 AUTH_TOKEN_MISSING.
+ *
+ * <p>Spring Security 필터 단의 인증 실패는 {@link org.springframework.web.bind.annotation.RestControllerAdvice}로
+ * 흐르지 않으므로 본 EntryPoint가 인증 실패 로그의 단일 진입점이다. Story 3-1: INFO 격상 + MDC errorCode
+ * 주입으로 GlobalExceptionHandler와 동일한 로그 정책을 적용. ({@link MDC#remove(String)}는 finally에서 즉시 정리)
  */
 @Slf4j
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     public static final String ERROR_CODE_ATTRIBUTE = "auth.error";
+    private static final String MDC_ERROR_CODE = "errorCode";
 
     private final ObjectMapper objectMapper;
 
@@ -39,19 +45,23 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                          AuthenticationException authException) throws IOException {
 
         ErrorCode errorCode = resolveErrorCode(request, authException);
+        try {
+            MDC.put(MDC_ERROR_CODE, errorCode.getCode());
+            log.info("authentication.failed code={} path={}", errorCode.getCode(), request.getRequestURI());
 
-        log.debug("[AUTH-ENTRY] {} → {} {}", request.getRequestURI(), errorCode.getCode(), errorCode.getMessage());
+            response.setStatus(errorCode.getStatus().value());
+            response.setContentType("application/json;charset=UTF-8");
 
-        response.setStatus(errorCode.getStatus().value());
-        response.setContentType("application/json;charset=UTF-8");
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("code", errorCode.getCode());
+            body.put("message", errorCode.getMessage());
+            body.put("path", request.getRequestURI());
+            body.put("timestamp", OffsetDateTime.now().toString());
 
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("code", errorCode.getCode());
-        body.put("message", errorCode.getMessage());
-        body.put("path", request.getRequestURI());
-        body.put("timestamp", OffsetDateTime.now().toString());
-
-        response.getWriter().write(objectMapper.writeValueAsString(body));
+            response.getWriter().write(objectMapper.writeValueAsString(body));
+        } finally {
+            MDC.remove(MDC_ERROR_CODE);
+        }
     }
 
     private ErrorCode resolveErrorCode(HttpServletRequest request, AuthenticationException ex) {

--- a/src/main/java/com/example/thirdtool/Common/security/auth/RefreshEntity.java
+++ b/src/main/java/com/example/thirdtool/Common/security/auth/RefreshEntity.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Table(name = "jwt_refresh_entity")
@@ -20,6 +21,11 @@ public class RefreshEntity extends BaseEntity {
     @Column(name = "username", nullable = false, unique = true)
     private String username;
 
+    /**
+     * Story 3-1: RT 원문이 로그·디버거 출력에 노출되지 않도록 방어. JwtService 회전 경로에서
+     * RT 원문이 출력되어야 한다면 {@code SensitiveLogMasker.maskToken(...)}를 거친다.
+     */
+    @ToString.Exclude
     @Column(name = "refresh", nullable = false, length = 512)
     private String refresh;
 

--- a/src/main/java/com/example/thirdtool/User/domain/model/UserEntity.java
+++ b/src/main/java/com/example/thirdtool/User/domain/model/UserEntity.java
@@ -25,19 +25,24 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString(onlyExplicitlyIncluded = true)
 public class UserEntity extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ToString.Include
     private Long id;
 
+    /**
+     * Story 3-1: username만 명시 노출. password·email·nickname·소셜 연관은 PII/민감으로 비노출.
+     */
+    @ToString.Include
     @Column(name = "username", unique = true, nullable = false, updatable = false)
     private String username;
 
     /**
-     * Story 3-1: BCrypt 해시이지만 원문 또는 해시 자체도 로그에 노출되지 않도록 방어.
-     * 향후 누군가 UserEntity에 {@code @ToString}을 추가해도 password 필드는 자동 제외된다.
+     * Story 3-1: BCrypt 해시이지만 원문도 로그에 노출되지 않도록 방어.
+     * 클래스 레벨 {@code @ToString(onlyExplicitlyIncluded=true)}로 자동 제외되며 별도 어노테이션 불요.
      */
-    @ToString.Exclude
     @Column(name = "password", nullable = false)
     private String password;
 

--- a/src/main/java/com/example/thirdtool/User/domain/model/UserEntity.java
+++ b/src/main/java/com/example/thirdtool/User/domain/model/UserEntity.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -32,6 +33,11 @@ public class UserEntity extends BaseEntity {
     @Column(name = "username", unique = true, nullable = false, updatable = false)
     private String username;
 
+    /**
+     * Story 3-1: BCrypt 해시이지만 원문 또는 해시 자체도 로그에 노출되지 않도록 방어.
+     * 향후 누군가 UserEntity에 {@code @ToString}을 추가해도 password 필드는 자동 제외된다.
+     */
+    @ToString.Exclude
     @Column(name = "password", nullable = false)
     private String password;
 

--- a/src/main/java/com/example/thirdtool/User/dto/LoginRequestDTO.java
+++ b/src/main/java/com/example/thirdtool/User/dto/LoginRequestDTO.java
@@ -14,4 +14,14 @@ public class LoginRequestDTO {
 
     @NotBlank
     private String password;
+
+    /**
+     * Story 3-1: 비밀번호 원문이 로그·예외 메시지·디버거 출력에 노출되지 않도록 toString을 명시 오버라이드.
+     * Validation 실패 시 Spring이 DTO를 toString해 로그에 흘리는 경로(MethodArgumentNotValidException)
+     * 등 모든 직렬화 경로에서 password 자리를 "***"로 고정.
+     */
+    @Override
+    public String toString() {
+        return "LoginRequestDTO(username=" + username + ", password=***)";
+    }
 }

--- a/src/main/java/com/example/thirdtool/User/infrastructure/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/example/thirdtool/User/infrastructure/kakao/KakaoOAuthClient.java
@@ -1,5 +1,6 @@
 package com.example.thirdtool.User.infrastructure.kakao;
 
+import com.example.thirdtool.Common.logging.util.SensitiveLogMasker;
 import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoTokenResponse;
 import com.example.thirdtool.User.infrastructure.kakao.dto.KakaoUserInfo;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ public class KakaoOAuthClient {
         formData.add("code", authorizationCode);
 
         log.info("[KakaoOAuthClient] 🔍 Token 요청 파라미터: grant_type={}, client_id={}, redirect_uri={}, code={}",
-                "authorization_code", clientId, redirectUri, authorizationCode);
+                "authorization_code", clientId, redirectUri, SensitiveLogMasker.maskToken(authorizationCode));
 
         return webClient.post()
                         .uri("/oauth/token")
@@ -52,7 +53,8 @@ public class KakaoOAuthClient {
                             log.error("[KakaoOAuthClient] ❌ 4xx 오류 발생: {}", response.statusCode());
                             return response.bodyToMono(String.class)
                                            .flatMap(body -> {
-                                               log.error("[KakaoOAuthClient] ❌ 응답 본문: {}", body);
+                                               // 본문에 access_token이 포함될 수 있으므로 길이만 노출
+                                               log.error("[KakaoOAuthClient] ❌ 응답 본문 length={}", body == null ? 0 : body.length());
                                                return Mono.error(new RuntimeException("카카오 토큰 요청 실패"));
                                            });
                         })

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    ThirdTool 로깅 인프라 (ADR008 · errorCode 키 추가 ADR009)
+    ThirdTool 로깅 인프라 (ADR008 · errorCode 키 추가 ADR011)
     - local        : 평문 콘솔 (개발자 가독성)
     - dev / prod   : JSON 한 줄 (LogstashEncoder, 수집기 호환)
     - MDC 화이트리스트: traceId, requestId, userId, method, path, errorCode

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    ThirdTool 로깅 인프라 (ADR008)
+    ThirdTool 로깅 인프라 (ADR008 · errorCode 키 추가 ADR009)
     - local        : 평문 콘솔 (개발자 가독성)
     - dev / prod   : JSON 한 줄 (LogstashEncoder, 수집기 호환)
-    - MDC 화이트리스트: traceId, requestId, userId, method, path
+    - MDC 화이트리스트: traceId, requestId, userId, method, path, errorCode
 -->
 <configuration>
 
@@ -31,6 +31,7 @@
                 <includeMdcKeyName>userId</includeMdcKeyName>
                 <includeMdcKeyName>method</includeMdcKeyName>
                 <includeMdcKeyName>path</includeMdcKeyName>
+                <includeMdcKeyName>errorCode</includeMdcKeyName>
                 <includeContext>false</includeContext>
             </encoder>
         </appender>

--- a/src/test/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,197 @@
+package com.example.thirdtool.Common.Exception;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("GlobalExceptionHandler 로그 레벨 분리")
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler handler;
+    private MockHttpServletRequest request;
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger handlerLogger;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalExceptionHandler();
+        request = new MockHttpServletRequest("GET", "/api/v1/test");
+
+        handlerLogger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        handlerLogger.addAppender(logAppender);
+
+        MDC.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        handlerLogger.detachAppender(logAppender);
+        logAppender.stop();
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("BusinessException은 WARN 레벨 + stack trace 미포함 + MDC errorCode 주입")
+    void BusinessException은_WARN_레벨_stack_미포함_MDC_errorCode_주입() {
+        BusinessException ex = new BusinessException(ErrorCode.CARD_NOT_FOUND);
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleBusiness(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.CARD_NOT_FOUND.getStatus());
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.CARD_NOT_FOUND.getCode());
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.CARD_NOT_FOUND.getCode());
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.WARN);
+        assertThat(event.getThrowableProxy()).as("WARN은 stack trace 미포함").isNull();
+        assertThat(event.getFormattedMessage()).contains("business.exception");
+        assertThat(event.getFormattedMessage()).contains(ErrorCode.CARD_NOT_FOUND.getCode());
+    }
+
+    @Test
+    @DisplayName("MethodArgumentNotValidException은 INFO 레벨 + MDC INVALID_INPUT 주입")
+    void MethodArgumentNotValidException은_INFO_레벨_MDC_INVALID_INPUT() {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+        when(bindingResult.getAllErrors()).thenReturn(Collections.emptyList());
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleValidation(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getThrowableProxy()).isNull();
+        assertThat(event.getFormattedMessage()).contains("validation.failed");
+    }
+
+    @Test
+    @DisplayName("ConstraintViolationException은 INFO 레벨 + MDC INVALID_INPUT 주입")
+    void ConstraintViolationException은_INFO_레벨_MDC_INVALID_INPUT() {
+        ConstraintViolationException ex = new ConstraintViolationException("constraint failed", Collections.emptySet());
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleConstraintViolation(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getFormattedMessage()).contains("validation.constraint.violation");
+    }
+
+    @Test
+    @DisplayName("AuthenticationException은 INFO 레벨 + MDC UNAUTHORIZED 주입 (빈번한 정상 분기)")
+    void AuthenticationException은_INFO_레벨_MDC_UNAUTHORIZED() {
+        BadCredentialsException ex = new BadCredentialsException("invalid");
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleAuthentication(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.UNAUTHORIZED.getStatus());
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.UNAUTHORIZED.getCode());
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.UNAUTHORIZED.getCode());
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getFormattedMessage()).contains("authentication.failed");
+    }
+
+    @Test
+    @DisplayName("AccessDeniedException은 WARN 레벨 + MDC AUTH_FORBIDDEN (보안 추적 가치)")
+    void AccessDeniedException은_WARN_레벨_MDC_AUTH_FORBIDDEN() {
+        AccessDeniedException ex = new AccessDeniedException("forbidden");
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleAccessDenied(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.AUTH_FORBIDDEN.getStatus());
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.AUTH_FORBIDDEN.getCode());
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.AUTH_FORBIDDEN.getCode());
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.WARN);
+        assertThat(event.getFormattedMessage()).contains("access.denied");
+    }
+
+    @Test
+    @DisplayName("MaxUploadSizeExceededException은 INFO 레벨 + MDC PAYLOAD_TOO_LARGE")
+    void MaxUploadSizeExceededException은_INFO_레벨_MDC_PAYLOAD_TOO_LARGE() {
+        MaxUploadSizeExceededException ex = new MaxUploadSizeExceededException(10_000_000L);
+
+        ResponseEntity<Map<String, String>> response = handler.handleMaxSizeException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo("PAYLOAD_TOO_LARGE");
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getFormattedMessage()).contains("upload.size.exceeded");
+    }
+
+    @Test
+    @DisplayName("fallback Exception은 ERROR 레벨 + stack trace 포함 + MDC INTERNAL_ERROR")
+    void fallback_Exception은_ERROR_레벨_stack_포함_MDC_INTERNAL_ERROR() {
+        NullPointerException ex = new NullPointerException("boom");
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleUnknown(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody().getCode()).isEqualTo(GlobalExceptionHandler.INTERNAL_ERROR_CODE);
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(GlobalExceptionHandler.INTERNAL_ERROR_CODE);
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(event.getThrowableProxy())
+                .as("fallback은 stack trace 포함")
+                .isNotNull();
+        assertThat(event.getThrowableProxy().getClassName()).isEqualTo(NullPointerException.class.getName());
+        assertThat(event.getFormattedMessage()).contains("unexpected.exception");
+    }
+
+    @Test
+    @DisplayName("BusinessException의 ex.getMessage()는 응답 body의 message에 사용된다 (detail 보존)")
+    void BusinessException_message는_응답_body에_사용된다() {
+        BusinessException ex = BusinessException.withDetail(ErrorCode.CARD_NOT_FOUND, "id=42");
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleBusiness(ex, request);
+
+        assertThat(response.getBody().getMessage()).contains(ErrorCode.CARD_NOT_FOUND.getMessage());
+        assertThat(response.getBody().getMessage()).contains("id=42");
+    }
+
+    private ILoggingEvent singleEvent() {
+        assertThat(logAppender.list)
+                .as("핸들러 호출 후 로그 이벤트가 정확히 1건 캡처되어야 한다")
+                .hasSize(1);
+        return logAppender.list.get(0);
+    }
+}

--- a/src/test/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/thirdtool/Common/Exception/GlobalExceptionHandlerTest.java
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,12 +18,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -57,15 +61,15 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    @DisplayName("BusinessException은 WARN 레벨 + stack trace 미포함 + MDC errorCode 주입")
-    void BusinessException은_WARN_레벨_stack_미포함_MDC_errorCode_주입() {
+    @DisplayName("BusinessException은 WARN 레벨 + stack trace 미포함 + 응답에 ErrorCode 정적 메시지만 노출")
+    void BusinessException은_WARN_레벨_stack_미포함_응답에_ErrorCode_정적_메시지만_노출() {
         BusinessException ex = new BusinessException(ErrorCode.CARD_NOT_FOUND);
 
         ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleBusiness(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(ErrorCode.CARD_NOT_FOUND.getStatus());
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.CARD_NOT_FOUND.getCode());
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.CARD_NOT_FOUND.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.CARD_NOT_FOUND.getMessage());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.WARN);
@@ -75,67 +79,100 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    @DisplayName("MethodArgumentNotValidException은 INFO 레벨 + MDC INVALID_INPUT 주입")
-    void MethodArgumentNotValidException은_INFO_레벨_MDC_INVALID_INPUT() {
+    @DisplayName("BusinessException.withDetail의 detail은 로그에만 남고 응답에는 노출되지 않는다 (input reflection 차단)")
+    void BusinessException_detail은_로그에만_남고_응답에는_노출되지_않는다() {
+        String userInput = "id=42-or-sensitive-leak";
+        BusinessException ex = BusinessException.withDetail(ErrorCode.CARD_NOT_FOUND, userInput);
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleBusiness(ex, request);
+
+        assertThat(response.getBody().getMessage())
+                .as("응답 message는 ErrorCode 정적 메시지만")
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND.getMessage())
+                .doesNotContain(userInput);
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getFormattedMessage())
+                .as("로그에는 detail까지 포함된 ex.getMessage() 노출")
+                .contains(userInput);
+    }
+
+    @Test
+    @DisplayName("MethodArgumentNotValidException은 INFO 레벨 + 응답 INVALID_INPUT")
+    void MethodArgumentNotValidException은_INFO_레벨_응답_INVALID_INPUT() {
         MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
         BindingResult bindingResult = mock(BindingResult.class);
         when(ex.getBindingResult()).thenReturn(bindingResult);
-        when(bindingResult.getAllErrors()).thenReturn(Collections.emptyList());
+        when(bindingResult.getAllErrors())
+                .thenReturn(List.of(new ObjectError("dto", "violation1"), new ObjectError("dto", "violation2")));
 
         ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleValidation(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.INFO);
-        assertThat(event.getThrowableProxy()).isNull();
-        assertThat(event.getFormattedMessage()).contains("validation.failed");
+        assertThat(event.getFormattedMessage()).contains("validation.failed").contains("errors=2");
     }
 
     @Test
-    @DisplayName("ConstraintViolationException은 INFO 레벨 + MDC INVALID_INPUT 주입")
-    void ConstraintViolationException은_INFO_레벨_MDC_INVALID_INPUT() {
-        ConstraintViolationException ex = new ConstraintViolationException("constraint failed", Collections.emptySet());
+    @DisplayName("ConstraintViolationException은 INFO 레벨 + 다중 violations 크기 로그 포함")
+    void ConstraintViolationException은_INFO_레벨_다중_violations_크기_로그() {
+        Set<ConstraintViolation<?>> violations = new HashSet<>();
+        violations.add(mock(ConstraintViolation.class));
+        violations.add(mock(ConstraintViolation.class));
+        ConstraintViolationException ex = new ConstraintViolationException("constraint failed", violations);
 
         ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleConstraintViolation(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.INFO);
-        assertThat(event.getFormattedMessage()).contains("validation.constraint.violation");
+        assertThat(event.getFormattedMessage()).contains("violations=2");
     }
 
     @Test
-    @DisplayName("AuthenticationException은 INFO 레벨 + MDC UNAUTHORIZED 주입 (빈번한 정상 분기)")
-    void AuthenticationException은_INFO_레벨_MDC_UNAUTHORIZED() {
+    @DisplayName("AuthenticationException(BadCredentials)은 INFO 레벨 + 응답 UNAUTHORIZED")
+    void AuthenticationException_BadCredentials은_INFO_레벨() {
         BadCredentialsException ex = new BadCredentialsException("invalid");
 
         ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleAuthentication(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(ErrorCode.UNAUTHORIZED.getStatus());
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.UNAUTHORIZED.getCode());
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.UNAUTHORIZED.getCode());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.INFO);
         assertThat(event.getFormattedMessage()).contains("authentication.failed");
+        assertThat(event.getFormattedMessage()).contains("BadCredentialsException");
     }
 
     @Test
-    @DisplayName("AccessDeniedException은 WARN 레벨 + MDC AUTH_FORBIDDEN (보안 추적 가치)")
-    void AccessDeniedException은_WARN_레벨_MDC_AUTH_FORBIDDEN() {
+    @DisplayName("AuthenticationException 하위 타입(InsufficientAuthentication)도 동일 INFO 처리 + 타입명 로그")
+    void AuthenticationException_InsufficientAuthentication도_INFO_타입명_로그() {
+        InsufficientAuthenticationException ex = new InsufficientAuthenticationException("auth required");
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleAuthentication(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.UNAUTHORIZED.getStatus());
+
+        ILoggingEvent event = singleEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getFormattedMessage()).contains("InsufficientAuthenticationException");
+    }
+
+    @Test
+    @DisplayName("AccessDeniedException은 WARN 레벨 + 응답 AUTH_FORBIDDEN")
+    void AccessDeniedException은_WARN_레벨_응답_AUTH_FORBIDDEN() {
         AccessDeniedException ex = new AccessDeniedException("forbidden");
 
         ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleAccessDenied(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(ErrorCode.AUTH_FORBIDDEN.getStatus());
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.AUTH_FORBIDDEN.getCode());
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(ErrorCode.AUTH_FORBIDDEN.getCode());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.WARN);
@@ -143,14 +180,15 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    @DisplayName("MaxUploadSizeExceededException은 INFO 레벨 + MDC PAYLOAD_TOO_LARGE")
-    void MaxUploadSizeExceededException은_INFO_레벨_MDC_PAYLOAD_TOO_LARGE() {
+    @DisplayName("MaxUploadSizeExceededException은 INFO 레벨 + ErrorResponse 포맷으로 통일 + PAYLOAD_TOO_LARGE 응답")
+    void MaxUploadSizeExceededException은_INFO_레벨_ErrorResponse_포맷_PAYLOAD_TOO_LARGE() {
         MaxUploadSizeExceededException ex = new MaxUploadSizeExceededException(10_000_000L);
 
-        ResponseEntity<Map<String, String>> response = handler.handleMaxSizeException(ex);
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleMaxSizeException(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo("PAYLOAD_TOO_LARGE");
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.PAYLOAD_TOO_LARGE.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.PAYLOAD_TOO_LARGE.getMessage());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.INFO);
@@ -158,34 +196,36 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    @DisplayName("fallback Exception은 ERROR 레벨 + stack trace 포함 + MDC INTERNAL_ERROR")
-    void fallback_Exception은_ERROR_레벨_stack_포함_MDC_INTERNAL_ERROR() {
+    @DisplayName("fallback Exception은 ERROR 레벨 + stack trace 포함 + INTERNAL_ERROR 응답")
+    void fallback_Exception은_ERROR_레벨_stack_포함_INTERNAL_ERROR() {
         NullPointerException ex = new NullPointerException("boom");
 
         ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleUnknown(ex, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response.getBody().getCode()).isEqualTo(GlobalExceptionHandler.INTERNAL_ERROR_CODE);
-        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isEqualTo(GlobalExceptionHandler.INTERNAL_ERROR_CODE);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INTERNAL_ERROR.getCode());
 
         ILoggingEvent event = singleEvent();
         assertThat(event.getLevel()).isEqualTo(Level.ERROR);
-        assertThat(event.getThrowableProxy())
-                .as("fallback은 stack trace 포함")
-                .isNotNull();
+        assertThat(event.getThrowableProxy()).as("fallback은 stack trace 포함").isNotNull();
         assertThat(event.getThrowableProxy().getClassName()).isEqualTo(NullPointerException.class.getName());
         assertThat(event.getFormattedMessage()).contains("unexpected.exception");
     }
 
     @Test
-    @DisplayName("BusinessException의 ex.getMessage()는 응답 body의 message에 사용된다 (detail 보존)")
-    void BusinessException_message는_응답_body에_사용된다() {
-        BusinessException ex = BusinessException.withDetail(ErrorCode.CARD_NOT_FOUND, "id=42");
+    @DisplayName("모든 핸들러는 try-finally로 MDC.errorCode를 즉시 정리한다 (비-HTTP 경로 누수 차단)")
+    void 모든_핸들러는_try_finally로_MDC_errorCode를_즉시_정리한다() {
+        handler.handleBusiness(new BusinessException(ErrorCode.CARD_NOT_FOUND), request);
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isNull();
 
-        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleBusiness(ex, request);
+        handler.handleAccessDenied(new AccessDeniedException("x"), request);
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isNull();
 
-        assertThat(response.getBody().getMessage()).contains(ErrorCode.CARD_NOT_FOUND.getMessage());
-        assertThat(response.getBody().getMessage()).contains("id=42");
+        handler.handleAuthentication(new BadCredentialsException("x"), request);
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isNull();
+
+        handler.handleUnknown(new NullPointerException("x"), request);
+        assertThat(MDC.get(GlobalExceptionHandler.MDC_ERROR_CODE)).isNull();
     }
 
     private ILoggingEvent singleEvent() {

--- a/src/test/java/com/example/thirdtool/Common/logging/SensitiveDataLoggingTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/SensitiveDataLoggingTest.java
@@ -37,15 +37,23 @@ class SensitiveDataLoggingTest {
     }
 
     @Test
-    @DisplayName("UserEntity.toString은 password 해시를 노출하지 않는다 (@ToString 미사용 + @ToString.Exclude 안전망)")
-    void UserEntity_toString은_password_해시를_노출하지_않는다() {
-        UserEntity user = UserEntity.ofLocal("user@example.com", RAW_HASHED, "nickname", "user@example.com");
+    @DisplayName("UserEntity.toString은 password 해시·email·nickname을 노출하지 않고 id·username만 노출한다")
+    void UserEntity_toString은_민감_필드를_노출하지_않고_id_username만_노출한다() {
+        UserEntity user = UserEntity.ofLocal("user@example.com", RAW_HASHED, "nickname-secret", "private@example.com");
 
         String dumped = user.toString();
 
         assertThat(dumped)
-                .as("password BCrypt 해시가 toString 결과 어디에도 등장하지 않아야 한다")
+                .as("Lombok @ToString(onlyExplicitlyIncluded=true)가 동작해 'UserEntity('로 시작해야 한다 (회귀 차단)")
+                .startsWith("UserEntity(");
+        assertThat(dumped).contains("username=user@example.com");
+        assertThat(dumped)
+                .as("password BCrypt 해시가 어디에도 등장하지 않아야 한다")
                 .doesNotContain(RAW_HASHED);
+        assertThat(dumped)
+                .as("nickname·email은 명시 노출 대상 외라 등장하지 않아야 한다")
+                .doesNotContain("nickname-secret")
+                .doesNotContain("private@example.com");
     }
 
     @Test

--- a/src/test/java/com/example/thirdtool/Common/logging/SensitiveDataLoggingTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/SensitiveDataLoggingTest.java
@@ -1,0 +1,62 @@
+package com.example.thirdtool.Common.logging;
+
+import com.example.thirdtool.Common.security.auth.RefreshEntity;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.User.dto.LoginRequestDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story 3-1: 민감정보(비밀번호·refresh 토큰)가 toString 직렬화 경로 어디서도 노출되지
+ * 않도록 회귀 방지. 신규 민감 DTO/엔티티 추가 시 본 테스트에 케이스 추가가 PR 체크리스트.
+ *
+ * <p>{@code @ToString.Exclude} 자체는 Lombok SOURCE retention이라 리플렉션으로 검증할 수
+ * 없으므로 functional 검증(실제 toString 결과에 원문이 포함되지 않는다)으로 회귀를 잡는다.
+ */
+@DisplayName("민감정보 로깅 차단")
+class SensitiveDataLoggingTest {
+
+    private static final String RAW_PASSWORD = "mySecret123!verySensitive";
+    private static final String RAW_HASHED = "$2a$10$BCryptHashedPasswordHere1234567890";
+    private static final String RAW_REFRESH = "rt.eyJhbGciOiJIUzI1NiJ9.payload.signature-FULL-SECRET";
+
+    @Test
+    @DisplayName("LoginRequestDTO.toString은 password 원문을 절대 포함하지 않는다 (명시 오버라이드)")
+    void LoginRequestDTO_toString은_password_원문을_절대_포함하지_않는다() {
+        LoginRequestDTO dto = new LoginRequestDTO();
+        dto.setUsername("user@example.com");
+        dto.setPassword(RAW_PASSWORD);
+
+        String dumped = dto.toString();
+
+        assertThat(dumped).doesNotContain(RAW_PASSWORD);
+        assertThat(dumped).contains("password=***");
+        assertThat(dumped).contains("username=user@example.com");
+    }
+
+    @Test
+    @DisplayName("UserEntity.toString은 password 해시를 노출하지 않는다 (@ToString 미사용 + @ToString.Exclude 안전망)")
+    void UserEntity_toString은_password_해시를_노출하지_않는다() {
+        UserEntity user = UserEntity.ofLocal("user@example.com", RAW_HASHED, "nickname", "user@example.com");
+
+        String dumped = user.toString();
+
+        assertThat(dumped)
+                .as("password BCrypt 해시가 toString 결과 어디에도 등장하지 않아야 한다")
+                .doesNotContain(RAW_HASHED);
+    }
+
+    @Test
+    @DisplayName("RefreshEntity.toString은 refresh 토큰 원문을 노출하지 않는다")
+    void RefreshEntity_toString은_refresh_토큰을_노출하지_않는다() {
+        RefreshEntity entity = RefreshEntity.ofNew("user@example.com", RAW_REFRESH);
+
+        String dumped = entity.toString();
+
+        assertThat(dumped)
+                .as("RT 원문 문자열이 toString 결과 어디에도 등장하지 않아야 한다")
+                .doesNotContain(RAW_REFRESH);
+    }
+}

--- a/src/test/java/com/example/thirdtool/Common/logging/util/SensitiveLogMaskerTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/util/SensitiveLogMaskerTest.java
@@ -1,0 +1,51 @@
+package com.example.thirdtool.Common.logging.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SensitiveLogMasker")
+class SensitiveLogMaskerTest {
+
+    @Test
+    @DisplayName("null 입력은 'null' 리터럴로 반환한다 (NPE 방지 + 명시 표기)")
+    void null_입력은_null_리터럴로_반환한다() {
+        assertThat(SensitiveLogMasker.maskToken(null)).isEqualTo("null");
+    }
+
+    @Test
+    @DisplayName("빈 문자열은 'blank'로 반환한다")
+    void 빈_문자열은_blank로_반환한다() {
+        assertThat(SensitiveLogMasker.maskToken("")).isEqualTo("blank");
+    }
+
+    @Test
+    @DisplayName("공백만 있는 문자열은 'blank'로 반환한다")
+    void 공백만_있는_문자열은_blank로_반환한다() {
+        assertThat(SensitiveLogMasker.maskToken("   \t\n")).isEqualTo("blank");
+    }
+
+    @Test
+    @DisplayName("8자 이하 토큰은 전부 마스킹된다 (prefix 노출 금지)")
+    void 짧은_토큰은_전부_마스킹된다() {
+        assertThat(SensitiveLogMasker.maskToken("abcd")).isEqualTo("***");
+        assertThat(SensitiveLogMasker.maskToken("12345678")).isEqualTo("***");
+    }
+
+    @Test
+    @DisplayName("9자 이상 토큰은 prefix 8자 + '***'로 마스킹된다")
+    void 긴_토큰은_prefix_8자_뒤를_마스킹한다() {
+        String token = "eyJhbGciOiJIUzI1NiJ9.payload.signature";
+        assertThat(SensitiveLogMasker.maskToken(token)).isEqualTo("eyJhbGci***");
+    }
+
+    @Test
+    @DisplayName("마스킹 결과에 원문이 9자 이상에서도 일부만 노출돼 원문 복원 불가능하다")
+    void 마스킹_결과는_원문_복원이_불가능하다() {
+        String token = "very-long-secret-token-1234567890";
+        String masked = SensitiveLogMasker.maskToken(token);
+        assertThat(masked).doesNotContain("1234567890");
+        assertThat(masked).doesNotContain("secret-token");
+    }
+}


### PR DESCRIPTION
## 개요
GlobalExceptionHandler를 예외 유형별 ERROR/WARN/INFO 로그 레벨로 분리하고, MDC에 `errorCode` 키를 주입한다. 비밀번호·RT 토큰·OAuth 인가 코드가 toString·로그 직렬화 경로 어디서도 원문 노출되지 않도록 정비.

## 왜 / 설계 결정
Product 1 알림(v2) 채널이 ERROR 로그를 구독하므로 "ERROR == 사람이 봐야 할 5xx 신호"라는 불변식을 만든다. 모든 예외를 한 번에 ERROR로 묶으면 신호가 노이즈에 묻혀 알림이 무력화된다.

설계 결정:
- **레벨 매핑** (ADR011): Business→WARN(stack 미포함), Validation/Constraint/Authentication→INFO, AccessDenied→WARN(보안 추적), MaxUploadSize→INFO(이제 ErrorResponse 포맷), fallback Exception→ERROR+stack
- **`errorCode` MDC 키 신설** + logback-spring.xml 화이트리스트 5→6개 확장 → 수집기에서 errorCode별 집계·알림 룰 작성 가능 (ADR011)
- **try-finally + MDC.remove**: 비-HTTP 경로(@Scheduled·@Async·테스트)의 ThreadLocal 누수 차단. SuggestionFallbacks의 기존 패턴과 일관
- **응답 message는 ErrorCode 정적 메시지만**: BusinessException.withDetail의 detail은 로그에만, 응답 body에 input reflection 차단
- **JwtAuthenticationEntryPoint도 INFO + MDC 격상**: Spring Security 필터 단의 정상 인증 실패가 @RestControllerAdvice로 흐르지 않으므로 EntryPoint를 동일 정책에 합류
- **UserEntity `@ToString(onlyExplicitlyIncluded=true)` + 안전 필드만 노출**: password·email·nickname·소셜 연관 자동 제외. id·username만 명시
- **`SensitiveLogMasker.maskToken`**: prefix 8자 + "***" 표준 마스킹. KakaoOAuthClient의 authorizationCode·응답 본문 폭로 차단

기각 대안: `@Loggable` 커스텀 어노테이션 + 리플렉션 자동 마스킹(v2 — 어노테이션 누락 시 노출 위험 동일).

## 작업 내용
- feat(exception): GlobalExceptionHandler 6개 핸들러 명시 분기 + try-finally MDC.remove(errorCode) + errorResponse 빌더 단일화 + 응답 message에 detail 미노출
- feat(security): JwtAuthenticationEntryPoint DEBUG→INFO + MDC.put(errorCode) + finally remove
- feat(errorcode): ErrorCode enum에 PAYLOAD_TOO_LARGE(FILE005), INTERNAL_ERROR(C500) 등록
- feat(logging): logback-spring.xml MDC 화이트리스트에 errorCode 추가 (5→6 키)
- feat(logging): SensitiveLogMasker 신규(prefix 8자 + ***) + KakaoOAuthClient 마스킹 적용
- feat(user): LoginRequestDTO.toString 명시 오버라이드(password=***) + UserEntity 클래스 레벨 @ToString(onlyExplicitlyIncluded=true) + id·username만 @ToString.Include + RefreshEntity.refresh @ToString.Exclude
- test(exception): GlobalExceptionHandlerTest 11건 — 6개 핸들러 레벨·MDC·응답 검증 + detail 응답 비노출 + 다중 violations + AuthenticationException 하위 타입 + finally 정리 통합 검증
- test(logging): SensitiveDataLoggingTest 3건 + SensitiveLogMaskerTest 6건
- docs(adr): ADR011 신설 + index 갱신

## 변경 유형
- [x] feat  - [ ] fix  - [ ] refactor  - [x] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.Common.Exception.GlobalExceptionHandlerTest"` → BUILD SUCCESSFUL (11/11)
- `./gradlew test --tests "com.example.thirdtool.Common.logging.*"` → BUILD SUCCESSFUL (단위+슬라이스 회귀 포함)
- `./gradlew test --tests "com.example.thirdtool.Common.security.filter.*"` → BUILD SUCCESSFUL (BlockListFilter·JWTFilter 회귀)
- 회귀: `LogbackJsonFormatTest` 8건, `MdcLoggingFilterTest` 19건, `MdcLoggingFilterConcurrencyTest` 3건 모두 정상

## Reviewer 5관점 결과
머지 전 Domain·Architecture·API·Test·Sceptical 5관점 1회 수행. Critical 4건 + Major 4건은 본 PR에서 보강 commit(`16da9e3`)으로 반영. 미반영 후속 사항:
- **MdcKeys 통합 클래스 신설** — 현재 MDC 키 상수가 3개 파일(GlobalExceptionHandler, MdcLoggingFilter, JwtAuthenticationEntryPoint, SuggestionFallbacks)에 분산. 별도 정비 Story로 위임.
- **@WebMvcTest/@SpringBootTest 통합 검증** — SecurityFilterChain + DispatcherServlet + GlobalExceptionHandler + MdcLoggingFilter 전 경로의 errorCode JSON 출력 회귀 안전망. 별도 Slice/통합 테스트 Story.
- **TestController @Profile("!prod") 적용** — Authentication 객체 INFO 로깅 위험. 별도 정비 Story.
- **ArchUnit으로 MDC 키 사용 정적 분석** — 화이트리스트 외 키 put 차단. v2 도입 결정 시.

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — 본 PR은 ErrorResponse(에러 응답 형식)만 사용. 정상 응답 래퍼 미해당
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — ADR011 신설 + index 갱신. UserEntity의 @ToString는 도메인 의도 변경 아님(DOMAIN.md 트리거 X)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — User → Common/logging/util 의존은 PACKAGE.md "BC → Common ✅" 정합
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈
- Product: `workflow/product/pes/ready/product-log.md` (Product 0-a 로깅)
- Epic: Epic 3 — 에러 로깅 표준화
- Story: Story 3-1 — GlobalExceptionHandler 예외 유형별 로그 레벨 분리 + 민감정보 차단
- 마일스톤: `workflow/product/milestones/version/0.0.1v/milestone.md` Tier 1 #3
- 관련 ADR: [ADR011](docs/adr/ADR011.md) — MDC 화이트리스트에 errorCode 추가, [ADR008](docs/adr/ADR008.md) — 로깅 인프라