### PR TITLE
chore(yml): application-{dev,prod}.yml 분리 + local override 체계

### DIFF
--- a/docs/operations/troubleshooting/ts003-profile-split.md
+++ b/docs/operations/troubleshooting/ts003-profile-split.md
@@ -1,0 +1,104 @@
+# ts003: application-{dev,prod}.yml 분리 + local override 체계
+
+## 변경 요약
+
+기존 `application.yml` 한 파일에 multi-document(`---`)로 묶여 있던 dev/prod 섹션을 별도 파일로 분리. 로컬 개발자 편의 override는 별도 `local` profile.
+
+```
+application.yml          공통 — servlet/jwt 공통/swagger/actuator 기본
+application-dev.yml      dev — H2 + dev secrets(env vars) + jwt.cookie.secure=false
+application-prod.yml     prod — RDS MySQL + prod secrets(env vars) + jwt.cookie.secure=true + swagger 비활성화
+application-local.yml    local — H2 console + show-sql + format_sql + batch off (dev/prod와 조합 활성화)
+application-test.yml     test — 자체 H2 + dummy secrets + actuator (test 전용, 다른 profile과 독립)
+```
+
+## Spring Boot profile 합본 규칙
+
+`spring.profiles.active`에 콤마로 나열된 순서는 **나중 것이 우선**. 즉 `dev,local`이면 local이 마지막 → local의 override가 dev 위에 적용.
+
+| `SPRING_PROFILES_ACTIVE` | 의도 | 결과 |
+| --- | --- | --- |
+| `dev,local` | dev base + local override (권장 로컬) | H2 + dev secrets + local의 show-sql·h2-console 활성화 |
+| `prod,local` | prod base + local override | RDS/로컬 MySQL + prod secrets + local의 show-sql·h2-console 활성화 |
+| `dev` | dev 단독 (CI/dev 서버) | H2 + dev secrets, show-sql 없음 |
+| `prod` | prod 단독 (운영 서버) | RDS + prod secrets, show-sql 없음, swagger 비활성화 |
+| `test` (`@ActiveProfiles("test")`) | 테스트 컨텍스트 | 자체 H2 + dummy secrets — env vars 불요 |
+
+`application.yml` 기본 `active`: `${SPRING_PROFILES_ACTIVE:dev,local}`. 환경변수 미설정 시 로컬 친화 default 적용. CI/서버는 환경변수로 `dev` 또는 `prod` override.
+
+## 로컬 개발자 환경변수 설정
+
+### IntelliJ Run Configuration
+
+`Run/Debug Configurations` → `ThirdToolApplication`:
+- `Active profiles`: 비워둠 (application.yml default `dev,local` 사용) 또는 `dev,local` 명시
+- `Environment variables`:
+  ```
+  JWT_SECRET_KEY=any-32char-or-longer-secret-for-dev-local
+  KAKAO_CLIENT_ID=<카카오 콘솔에서 발급>
+  KAKAO_CLIENT_SECRET=<카카오 콘솔에서 발급>
+  NAVER_CLIENT_ID=<네이버 콘솔에서 발급>
+  NAVER_CLIENT_SECRET=<네이버 콘솔에서 발급>
+  AWS_ACCESS_KEY_ID=<S3 IAM 키>
+  AWS_SECRET_ACCESS_KEY=<S3 IAM 시크릿>
+  ```
+
+### CLI / Gradle bootRun
+
+```bash
+# bash/zsh — application.yml default(dev,local) 그대로 사용
+export JWT_SECRET_KEY=...
+export KAKAO_CLIENT_ID=...
+# ... (kakao, naver, AWS)
+./gradlew bootRun
+
+# PowerShell
+$env:JWT_SECRET_KEY = "..."
+$env:KAKAO_CLIENT_ID = "..."
+./gradlew bootRun
+
+# profile 명시 override (예: local 끄고 dev만)
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+```
+
+### local + prod 시뮬레이션
+
+로컬에서 prod profile 동작을 확인하려면 (예: HikariCP·Flyway·Hibernate validate 검증):
+
+```bash
+export SPRING_PROFILES_ACTIVE=prod,local
+export DB_HOST=localhost
+export DB_PORT=3306
+export DB_NAME=thirdtool_local
+export DB_USERNAME=root
+export DB_PASSWORD=...
+# kakao/naver/AWS prod 환경변수
+./gradlew bootRun
+```
+
+로컬 MySQL 실행 필요(`docker run -p 3306:3306 mysql:8`). `ddl-auto: validate`라 Flyway 마이그레이션이 먼저 실행되어야 스키마 검증 통과.
+
+## 검증
+
+```bash
+# 기본 (dev,local) — H2 + show-sql + console
+./gradlew bootRun
+# 로그: SQL 콘솔 출력. http://localhost:8080/h2-console 접속 가능
+
+# dev 단독 (CI 모사) — H2 + show-sql false
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+# 로그: SQL 출력 없음. h2-console 접근 불가
+
+# prod 활성화 — RDS(또는 로컬 MySQL) + Flyway
+SPRING_PROFILES_ACTIVE=prod ./gradlew bootRun
+```
+
+## test profile은 독립
+
+`@ActiveProfiles("test")`는 `application-test.yml`만 로드 (application.yml의 default `dev,local`은 적용 안 됨 — Spring Test가 ActiveProfiles로 override). test profile은 자체 H2 + dummy secrets + actuator 노출 설정을 포함해 환경변수 의존 없이 부팅.
+
+## 관련
+
+- 분리 트리거: 사용자 요청 — application.yml gitignore 해제 후 환경별 분리 + 로컬에서 dev/prod 시뮬레이션 둘 다 지원
+- 환경변수 가이드: [`ts002-environment-variables.md`](ts002-environment-variables.md)
+- 후속: AWS Secrets Manager 도입 시 환경변수 패턴이 SecretManager fetch로 전환 (Product 7)

