### PR TITLE
feat(metrics): Actuator + Micrometer Prometheus endpoint + actuator URI 카디널리티 차단 [Story-041]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Prometheus scrape endpoint (Story 4-1, 0-b 메트릭 Epic 1)
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'

--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -170,9 +170,13 @@ public LearningFacadeResponse.UpdateAxisName updateAxisName(
 - `config/` — MvcConfig, QuerydslConfig, S3Config, SecurityConfig, SwaggerConfig, WebClientConfig
 - `Exception/` — `BusinessException`, `GlobalExceptionHandler`, `ErrorCode/ErrorCode`(Enum, 전 BC 에러 코드 등록처)
 - `init/` — 초기 데이터 로딩
-- `security/` — `auth/jwt/{JwtController, JwtService, RefreshEntity, RefreshRepository}`, `filter/JWTFilter`
+- `logging/` — `filter/MdcLoggingFilter` (Story 2-1), `util/SensitiveLogMasker` (Story 3-1)
+- `observability/` — `config/ActuatorMetricsConfig` (Story 4-1, Prometheus 공통 태그·histogram·actuator URI deny)
+- `security/` — `auth/jwt/{JwtController, JwtService, RefreshEntity, RefreshRepository}`, `filter/JWTFilter`, `filter/BlockListFilter`
 - `Util/` — `JWTUtil`, `UUIDUtil`, `mapper/`
 - `BaseEntity` — JPA Auditing 공통
+
+**logging vs observability 책임 분리**: 양쪽 모두 관찰성 인프라지만, `logging/`은 이벤트 시계열(요청·예외 라인), `observability/`는 수치 메트릭(응답시간·처리량 시리즈). 분산 트레이싱·APM 도입 시 `observability/tracing/` 등 추가 예정.
 
 ### infra (BC 아님)
 - `S3/S3StorageAdapter` — AWS S3 어댑터

--- a/docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md
+++ b/docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md
@@ -64,6 +64,23 @@ curl -i localhost:8080/actuator/heapdump
 
 회귀 안전망은 `src/test/java/com/example/thirdtool/Common/observability/ActuatorMetricsIntegrationTest`가 동등 케이스 6건으로 보장.
 
+## 운영 책임 — LB·CloudFront 경로 차단
+
+`/actuator/prometheus`는 SecurityConfig가 익명 호출을 허용한다 (Prometheus scraper가 인증 없이 10초 간격 호출하는 운영 패턴). 따라서 **인프라 단(ALB/CloudFront/Nginx)에서 `/actuator/**` 경로를 내부 VPC·관리자 네트워크에만 허용**해야 외부 노출이 차단된다.
+
+- 메트릭 본문은 application URI 구조·JVM 정보·DB connection pool 통계 등 공격 표면에 도움이 되는 정보를 포함한다.
+- 본 PR의 `SecurityConfig` `denyAll`은 `/actuator/env`·`heapdump` 같은 민감 endpoint만 차단하고, `prometheus`·`health`·`info`는 통과시킨다. LB가 별도 차단하지 않으면 외부에서 메트릭이 직접 보인다.
+- 후속 ADR/Story 후보: Bearer token 기반 `/actuator/prometheus` 인증(scraper Bearer 발급 + Prometheus scrape config), 또는 별도 management port 분리 (`management.server.port: 8081`).
+
+## 메트릭 카디널리티 — actuator 자기 누적 차단
+
+`ActuatorMetricsConfig.denyActuatorHttpServerRequests` MeterFilter가 `http.server.requests{uri=~"/actuator/.*"}` 시리즈를 거부한다. 이유:
+
+- 10초 간격 scrape가 자체 시계열로 누적되면 그라파나 패널이 actuator scrape 트래픽으로 가득 차고 진짜 사용자 요청 시그널이 묻힌다.
+- `MdcLoggingFilter`의 SKIP은 로그만 차단 — 메트릭은 Micrometer가 자체 수집하므로 별도 MeterFilter가 필요.
+
+회귀 검증: `ActuatorMetricsIntegrationTest.actuator_경로의_http_server_requests_메트릭은_시리즈에_포함되지_않는다`.
+
 ## 관련
 
 - Story 4-1 (Product 0-b 메트릭 Epic 1) — Prometheus scrape endpoint 첫 노출

--- a/docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md
+++ b/docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md
@@ -1,0 +1,72 @@
+# ts001: Story 4-1 후 `application.yml`에 actuator 설정을 사용자가 직접 갱신해야 한다
+
+## 상황
+
+Story 4-1로 `io.micrometer:micrometer-registry-prometheus` 의존성을 추가하고 `ActuatorMetricsConfig`로 공통 태그·histogram을 Java 설정으로 적용했지만, **endpoint 노출 자체는 Spring Boot가 부트스트랩에서 properties로 읽기 때문에 Java 설정으로 대체할 수 없다**. `application.yml`은 `.gitignore` 대상이라 본 PR에서 commit되지 않으므로 사용자 환경에서 직접 갱신해야 dev/prod에서 `/actuator/prometheus`가 노출된다.
+
+## 증상
+
+- 본 PR 머지 후 `./gradlew bootRun` 또는 배포 환경에서 `curl localhost:8080/actuator/prometheus` → **404 Not Found**
+- `curl localhost:8080/actuator` → endpoint 목록에 `prometheus` 부재
+- 로그에 `PrometheusMeterRegistry` 빈은 등록되어 있으나 endpoint가 노출되지 않음
+
+## 원인
+
+- `application.yml`의 기본값이 `management.endpoints.web.exposure.include: []` (빈 배열)
+- Spring Boot 3.5에서 PrometheusMeterRegistry 자동 등록 자체는 `micrometer-registry-prometheus` classpath만으로 작동하지만, 다음 두 properties가 명시되어야 endpoint가 노출·activation된다:
+  - `management.endpoints.web.exposure.include` — endpoint 노출 화이트리스트
+  - `management.prometheus.metrics.export.enabled` — Prometheus registry export 활성화 (Spring Boot 3.5에서 명시 권장 — 통합 테스트에서 이를 누락하면 빈이 등록되지 않는 사례 확인)
+
+## 해결 — `application.yml` 갱신
+
+`application.yml` 공통 섹션의 `management` 블록을 다음으로 교체한다.
+
+```yaml
+# Actuator / Micrometer Prometheus (Story 4-1)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info
+        # env/beans/heapdump/threaddump 등은 환경변수·메모리·구조 정보를 노출하므로 명시 차단 (defense in depth)
+        exclude: env, beans, heapdump, threaddump, configprops, mappings
+  endpoint:
+    prometheus:
+      enabled: true
+    health:
+      show-details: when-authorized
+      cache:
+        time-to-live: 30s
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+```
+
+`SecurityConfig`는 본 PR로 `/actuator/prometheus`·`/health`·`/info`를 익명 허용하고 그 외 `/actuator/**`는 `denyAll`로 명시 차단하므로 위 yaml 외 추가 작업 불요.
+
+## 검증
+
+```bash
+# 1. 200 OK + http_server_requests_seconds_count 라인 확인
+curl -s localhost:8080/actuator/prometheus | head -20
+
+# 2. application=thirdtool 공통 태그 확인 (Java 설정에서 부착)
+curl -s localhost:8080/actuator/prometheus | grep 'application="thirdtool"' | head -3
+
+# 3. histogram bucket 확인 (P95/P99 계산 기반)
+curl -s localhost:8080/actuator/prometheus | grep http_server_requests_seconds_bucket | head -3
+
+# 4. 민감 endpoint 차단 확인 (404 또는 401/403)
+curl -i localhost:8080/actuator/env
+curl -i localhost:8080/actuator/heapdump
+```
+
+회귀 안전망은 `src/test/java/com/example/thirdtool/Common/observability/ActuatorMetricsIntegrationTest`가 동등 케이스 6건으로 보장.
+
+## 관련
+
+- Story 4-1 (Product 0-b 메트릭 Epic 1) — Prometheus scrape endpoint 첫 노출
+- Story 2-1 (`MdcLoggingFilter`) — `/actuator/**` 경로는 필터 자체 스킵으로 10초 scrape 노이즈 차단
+- Story 3-1 (`GlobalExceptionHandler`) — endpoint 실패 시 ERROR + INTERNAL_ERROR(C500) 응답으로 fallback. PrometheusMeterRegistry 빈 누락 시 500 응답으로 catch됨
+- `docs/adr/ADR008.md` — 로깅 인프라 (logback-spring.xml은 commit되지만 application.yml은 `.gitignore` 대상이라는 패턴은 본 케이스에도 동일)

--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -189,8 +189,10 @@ public class SecurityConfig {
 
         // ==============================
         // 6️⃣ MDC 로깅 필터 (Story 2-1) — 최선단에서 requestId 부여 + 응답 헤더 echo + MDC clear
+        //    anchor는 Spring Security 등록 표준 필터(UsernamePasswordAuthenticationFilter)로 통일.
+        //    같은 anchor의 addFilterBefore는 등록 순서대로 정렬되므로 본 줄이 가장 먼저 실행됨.
         // ==============================
-        http.addFilterBefore(new MdcLoggingFilter(), BlockListFilter.class);
+        http.addFilterBefore(new MdcLoggingFilter(), UsernamePasswordAuthenticationFilter.class);
 
         // ==============================
         // 7️⃣ 악성 URL 차단 필터 (Story 3-3) — JWTFilter 앞단에서 즉시 404

--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -53,7 +53,9 @@ public class SecurityConfig {
             "/api/auth/refresh",
             "/social/login/**",
             "/oauth2/**",
-            "/actuator/health"// ✅ 카카오/네이버 로그인 엔드포인트도 화이트리스트에 추가
+            "/actuator/health",
+            "/actuator/info",
+            "/actuator/prometheus"// ✅ 카카오/네이버 로그인 엔드포인트도 화이트리스트에 추가 + 모니터링 스크랩(Story 4-1)
     };
 
     private final UserRepository userRepository;
@@ -158,6 +160,9 @@ public class SecurityConfig {
                                         "/swagger-config",          // ✅ swagger-ui가 자동으로 호출하는 경로
                                         "/swagger-ui/swagger-config"
                                                 ).permitAll()
+
+                                // ✅ 모니터링 — 익명 허용 외 actuator 경로는 명시 차단 (defense in depth, Story 4-1)
+                                .requestMatchers("/actuator/**").denyAll()
 
                                 // ✅ 회원가입/중복확인 API
                                 .requestMatchers(HttpMethod.POST, "/user", "/user/exist").permitAll()

--- a/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
@@ -43,8 +43,8 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     static final String MDC_PATH = "path";
     static final int MAX_LEN = 64;
 
-    private static final String ACTUATOR_PREFIX = "/actuator";
-    private static final Set<String> SKIP_EXACT_PATHS = Set.of("/health");
+    private static final String ACTUATOR_PREFIX = "/actuator/";
+    private static final Set<String> SKIP_EXACT_PATHS = Set.of("/health", "/actuator");
 
     /**
      * 노이즈 차단을 위해 actuator 경로 전체와 비-actuator health probe를 스킵.

--- a/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilter.java
@@ -43,11 +43,18 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     static final String MDC_PATH = "path";
     static final int MAX_LEN = 64;
 
-    private static final Set<String> SKIP_PATHS = Set.of("/actuator/health", "/health");
+    private static final String ACTUATOR_PREFIX = "/actuator";
+    private static final Set<String> SKIP_EXACT_PATHS = Set.of("/health");
 
+    /**
+     * 노이즈 차단을 위해 actuator 경로 전체와 비-actuator health probe를 스킵.
+     * Story 4-1로 {@code /actuator/prometheus}가 10초 간격 스크랩되면 request.start/end가
+     * 그만큼 출력되므로 prefix 매칭으로 한 번에 차단.
+     */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return SKIP_PATHS.contains(request.getRequestURI());
+        String uri = request.getRequestURI();
+        return uri.startsWith(ACTUATOR_PREFIX) || SKIP_EXACT_PATHS.contains(uri);
     }
 
     /**

--- a/src/main/java/com/example/thirdtool/Common/observability/config/ActuatorMetricsConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/observability/config/ActuatorMetricsConfig.java
@@ -1,0 +1,66 @@
+package com.example.thirdtool.Common.observability.config;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Actuator/Micrometer 공통 메트릭 구성 (Story 4-1, 0-b 메트릭 Epic 1).
+ *
+ * <p>application.yml은 .gitignore 대상이라 운영 환경별 갱신을 보장할 수 없다. 본 Java 설정은
+ * 환경 무관하게 빌드 산출물에 포함되어 다음 두 책임을 단일 진실 소스로 처리한다.
+ * <ul>
+ *   <li>모든 메트릭에 {@code application=thirdtool} 공통 태그 부착 — 다중 서비스 환경에서 구분</li>
+ *   <li>{@code http.server.requests} 메트릭에 histogram bucket + P50·P95·P99 등록 —
+ *       Prometheus {@code histogram_quantile()}로 P95/P99 패널 계산 가능</li>
+ * </ul>
+ *
+ * <p>endpoint 노출(`management.endpoints.web.exposure.include` 등)은 Spring Boot가 부트스트랩 단에서
+ * properties로 읽으므로 Java 설정으로 대체 불가. 사용자 환경의 application.yml에서 명시한다 (가이드:
+ * {@code docs/operations/troubleshooting/}).
+ */
+@Configuration
+public class ActuatorMetricsConfig {
+
+    static final String APPLICATION_TAG_KEY = "application";
+    static final String APPLICATION_TAG_VALUE = "thirdtool";
+    static final String HTTP_SERVER_REQUESTS = "http.server.requests";
+
+    /**
+     * 모든 Meter에 {@code application=thirdtool} 태그를 공통 부착한다.
+     * 향후 멀티 인스턴스/멀티 서비스 배포 시 수집기에서 서비스 식별의 1차 키.
+     */
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> applicationCommonTag() {
+        return registry -> registry.config().commonTags(APPLICATION_TAG_KEY, APPLICATION_TAG_VALUE);
+    }
+
+    /**
+     * {@code http.server.requests} 시리즈에 percentile histogram bucket을 활성화하고
+     * P50/P95/P99 정량 분포를 등록한다. application.yml의 동등 설정:
+     * <pre>
+     * management.metrics.distribution.percentiles-histogram.http.server.requests: true
+     * management.metrics.distribution.percentiles.http.server.requests: 0.5, 0.95, 0.99
+     * </pre>
+     */
+    @Bean
+    public MeterFilter httpServerRequestsDistribution() {
+        return new MeterFilter() {
+            @Override
+            public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+                if (id.getName().startsWith(HTTP_SERVER_REQUESTS)) {
+                    return DistributionStatisticConfig.builder()
+                            .percentilesHistogram(true)
+                            .percentiles(0.5, 0.95, 0.99)
+                            .build()
+                            .merge(config);
+                }
+                return config;
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/thirdtool/Common/observability/config/ActuatorMetricsConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/observability/config/ActuatorMetricsConfig.java
@@ -29,14 +29,33 @@ public class ActuatorMetricsConfig {
     static final String APPLICATION_TAG_KEY = "application";
     static final String APPLICATION_TAG_VALUE = "thirdtool";
     static final String HTTP_SERVER_REQUESTS = "http.server.requests";
+    static final String URI_TAG = "uri";
+    static final String ACTUATOR_URI_PREFIX = "/actuator";
 
     /**
-     * 모든 Meter에 {@code application=thirdtool} 태그를 공통 부착한다.
-     * 향후 멀티 인스턴스/멀티 서비스 배포 시 수집기에서 서비스 식별의 1차 키.
+     * 모든 Meter에 {@code application=thirdtool} 공통 태그 + {@code /actuator/**} URI의
+     * {@code http.server.requests} 메트릭 deny를 등록한다.
+     *
+     * <p>actuator deny 사유: 10초 간격 Prometheus scrape가 자체 시계열을 누적하면 카디널리티
+     * 노이즈만 증가하고 관측 가치는 없다. {@code MdcLoggingFilter} SKIP은 로그만 차단하므로
+     * 메트릭 측 차단은 본 MeterFilter가 책임.
+     *
+     * <p>{@link MeterFilter} 빈 자동 감지 패턴 대신 {@link MeterRegistryCustomizer} 안에서
+     * 명시 등록하는 이유: Spring Boot 3.5 + Prometheus registry 조합에서 MeterFilter 빈이
+     * PrometheusMeterRegistry까지 일관 적용되지 않는 케이스가 발견됨 (통합 테스트에서 catch).
      */
     @Bean
     public MeterRegistryCustomizer<MeterRegistry> applicationCommonTag() {
-        return registry -> registry.config().commonTags(APPLICATION_TAG_KEY, APPLICATION_TAG_VALUE);
+        return registry -> {
+            registry.config().commonTags(APPLICATION_TAG_KEY, APPLICATION_TAG_VALUE);
+            registry.config().meterFilter(MeterFilter.deny(id -> {
+                if (!id.getName().startsWith(HTTP_SERVER_REQUESTS)) {
+                    return false;
+                }
+                String uri = id.getTag(URI_TAG);
+                return uri != null && uri.startsWith(ACTUATOR_URI_PREFIX);
+            }));
+        };
     }
 
     /**
@@ -63,4 +82,5 @@ public class ActuatorMetricsConfig {
             }
         };
     }
+
 }

--- a/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterTest.java
+++ b/src/test/java/com/example/thirdtool/Common/logging/filter/MdcLoggingFilterTest.java
@@ -246,6 +246,30 @@ class MdcLoggingFilterTest {
     }
 
     @Test
+    @DisplayName("/actuator/prometheus 경로도 필터가 스킵된다 (Story 4-1 prefix 매칭 확장 회귀)")
+    void actuator_prometheus_경로도_필터가_스킵된다() throws Exception {
+        request.setRequestURI("/actuator/prometheus");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isNull();
+        assertThat(logAppender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("/actuator-자체-아닌-prefix는 스킵되지 않는다 (false positive 차단)")
+    void 유사한_prefix_경로는_스킵되지_않는다() throws Exception {
+        // /actuators (s 포함) 또는 /actuator-metrics 같은 false positive 패턴은 스킵 X
+        request.setRequestURI("/actuator-metrics");
+
+        filter.doFilter(request, response, chain);
+
+        // 정상 필터 동작 — 응답 헤더 + 로그 출력
+        assertThat(response.getHeader(MdcLoggingFilter.HEADER)).isNotBlank();
+        assertThat(logAppender.list).isNotEmpty();
+    }
+
+    @Test
     @DisplayName("chain doFilter에서 예외가 throw되어도 MDC가 clear된다")
     void chain_doFilter에서_예외가_throw되어도_MDC가_clear된다() throws Exception {
         doThrow(new ServletException("boom")).when(chain).doFilter(request, response);

--- a/src/test/java/com/example/thirdtool/Common/observability/ActuatorMetricsIntegrationTest.java
+++ b/src/test/java/com/example/thirdtool/Common/observability/ActuatorMetricsIntegrationTest.java
@@ -114,4 +114,25 @@ class ActuatorMetricsIntegrationTest {
         assertThat(response.getStatusCode())
                 .isIn(HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN, HttpStatus.NOT_FOUND);
     }
+
+    @Test
+    @DisplayName("/actuator/** 경로의 http_server_requests 시리즈는 메트릭에 누적되지 않는다 (카디널리티 차단)")
+    void actuator_경로의_http_server_requests_메트릭은_시리즈에_포함되지_않는다() {
+        // 10초 scrape 모사 — 여러 번 호출해 자체 누적 발생 가능 상황을 만든다
+        for (int i = 0; i < 3; i++) {
+            scrapePrometheus();
+            restTemplate.getForEntity("/actuator/health", String.class);
+        }
+        restTemplate.getForEntity("/health", String.class);
+
+        ResponseEntity<String> response = scrapePrometheus();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String body = response.getBody();
+        // http_server_requests* (서버 inbound) 시리즈 한 줄 안에 uri="/actuator/..." 라벨이 동시 존재하지 않아야 한다.
+        // (http_client_requests는 TestRestTemplate outbound 시리즈로 별개. 본 PR의 deny 대상 아님)
+        assertThat(body)
+                .as("http_server_requests*{uri=\"/actuator/...\"} 시리즈가 deny되어 출력되지 않아야 한다")
+                .doesNotContainPattern("http_server_requests[a-z_]*\\{[^}]*uri=\"/actuator/[^\"]+\"");
+    }
 }

--- a/src/test/java/com/example/thirdtool/Common/observability/ActuatorMetricsIntegrationTest.java
+++ b/src/test/java/com/example/thirdtool/Common/observability/ActuatorMetricsIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.example.thirdtool.Common.observability;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * Story 4-1: Actuator Prometheus endpoint 노출·민감 endpoint 차단·메트릭 라벨·histogram bucket
+ * 회귀 안전망. SecurityConfig·ActuatorMetricsConfig·application-test.yml의 management 설정이
+ * 한 단위로 동작하는지 단일 SpringBootTest 컨텍스트에서 검증.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("Actuator Prometheus endpoint 통합")
+class ActuatorMetricsIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("/actuator/prometheus는 200 OK + application=thirdtool 공통 태그 + http_server_requests 시리즈 노출")
+    void prometheus_endpoint_노출_application_태그_http_server_requests_시리즈() {
+        // 메트릭 누적을 위해 임의 endpoint 호출 1회 (정상/오류 무관)
+        restTemplate.getForEntity("/health", String.class);
+
+        ResponseEntity<String> response = scrapePrometheus();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String body = response.getBody();
+        assertThat(body).isNotBlank();
+        assertThat(body)
+                .as("공통 태그 application=thirdtool")
+                .contains("application=\"thirdtool\"");
+        assertThat(body)
+                .as("http_server_requests 시리즈 (count·sum) 노출")
+                .contains("http_server_requests_seconds_count");
+    }
+
+    @Test
+    @DisplayName("/actuator/prometheus 응답에 http_server_requests_seconds_bucket(histogram)이 포함된다")
+    void prometheus_응답에_histogram_bucket이_포함된다() {
+        restTemplate.getForEntity("/health", String.class);
+        restTemplate.getForEntity("/actuator/health", String.class);
+
+        ResponseEntity<String> response = scrapePrometheus();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody())
+                .as("percentilesHistogram=true → histogram_quantile 계산 가능한 bucket 시리즈")
+                .contains("http_server_requests_seconds_bucket");
+    }
+
+    /**
+     * Prometheus scrape endpoint는 {@code text/plain; version=0.0.4} 또는 OpenMetrics 형식만 응답.
+     * TestRestTemplate 기본 Accept 헤더가 {@code text/plain, application/json, ...}이지만 OpenMetrics
+     * 협상 단계에서 NPE를 유발할 수 있어 실 운영의 Prometheus scraper 행태처럼 Accept를 명시한다.
+     */
+    private ResponseEntity<String> scrapePrometheus() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.parseMediaType("text/plain"), MediaType.ALL));
+        return restTemplate.exchange(
+                "/actuator/prometheus", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+    }
+
+    @Test
+    @DisplayName("/actuator/health는 익명 호출 200 OK + UP")
+    void actuator_health는_익명_호출_200_OK_UP() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/health", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @DisplayName("/actuator/info는 익명 호출 200 OK (화이트리스트 허용)")
+    void actuator_info는_익명_호출_200_OK() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/info", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("/actuator/env는 노출 제외 + denyAll로 차단되어 본문이 반환되지 않는다")
+    void actuator_env는_노출_제외_및_denyAll로_차단된다() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/env", String.class);
+
+        assertThat(response.getStatusCode())
+                .as("차단 status — 401(인증 요구) 또는 403(권한 거부) 또는 404(endpoint 미노출)")
+                .isIn(HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN, HttpStatus.NOT_FOUND);
+        assertThat(response.getBody() == null || !response.getBody().contains("DB_PASSWORD"))
+                .as("환경변수 본문이 응답에 노출되어선 안 된다")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("/actuator/heapdump도 노출 제외 + denyAll로 차단되어 메모리 덤프가 응답되지 않는다")
+    void actuator_heapdump는_노출_제외_및_denyAll로_차단된다() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/heapdump", String.class);
+
+        assertThat(response.getStatusCode())
+                .isIn(HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -59,3 +59,20 @@ naver:
 seed:
   s3-base-url: "http://localhost"
   image-count: 0
+
+# Actuator / Micrometer Prometheus (Story 4-1) — 통합 테스트에서 endpoint 노출 검증
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info
+        exclude: env, beans, heapdump, threaddump, configprops, mappings
+  endpoint:
+    prometheus:
+      enabled: true
+    health:
+      show-details: when-authorized
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 개요
`/actuator/prometheus` 노출을 위한 Micrometer 의존성·SecurityConfig·MdcLoggingFilter·Java config을 정비한다. `application=thirdtool` 공통 태그 + `http.server.requests` histogram(P50/P95/P99) + `/actuator/**` URI 카디널리티 차단까지 포함.

## 왜 / 설계 결정
- **`application.yml`은 `.gitignore` 대상** (ADR008 패턴 동일). endpoint 노출 properties(`management.endpoints.web.exposure.include` 등)는 사용자 환경 갱신 필수 → ts001로 가이드 정착. Java로 가능한 부분(태그·histogram·deny)은 `ActuatorMetricsConfig`로 commit
- **Spring Boot 3.5 + Prometheus registry 조합 특이점**: `management.prometheus.metrics.export.enabled: true` 명시가 필요한 케이스를 통합 테스트가 catch → ts001에 기록
- **`/actuator/**` URI 메트릭 deny**: 10초 scrape 자체 시계열 누적은 카디널리티 노이즈만 증가시키므로 `MeterRegistryCustomizer` 안에서 명시 deny 등록 (MeterFilter Bean 자동 적용은 Spring Boot 3.5 + Prometheus 조합에서 일관되지 않음)
- **MdcLoggingFilter prefix 매칭 정합**: `ACTUATOR_PREFIX = "/actuator/"` (trailing slash) + `/actuator` exact path로 `/actuator-metrics` 같은 false positive 차단
- **Story 2-1 회귀 fix 포함**: `MdcLoggingFilter`를 `addFilterBefore(BlockListFilter.class)`로 등록한 게 Spring Security가 사용자 정의 필터 anchor의 order를 모르므로 부팅 IllegalArgumentException 유발. 본 PR 통합 테스트가 첫 catch → 표준 anchor `UsernamePasswordAuthenticationFilter.class`로 통일

기각 대안: Bearer token 기반 `/actuator/prometheus` 인증, 별도 management port 분리 — Story 4-1 범위 외 운영 옵션.

## 작업 내용
- chore(deps): `io.micrometer:micrometer-registry-prometheus` 추가
- feat(observability): `Common/observability/config/ActuatorMetricsConfig` 신규 — MeterRegistryCustomizer로 공통 태그(application=thirdtool) + actuator URI deny + MeterFilter로 http.server.requests percentilesHistogram + P50/P95/P99
- feat(security): SecurityConfig 인가에 `/actuator/prometheus`·`/actuator/info`·`/actuator/health` permitAll + `/actuator/**` denyAll(defense in depth)
- fix(security): MdcLoggingFilter anchor를 UsernamePasswordAuthenticationFilter로 정정 (Story 2-1 회귀)
- feat(logging): MdcLoggingFilter SKIP_PATHS을 `/actuator/` prefix + `/actuator`·`/health` exact로 확장
- test(metrics): `ActuatorMetricsIntegrationTest` 7건 — Prometheus endpoint 노출/태그/histogram/health/info/env·heapdump 차단/actuator URI 메트릭 deny
- test(logging): MdcLoggingFilterTest 3건 추가 — actuator/prometheus 스킵·health·false positive(/actuator-metrics) 차단
- docs(operations): ts001 — application.yml 갱신 가이드 + LB/CloudFront 차단 운영 책임 + 카디널리티 차단 정책
- docs(package): Common 하위에 `logging/`·`observability/` 등재 + 책임 분리(이벤트 시계열 vs 수치 메트릭)

## 변경 유형
- [x] feat  - [x] fix  - [ ] refactor  - [x] docs  - [x] test  - [x] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.Common.observability.ActuatorMetricsIntegrationTest"` → BUILD SUCCESSFUL (7/7)
- `./gradlew test --tests "com.example.thirdtool.Common.logging.filter.*"` → BUILD SUCCESSFUL (단위 21건 + 동시성 3건)
- `./gradlew test --tests "com.example.thirdtool.Common.*"` → BUILD SUCCESSFUL (Common 전체 회귀)
- 회귀: GlobalExceptionHandlerTest 11건, MdcLoggingFilterTest 21건(prefix 매칭 확장 회귀 포함), SensitiveDataLoggingTest 3건, BlockListFilterTest 5건 모두 정상

## Reviewer 5관점 결과
머지 전 5관점 1회 수행 후 Critical·Major 5건은 본 PR에서 보강 commit(`a8f4920`)으로 반영. 미반영 후속:
- **AC 엣지 통합 테스트 3건** — path template uri 정규화(`/api/v1/cards/{id}`) / 존재 안 함 경로의 `uri="UNKNOWN"` 처리 / 5xx status 라벨 분리. 단위 단계에서 검증이 어려운 운영 회귀 안전망이라 별도 Slice/E2E Story로 위임
- **application.yml 미갱신 silent failure 헬스체크** — `ApplicationReadyEvent` 리스너로 PrometheusScrapeEndpoint 빈 + exposure include 검증 → 누락 시 WARN. ADR 후보로 별도 Story
- **`/actuator/info` 본문 검증** — 향후 `InfoContributor` 추가 시 익명 노출 위험. 도입 시점에 검증 추가
- **commit 메시지 `[Story-041]` 형식** — git.md `[Story-{NNN}-{N}]`과 다름. 최근 Story-021/031과 일관성은 유지되어 룰 자체 갱신 필요

## ⚠️ 머지 후 운영자 액션 필수
**application.yml은 `.gitignore`라 본 PR에 포함되지 않습니다**. 머지 후 dev/prod 환경에서 `/actuator/prometheus`를 노출하려면 `docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md`의 yaml 블록을 `application.yml`에 직접 갱신해야 합니다. 미갱신 시 404.

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (Actuator endpoint는 Spring Boot 표준 포맷)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — PACKAGE.md Common 섹션에 observability/·logging/ 등재. ADR 신규 트리거 없음(ts001로 충분)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 — Common 내부 변경만, BC 무영향
- [x] (stacked) 대상 브랜치 = `develop`

## 관련 이슈
- Product: `workflow/product/pes/ready/product-op.md` (Product 0-b 메트릭)
- Epic: Epic 1 — Actuator/Prometheus 메트릭 노출
- Story: Story 1-1 — Actuator + Micrometer Prometheus 엔드포인트 구성 · 민감 엔드포인트 차단
- 마일스톤: `workflow/product/milestones/version/0.0.1v/milestone.md` Tier 1 #4
- 관련 ADR: [ADR008](docs/adr/ADR008.md) — application.yml은 .gitignore, Java config 우선 패턴 동일