--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -184,8 +184,10 @@ public class SecurityConfig {
 
         // ==============================
         // 6️⃣ MDC 로깅 필터 (Story 2-1) — 최선단에서 requestId 부여 + 응답 헤더 echo + MDC clear
+        //    anchor는 Spring Security 등록 표준 필터(UsernamePasswordAuthenticationFilter)로 통일.
+        //    같은 anchor의 addFilterBefore는 등록 순서대로 정렬되므로 본 줄이 가장 먼저 실행됨.
         // ==============================
-        http.addFilterBefore(new MdcLoggingFilter(), BlockListFilter.class);
+        http.addFilterBefore(new MdcLoggingFilter(), UsernamePasswordAuthenticationFilter.class);
 
         // ==============================
         // 7️⃣ 악성 URL 차단 필터 (Story 3-3) — JWTFilter 앞단에서 즉시 404

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,56 @@
+# ===========================================
+# dev 프로필 — 개발 환경 (CI · dev 서버 · 로컬 dev 기본)
+# - H2 인메모리 (Flyway 미사용, Hibernate DDL 자동)
+# - 환경변수 secret 필수 — 가이드: docs/operations/troubleshooting/ts002-environment-variables.md
+# - 로컬 개발자가 H2 console·show-sql 보고 싶으면 local profile을 함께 활성화 (SPRING_PROFILES_ACTIVE=local,dev)
+# ===========================================
+spring:
+  datasource:
+    url: jdbc:h2:mem:thirdtool;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop  # 앱 시작 시 테이블 생성, 종료 시 삭제
+    show-sql: false          # local profile에서 true로 override
+    properties:
+      hibernate:
+        format_sql: false
+        default_batch_fetch_size: 100
+
+  flyway:
+    enabled: false           # H2에서는 Flyway 미사용. DDL은 Hibernate가 담당
+
+# dev 프로파일 — HTTPS 없는 환경. Secure=false (Story 1-3)
+jwt:
+  cookie:
+    secure: false
+
+# 소셜 로그인 — dev FE 기준 (로컬 5173)
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: http://localhost:5173/oauth/kakao/callback
+
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+  redirect-uri: http://localhost:5173/oauth/naver/callback
+
+# AWS S3 — dev에서도 실제 S3 사용 (이미지 업로드 확인용)
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: third-tool-s3-server
+    region:
+      static: ap-northeast-2
+
+seed:
+  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
+  image-count: 10

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,36 +1,23 @@
 # ===========================================
-# local 프로필 — 로컬 개발자 환경 (평문 로그, H2 인메모리)
-# - secret-free: 소셜/AWS 등 자격이 필요한 항목은 application.yml(gitignore)에서 관리
-# - 활성화: spring.profiles.active=local (CLI --args 또는 application.yml의 active)
+# local 프로필 — 로컬 개발자 override (다른 profile과 조합 사용)
+# - 단독 사용 X — 항상 dev 또는 prod와 조합: SPRING_PROFILES_ACTIVE=local,dev
+# - dev/prod의 datasource·secret은 그쪽 yml이 책임. local은 개발 편의 override만.
 # - 로그 포맷은 logback-spring.xml의 <springProfile name="local">에서 평문으로 분기 (ADR008)
 # ===========================================
 spring:
-  datasource:
-    url: jdbc:h2:mem:thirdtool;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password: sa
-    driver-class-name: org.h2.Driver
-
   h2:
     console:
-      enabled: true
+      enabled: true          # http://localhost:8080/h2-console 에서 DB 확인 가능
       path: /h2-console
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
+    show-sql: true           # 로컬에선 SQL 콘솔 출력
     properties:
       hibernate:
-        format_sql: true
-        default_batch_fetch_size: 100
-
-  flyway:
-    enabled: false
+        format_sql: true     # 보기 좋게 포맷
 
 # Card 야간 만료 배치(Story 2-2)는 로컬에서 비활성화 — Spring `@Scheduled`는 cron="-"을 disabled로 해석.
-# 운영 환경(application.yml, gitignored)에서 cron 활성화한다.
+# 운영 환경(prod profile)에서 cron 활성화한다.
 card:
   expiry:
     cron: "-"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,72 @@
+# ===========================================
+# prod 프로필 — 운영 환경 (AWS RDS MySQL, HTTPS, Swagger 비활성화)
+# - 모든 secret은 환경변수 필수. default 없음 — Spring Boot가 placeholder 미해석 시 부팅 실패 (의도)
+# - SecretManager 마이그레이션 이후엔 Spring Cloud AWS가 환경변수 대신 fetch
+# - 로컬에서 prod 시뮬레이션: SPRING_PROFILES_ACTIVE=local,prod + 로컬 MySQL 또는 RDS 환경변수
+# ===========================================
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: validate          # 운영에서는 Flyway가 DDL 담당. Hibernate는 검증만
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        globally_quoted_identifiers: true
+        default_batch_fetch_size: 100
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+# prod 프로파일 — HTTPS 환경. Secure=true (Story 1-3)
+jwt:
+  cookie:
+    secure: true
+
+# Swagger — 운영에서는 비활성화
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
+# 소셜 로그인 — 운영 도메인 기준
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: https://thirdstool.com/oauth/kakao/callback
+
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+  redirect-uri: https://thirdstool.com/oauth/naver/callback
+
+# AWS S3
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: third-tool-s3-server
+    region:
+      static: ap-northeast-2
+
+seed:
+  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
+  image-count: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
-
 # ===========================================
 # 공통 설정 (모든 환경 적용)
+# - 환경별 datasource·secret은 application-{dev,prod}.yml로 분리
+# - 로컬 개발자 override(show-sql·h2 console)는 application-local.yml
+# - SPRING_PROFILES_ACTIVE 환경변수로 override 가능. 기본: local,dev (로컬 개발자 편의)
+# - CI/서버: SPRING_PROFILES_ACTIVE=dev / prod 명시
 # ===========================================
 spring:
   servlet:
@@ -13,27 +16,29 @@ spring:
     name: third-tool-backend
 
   profiles:
-    active: dev  # 기본 프로필: dev (H2 인메모리)
+    # 기본 default는 dev,local (로컬 개발자 친화 — H2 console·show-sql 자동 활성화).
+    # 콤마 순서: 나중 profile이 우선 → local의 override가 dev 위에 적용.
+    # CI/서버는 SPRING_PROFILES_ACTIVE=dev 또는 prod 명시. 가이드: ts003.
+    active: ${SPRING_PROFILES_ACTIVE:dev,local}
 
 # 로깅 설정은 logback-spring.xml로 일원화 (ADR008)
 
-# JWT 토큰 설정 (Story 1-1 외부화)
+# JWT 토큰 공통 (Story 1-1 외부화) — cookie.secure는 profile별 override
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-ttl: 30m   # Access Token TTL — 30분 (Product 1)
   refresh-token-ttl: 7d   # Refresh Token TTL — 7일 (Product 1)
 
-  # AT 쿠키 보안 속성 (Story 1-3 외부화)
-  # 공통 기본값. 프로파일별 override는 아래 dev/prod 블록에서.
   cookie:
     name: access_token
     path: /
     http-only: true
     same-site: Strict
-    # secure는 프로파일별 분기 — 공통은 안전한 default (true)
+    # secure는 application-{dev,prod}.yml에서 override (dev: false, prod: true)
     secure: true
 
-# Actuator
+# Actuator — endpoint 노출은 운영자가 환경별로 application-{dev,prod}.yml에서 갱신.
+# 기본은 미노출. Story 4-1 + ts001 참고.
 management:
   endpoints:
     web:
@@ -45,7 +50,7 @@ management:
       cache:
         time-to-live: 30s
 
-# Swagger / OpenAPI
+# Swagger / OpenAPI — prod profile에서 비활성화
 springdoc:
   api-docs:
     path: /custom-api-docs
@@ -62,142 +67,3 @@ springdoc:
     cache:
       disabled: true
     model-and-view-allowed: true
-
-# ===========================================
-# dev 프로필 — H2 인메모리 (로컬 개발·테스트)
-# ===========================================
----
-spring:
-  config:
-    activate:
-      on-profile: dev
-
-  datasource:
-    url: jdbc:h2:mem:thirdtool;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password: sa
-    driver-class-name: org.h2.Driver
-
-  h2:
-    console:
-      enabled: true          # http://localhost:8080/h2-console 에서 DB 확인 가능
-      path: /h2-console
-
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create-drop  # 앱 시작 시 테이블 생성, 종료 시 삭제
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        default_batch_fetch_size: 100
-
-  flyway:
-    enabled: false           # H2에서는 Flyway 미사용. DDL은 Hibernate가 담당
-
-# dev 프로파일 — HTTPS 없는 로컬 개발 환경. Secure=false 명시 (Story 1-3)
-jwt:
-  cookie:
-    secure: false
-
-# 소셜 로그인 — 로컬 FE 기준 (비밀은 환경변수로만 주입, SecretManager 도입 전 임시)
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: http://localhost:5173/oauth/kakao/callback
-
-naver:
-  client-id: ${NAVER_CLIENT_ID}
-  client-secret: ${NAVER_CLIENT_SECRET}
-  redirect-uri: http://localhost:5173/oauth/naver/callback
-
-# AWS S3 — 로컬에서도 실제 S3 사용 (이미지 업로드 확인용)
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY_ID}
-      secret-key: ${AWS_SECRET_ACCESS_KEY}
-    s3:
-      bucket: third-tool-s3-server
-    region:
-      static: ap-northeast-2
-
-seed:
-  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
-  image-count: 10
-
-# ===========================================
-# prod 프로필 — AWS RDS MySQL (운영)
-# ===========================================
----
-spring:
-  config:
-    activate:
-      on-profile: prod
-
-  datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
-      connection-timeout: 30000
-      idle-timeout: 600000
-      max-lifetime: 1800000
-
-  jpa:
-    database-platform: org.hibernate.dialect.MySQLDialect
-    hibernate:
-      ddl-auto: validate          # 운영에서는 Flyway가 DDL 담당. Hibernate는 검증만
-    show-sql: false
-    properties:
-      hibernate:
-        format_sql: false
-        globally_quoted_identifiers: true
-        default_batch_fetch_size: 100
-
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-    baseline-on-migrate: true
-
-# prod 프로파일 — HTTPS 환경. Secure=true 강제 (Story 1-3)
-jwt:
-  cookie:
-    secure: true
-
-# Swagger — 운영에서는 비활성화
-springdoc:
-  swagger-ui:
-    enabled: false
-  api-docs:
-    enabled: false
-
-# 소셜 로그인 — 운영 도메인 기준
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: https://thirdstool.com/oauth/kakao/callback
-
-naver:
-  client-id: ${NAVER_CLIENT_ID}
-  client-secret: ${NAVER_CLIENT_SECRET}
-  redirect-uri: https://thirdstool.com/oauth/naver/callback
-
-# AWS S3
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY_ID}
-      secret-key: ${AWS_SECRET_ACCESS_KEY}
-    s3:
-      bucket: third-tool-s3-server
-    region:
-      static: ap-northeast-2
-
-seed:
-  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
-  image-count: 10

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
@@ -29,7 +29,7 @@ class StaticSuggestionAdapterConditionalTest {
 
     @Nested
     @SpringBootTest(properties = "thirdtool.suggestion.provider=static")
-    @ActiveProfiles("dev")
+    @ActiveProfiles("test")
     @DisplayName("provider=static (또는 미설정 matchIfMissing)")
     class WhenStaticProvider {
 
@@ -54,7 +54,7 @@ class StaticSuggestionAdapterConditionalTest {
 
     @Nested
     @SpringBootTest(properties = "thirdtool.suggestion.provider=llm")
-    @ActiveProfiles("dev")
+    @ActiveProfiles("test")
     @DisplayName("provider=llm (비-static)")
     class WhenNonStaticProvider {
 

--- a/src/test/java/com/example/thirdtool/ThirdToolApplicationTests.java
+++ b/src/test/java/com/example/thirdtool/ThirdToolApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.thirdtool;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ThirdToolApplicationTests {
 
     @Test


### PR DESCRIPTION
## ⚠️ Stacked PR — base = `chore/expose-application-yml` (PR #169)
PR #169가 먼저 머지되어야 본 PR의 base가 develop이 됩니다. PR #169 머지 시 본 PR base 자동 변경.

## 개요
PR #169로 추적되기 시작한 `application.yml`을 **공통/dev/prod 파일로 분리**하고 **로컬 개발자 override는 별도 local profile**로 격리. 로컬에서 dev/prod 시뮬레이션 둘 다 지원.

## 왜 / 설계 결정
사용자 요청: "application-dev, application-prod 환경별 yml 분리 + local에서 dev/prod 분할까지 고려".

분리 구조:
```
application.yml          공통 (servlet/jwt 공통/swagger/actuator 기본)
application-dev.yml      dev (H2 + dev secrets env vars + cookie.secure=false)
application-prod.yml     prod (RDS + prod secrets env vars + cookie.secure=true + swagger off)
application-local.yml    local override만 (h2 console + show-sql + batch off)
application-test.yml     test 전용 (자체 H2 + dummy secrets)
```

핵심 결정:
- **local profile은 dev/prod와 조합 활성화** — 단독 사용 X. Spring Boot의 profile 합본 규칙(나중이 우선)을 활용해 `dev,local` / `prod,local` 형태로 사용
- **application.yml default `active=${SPRING_PROFILES_ACTIVE:dev,local}`** — 로컬 친화 default. CI/서버는 환경변수로 `dev`/`prod` override
- **prod profile은 모든 secret이 env vars 의존, default 없음** — 부팅 단계에서 누락 catch (의도된 실패)
- **test profile은 독립** — `@ActiveProfiles("test")`로 명시 활성화. 자체 H2 + dummy secrets라 환경변수 불요

## 작업 내용
- chore(yml): application.yml 분리 + application-{dev,prod,local}.yml 정비
- fix(test): `ThirdToolApplicationTests`에 `@ActiveProfiles("test")` 명시 + `StaticSuggestionAdapterConditionalTest`의 `@ActiveProfiles("dev")` → `("test")` 변경 (해당 테스트는 provider 프로퍼티 검증이라 profile 무관)
- fix(security): MdcLoggingFilter anchor를 `UsernamePasswordAuthenticationFilter`로 통일 (PR #168과 동일 변경, 머지 순서 무관)
- docs(operations): ts003 — profile 분리 가이드 + 합본 규칙 + 로컬 시나리오 + 검증 명령

## 변경 유형
- [ ] feat  - [x] fix  - [x] refactor  - [x] docs  - [x] test  - [x] chore

## 테스트
- `./gradlew test` → BUILD SUCCESSFUL (전체 회귀)
- 검증 시나리오:
  - `./gradlew bootRun` (default `dev,local`) — local override 적용 확인
  - `SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun` — local 끄고 dev 단독
  - test profile 격리 — `@ActiveProfiles("test")` 시 application-test.yml만 로드

## ⚠️ 머지 후 로컬 개발자 액션
환경변수 6종(`JWT_SECRET_KEY`, `KAKAO/NAVER/AWS_*`)은 여전히 필수. 가이드:
- `docs/operations/troubleshooting/ts002-environment-variables.md` — 환경변수 설정 방법
- `docs/operations/troubleshooting/ts003-profile-split.md` — profile 활성화 + 로컬에서 prod 시뮬레이션

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 — N/A (운영 가이드는 ts002·ts003)
- [x] BC 간 의존 방향 위반 없음
- [x] (stacked) 대상 브랜치 = `chore/expose-application-yml` (PR #169) — 머지 시 develop으로 자동 변경

## 관련 이슈
- 선행 PR: #169 chore(secrets) application.yml 추적 시작 + default 평문 secret 제거
- 후속: AWS Secrets Manager 도입 시 환경변수 → SecretManager fetch 전환 (Product 7)