### PR TITLE
feat(infra): Prometheus + Grafana docker-compose 모니터링 스택 [Story-042]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ out/
 .env.prod
 .env
 
+# 모니터링 스택 secrets (Story 2-1) — .example만 commit, 실제 비밀번호는 ignore
+monitoring/.env.monitoring
+
 ### ai workflow ###
 # 내부 문서 — GitHub 노출 차단 목적. Claude Code는 .gitignore 여부와 무관하게
 # working tree에 무조건 갱신한다 (개발자만 보는 자료).

--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -27,6 +27,29 @@ com.example.thirdtool
 └── RemindSearch/             # (빈 디렉토리, v2 — 검색 인프라는 운영 중)
 ```
 
+프로젝트 루트(`src/main/java/` 외)의 운영 인프라:
+
+```
+{프로젝트 루트}/
+├── src/main/java/com/example/thirdtool/   # 위 트리
+├── src/main/resources/
+│   ├── application.yml             # 공통 + profile별 active default
+│   ├── application-dev.yml         # H2 + dev secrets (env vars)
+│   ├── application-prod.yml        # RDS + prod secrets (env vars)
+│   ├── application-local.yml       # 로컬 개발자 override (h2 console, show-sql)
+│   └── logback-spring.xml          # ADR008 + ADR011 (MDC 6 키 화이트리스트)
+├── monitoring/                     # 로컬 모니터링 스택 (Story 2-1, 0-b Epic 2)
+│   ├── docker-compose.monitoring.yml   # Prometheus 2.54 + Grafana 11.2
+│   ├── prometheus/prometheus.yml       # 10s scrape, thirdtool job
+│   ├── grafana/provisioning/{datasources,dashboards}/*.yml
+│   ├── grafana/dashboards/*.json   # (Epic 3 Story 3-1에서 thirdtool.json 추가)
+│   └── .env.monitoring.example     # 실제 .env.monitoring은 .gitignore
+└── docs/                           # 의도·결정 기록 (코드만으론 알 수 없는 것)
+    ├── DOMAIN.md, PACKAGE.md, adr/
+    ├── operations/troubleshooting/ # ts001(actuator) · ts002(env vars) · ts003(profiles) · ts004(monitoring)
+    └── ...
+```
+
 신규 BC를 추가할 때는 §2의 4-레이어 구조를 그대로 따른다. 빈 BC 디렉토리는 의도 모호를 유발하므로 도입 시점에 생성한다.
 
 ---

--- a/docs/operations/troubleshooting/ts003-profile-split.md
+++ b/docs/operations/troubleshooting/ts003-profile-split.md
@@ -1,0 +1,104 @@
+# ts003: application-{dev,prod}.yml 분리 + local override 체계
+
+## 변경 요약
+
+기존 `application.yml` 한 파일에 multi-document(`---`)로 묶여 있던 dev/prod 섹션을 별도 파일로 분리. 로컬 개발자 편의 override는 별도 `local` profile.
+
+```
+application.yml          공통 — servlet/jwt 공통/swagger/actuator 기본
+application-dev.yml      dev — H2 + dev secrets(env vars) + jwt.cookie.secure=false
+application-prod.yml     prod — RDS MySQL + prod secrets(env vars) + jwt.cookie.secure=true + swagger 비활성화
+application-local.yml    local — H2 console + show-sql + format_sql + batch off (dev/prod와 조합 활성화)
+application-test.yml     test — 자체 H2 + dummy secrets + actuator (test 전용, 다른 profile과 독립)
+```
+
+## Spring Boot profile 합본 규칙
+
+`spring.profiles.active`에 콤마로 나열된 순서는 **나중 것이 우선**. 즉 `dev,local`이면 local이 마지막 → local의 override가 dev 위에 적용.
+
+| `SPRING_PROFILES_ACTIVE` | 의도 | 결과 |
+| --- | --- | --- |
+| `dev,local` | dev base + local override (권장 로컬) | H2 + dev secrets + local의 show-sql·h2-console 활성화 |
+| `prod,local` | prod base + local override | RDS/로컬 MySQL + prod secrets + local의 show-sql·h2-console 활성화 |
+| `dev` | dev 단독 (CI/dev 서버) | H2 + dev secrets, show-sql 없음 |
+| `prod` | prod 단독 (운영 서버) | RDS + prod secrets, show-sql 없음, swagger 비활성화 |
+| `test` (`@ActiveProfiles("test")`) | 테스트 컨텍스트 | 자체 H2 + dummy secrets — env vars 불요 |
+
+`application.yml` 기본 `active`: `${SPRING_PROFILES_ACTIVE:dev,local}`. 환경변수 미설정 시 로컬 친화 default 적용. CI/서버는 환경변수로 `dev` 또는 `prod` override.
+
+## 로컬 개발자 환경변수 설정
+
+### IntelliJ Run Configuration
+
+`Run/Debug Configurations` → `ThirdToolApplication`:
+- `Active profiles`: 비워둠 (application.yml default `dev,local` 사용) 또는 `dev,local` 명시
+- `Environment variables`:
+  ```
+  JWT_SECRET_KEY=any-32char-or-longer-secret-for-dev-local
+  KAKAO_CLIENT_ID=<카카오 콘솔에서 발급>
+  KAKAO_CLIENT_SECRET=<카카오 콘솔에서 발급>
+  NAVER_CLIENT_ID=<네이버 콘솔에서 발급>
+  NAVER_CLIENT_SECRET=<네이버 콘솔에서 발급>
+  AWS_ACCESS_KEY_ID=<S3 IAM 키>
+  AWS_SECRET_ACCESS_KEY=<S3 IAM 시크릿>
+  ```
+
+### CLI / Gradle bootRun
+
+```bash
+# bash/zsh — application.yml default(dev,local) 그대로 사용
+export JWT_SECRET_KEY=...
+export KAKAO_CLIENT_ID=...
+# ... (kakao, naver, AWS)
+./gradlew bootRun
+
+# PowerShell
+$env:JWT_SECRET_KEY = "..."
+$env:KAKAO_CLIENT_ID = "..."
+./gradlew bootRun
+
+# profile 명시 override (예: local 끄고 dev만)
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+```
+
+### local + prod 시뮬레이션
+
+로컬에서 prod profile 동작을 확인하려면 (예: HikariCP·Flyway·Hibernate validate 검증):
+
+```bash
+export SPRING_PROFILES_ACTIVE=prod,local
+export DB_HOST=localhost
+export DB_PORT=3306
+export DB_NAME=thirdtool_local
+export DB_USERNAME=root
+export DB_PASSWORD=...
+# kakao/naver/AWS prod 환경변수
+./gradlew bootRun
+```
+
+로컬 MySQL 실행 필요(`docker run -p 3306:3306 mysql:8`). `ddl-auto: validate`라 Flyway 마이그레이션이 먼저 실행되어야 스키마 검증 통과.
+
+## 검증
+
+```bash
+# 기본 (dev,local) — H2 + show-sql + console
+./gradlew bootRun
+# 로그: SQL 콘솔 출력. http://localhost:8080/h2-console 접속 가능
+
+# dev 단독 (CI 모사) — H2 + show-sql false
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+# 로그: SQL 출력 없음. h2-console 접근 불가
+
+# prod 활성화 — RDS(또는 로컬 MySQL) + Flyway
+SPRING_PROFILES_ACTIVE=prod ./gradlew bootRun
+```
+
+## test profile은 독립
+
+`@ActiveProfiles("test")`는 `application-test.yml`만 로드 (application.yml의 default `dev,local`은 적용 안 됨 — Spring Test가 ActiveProfiles로 override). test profile은 자체 H2 + dummy secrets + actuator 노출 설정을 포함해 환경변수 의존 없이 부팅.
+
+## 관련
+
+- 분리 트리거: 사용자 요청 — application.yml gitignore 해제 후 환경별 분리 + 로컬에서 dev/prod 시뮬레이션 둘 다 지원
+- 환경변수 가이드: [`ts002-environment-variables.md`](ts002-environment-variables.md)
+- 후속: AWS Secrets Manager 도입 시 환경변수 패턴이 SecretManager fetch로 전환 (Product 7)

--- a/docs/operations/troubleshooting/ts004-monitoring-stack-runtime.md
+++ b/docs/operations/troubleshooting/ts004-monitoring-stack-runtime.md
@@ -1,0 +1,106 @@
+# ts004: 모니터링 스택 (Prometheus + Grafana) 기동·환경별 이슈
+
+Story 2-1로 추가된 `monitoring/docker-compose.monitoring.yml` 실행 시 자주 마주치는 케이스 정리.
+
+## ts004-1: Prometheus `targets` 화면에서 `thirdtool` job이 DOWN
+
+### 증상
+http://localhost:9090/targets 접속 시 `thirdtool` job이 `DOWN` + Error에 `connection refused` 또는 `dial tcp ...: i/o timeout`.
+
+### 원인 분기
+
+| 원인 | 확인 | 해결 |
+| --- | --- | --- |
+| Spring Boot 앱이 미실행 | `curl localhost:8080/actuator/prometheus` 응답 여부 | 별도 터미널에서 `./gradlew bootRun` |
+| `application.yml`의 actuator 노출 미설정 | `curl localhost:8080/actuator/prometheus` 404 응답 | ts001 가이드 따라 `management.endpoints.web.exposure.include`에 `prometheus` 추가 |
+| Linux에서 `host.docker.internal` 미해석 | Prometheus 컨테이너 안 `curl host.docker.internal:8080` 실패 | 본 문서 ts004-2 참고 |
+| 8080 포트 다른 프로세스 점유 | `lsof -i :8080` 또는 `netstat -ano | findstr 8080` | 다른 포트로 부팅하거나 충돌 프로세스 종료 |
+
+## ts004-2: Linux에서 `host.docker.internal` 해석 실패
+
+### 증상
+Mac/Windows에선 정상이나 Linux 호스트에서 Prometheus 컨테이너가 `host.docker.internal:8080`을 못 찾음.
+
+### 원인
+Docker Desktop(Mac/Windows)은 기본으로 `host.docker.internal`을 호스트 IP로 자동 매핑한다. 그러나 순수 Docker Engine(Linux)은 이 기능이 없다.
+
+### 해결 — 본 PR 적용 사항
+
+`docker-compose.monitoring.yml`에 이미 `extra_hosts: ["host.docker.internal:host-gateway"]`가 명시되어 있다. Docker 20.10+ 에서 `host-gateway` 키워드가 자동으로 호스트 게이트웨이 IP를 매핑.
+
+여전히 실패 시 대안:
+
+```yaml
+# 옵션 A — network_mode: host (Linux 전용. Mac/Windows 호환 X)
+services:
+  prometheus:
+    network_mode: host
+    # ports: 매핑 제거 (host 네트워크엔 무효)
+```
+
+또는 호스트 IP 직접 지정:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: thirdtool
+    static_configs:
+      - targets: ["172.17.0.1:8080"]   # Linux Docker bridge gateway IP
+```
+
+호스트 IP 확인: `ip addr show docker0` → inet 값.
+
+## ts004-3: `.env.monitoring` 누락 시 부팅 실패
+
+### 증상
+```
+WARN[0000] The "GRAFANA_ADMIN_PASSWORD" variable is not set. Defaulting to a blank string.
+...
+service "grafana" can't be started: ...
+```
+
+### 해결
+```bash
+cp monitoring/.env.monitoring.example monitoring/.env.monitoring
+# 에디터로 GRAFANA_ADMIN_PASSWORD 변경
+docker compose --env-file monitoring/.env.monitoring \
+               -f monitoring/docker-compose.monitoring.yml up -d
+```
+
+`--env-file` 플래그 누락도 동일 증상. 명령 그대로 복사.
+
+## ts004-4: 재시작 후 Grafana 로그인 비밀번호 변경 안 됨
+
+### 증상
+`.env.monitoring`의 `GRAFANA_ADMIN_PASSWORD`를 변경 후 `docker compose up -d`해도 이전 비밀번호로만 로그인됨.
+
+### 원인
+Grafana는 첫 부팅 시에만 `GF_SECURITY_ADMIN_PASSWORD` 환경변수를 읽어 admin 비밀번호를 설정한다. 이후엔 named volume(`grafana-data`)의 sqlite DB 값이 우선.
+
+### 해결
+- 일회성 변경: Grafana UI(Configuration → Users → admin → Change password)
+- 강제 초기화: `docker compose down -v` 후 다시 up — 시계열·대시보드 모두 삭제됨
+
+## ts004-5: Prometheus 시계열이 컨테이너 재시작 후 사라짐
+
+### 증상
+`docker compose down && up`을 했더니 1주일 추이 데이터가 모두 사라짐.
+
+### 원인
+`-v` 플래그 또는 `volumes:` 정의 누락으로 named volume이 제거됨.
+
+### 확인
+```bash
+docker volume ls | grep -E "prometheus-data|grafana-data"
+# 둘 다 존재해야 정상
+```
+
+### 해결
+- `-v` 플래그 없이 `down`만 사용 — `docker compose -f monitoring/docker-compose.monitoring.yml down`
+- 의도적 초기화만 `down -v` 사용
+
+## 관련
+
+- Story 2-1 (Product 0-b 메트릭 Epic 2) — Prometheus + Grafana docker-compose
+- ts001 — Story 4-1 `/actuator/prometheus` 노출을 위한 application.yml 갱신
+- 후속 Epic 3 Story 3-1 — Grafana 대시보드 4 섹션 + `thirdtool.json`

--- a/monitoring/.env.monitoring.example
+++ b/monitoring/.env.monitoring.example
@@ -1,0 +1,11 @@
+# ThirdTool 모니터링 스택 환경변수 예시 (Story 2-1)
+#
+# 사용법:
+#   cp monitoring/.env.monitoring.example monitoring/.env.monitoring
+#   # 아래 GRAFANA_ADMIN_PASSWORD를 실제 비밀번호로 교체
+#
+# .env.monitoring 파일은 .gitignore 대상 — 실제 비밀번호는 commit되지 않음.
+
+# Grafana admin 비밀번호 (admin/<여기> 로 로그인)
+# 기본 admin/admin 사용 금지 — 부팅 시 reset 강제됨
+GRAFANA_ADMIN_PASSWORD=change-me-to-a-strong-password

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -17,6 +17,13 @@ monitoring/
     └── dashboards/                    # Epic 3 Story 3-1에서 thirdtool.json 추가 예정
 ```
 
+## 사전 조건
+
+- **Docker Desktop (Mac/Windows) 또는 Docker Engine 20.10+ (Linux)** 실행 중
+- **Spring Boot 앱(`./gradlew bootRun`)이 `:8080`에서 떠 있어야 한다** (별도 터미널)
+- **`application.yml` actuator 설정 완료** — `docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md` 가이드 따라 갱신 (미적용 시 thirdtool job 영구 DOWN)
+- (Linux 한정) `extra_hosts: host-gateway`로 `host.docker.internal` 해석 — 본 compose 파일에 이미 포함
+
 ## 실행 절차
 
 ### 1. Spring Boot 앱 실행 (별도 터미널)
@@ -70,7 +77,15 @@ docker compose -f monitoring/docker-compose.monitoring.yml down -v
 ## 환경별 주의
 
 - **Mac / Windows**: `host.docker.internal:8080`이 호스트의 Spring Boot로 자동 해석된다.
-- **Linux**: `docker-compose.monitoring.yml`에 `extra_hosts: ["host.docker.internal:host-gateway"]`를 명시해 동일 동작을 보장. 그래도 안 되면 `network_mode: host` 또는 호스트 IP 직접 지정 — `docs/operations/troubleshooting/ts004-monitoring-stack-runtime.md` 참고.
+- **Linux**: `docker-compose.monitoring.yml`에 `extra_hosts: ["host.docker.internal:host-gateway"]`를 명시해 동일 동작을 보장 (Docker 20.10+). 미지원 환경 또는 fallback 절차는 `docs/operations/troubleshooting/ts004-monitoring-stack-runtime.md` ts004-2 참고.
+
+## 디스크 사용량
+
+Prometheus는 retention 7일 + 2GB 상한(`--storage.tsdb.retention.{time,size}`)으로 폭증을 차단한다. 다음 명령으로 사용량 확인:
+
+```bash
+docker system df -v | grep -E "prometheus-data|grafana-data"
+```
 
 ## 검증
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,94 @@
+# ThirdTool 모니터링 스택
+
+Spring Boot Actuator(`/actuator/prometheus`)를 Prometheus가 10초 간격으로 스크랩하고, Grafana가 시각화하는 로컬 개발용 모니터링 스택입니다 (Story 2-1, Product 0-b 메트릭 Epic 2).
+
+## 구성
+
+```
+monitoring/
+├── docker-compose.monitoring.yml      # Prometheus + Grafana 컨테이너 정의
+├── .env.monitoring.example            # GRAFANA_ADMIN_PASSWORD 예시 (실제 .env.monitoring은 .gitignore)
+├── prometheus/
+│   └── prometheus.yml                 # scrape config (thirdtool job, 10s 간격)
+└── grafana/
+    ├── provisioning/
+    │   ├── datasources/datasource.yml # Prometheus를 default Datasource로 자동 등록
+    │   └── dashboards/dashboard.yml   # /var/lib/grafana/dashboards 자동 로드 provider
+    └── dashboards/                    # Epic 3 Story 3-1에서 thirdtool.json 추가 예정
+```
+
+## 실행 절차
+
+### 1. Spring Boot 앱 실행 (별도 터미널)
+
+ThirdTool 앱이 `:8080`에서 떠 있어야 Prometheus가 스크랩 대상을 찾는다.
+
+```bash
+./gradlew bootRun
+```
+
+`application.yml`에 actuator 노출 설정 필수 — `docs/operations/troubleshooting/ts001-actuator-prometheus-application-yml.md` 가이드 따라 갱신.
+
+### 2. 환경변수 파일 생성
+
+```bash
+cp monitoring/.env.monitoring.example monitoring/.env.monitoring
+# 에디터로 GRAFANA_ADMIN_PASSWORD 변경 (기본 'change-me-...' 그대로 두지 말 것)
+```
+
+### 3. 모니터링 스택 기동
+
+```bash
+docker compose --env-file monitoring/.env.monitoring \
+               -f monitoring/docker-compose.monitoring.yml up -d
+```
+
+### 4. 접속 확인
+
+| URL | 용도 | 로그인 |
+| --- | --- | --- |
+| http://localhost:9090 | Prometheus UI | 없음 |
+| http://localhost:9090/targets | scrape 대상 상태 확인 (`thirdtool` job UP 여부) | 없음 |
+| http://localhost:3000 | Grafana UI | `admin` / `.env.monitoring`의 비밀번호 |
+
+Grafana 로그인 후 `Configuration → Data sources`에서 **Prometheus**가 default로 등록되어 있어야 한다.
+
+### 5. 중단·재시작
+
+```bash
+# 중단 (시계열·대시보드 설정은 named volume에 유지)
+docker compose -f monitoring/docker-compose.monitoring.yml down
+
+# 다시 기동 — 데이터 복원
+docker compose --env-file monitoring/.env.monitoring \
+               -f monitoring/docker-compose.monitoring.yml up -d
+
+# 데이터까지 완전 초기화
+docker compose -f monitoring/docker-compose.monitoring.yml down -v
+```
+
+## 환경별 주의
+
+- **Mac / Windows**: `host.docker.internal:8080`이 호스트의 Spring Boot로 자동 해석된다.
+- **Linux**: `docker-compose.monitoring.yml`에 `extra_hosts: ["host.docker.internal:host-gateway"]`를 명시해 동일 동작을 보장. 그래도 안 되면 `network_mode: host` 또는 호스트 IP 직접 지정 — `docs/operations/troubleshooting/ts004-monitoring-stack-runtime.md` 참고.
+
+## 검증
+
+```bash
+# 1. Prometheus가 thirdtool 메트릭 수집 중인지 query
+curl -s 'http://localhost:9090/api/v1/query?query=up{job="thirdtool"}' | jq
+
+# 2. Grafana Datasource 자동 등록 확인
+curl -s -u admin:<PASSWORD> http://localhost:3000/api/datasources | jq '.[].name'
+
+# 3. 재시작 후 데이터 유지
+docker compose -f monitoring/docker-compose.monitoring.yml restart
+sleep 5
+curl -s 'http://localhost:9090/api/v1/query?query=up{job="thirdtool"}' | jq
+```
+
+## 후속
+
+- Epic 3 Story 3-1 — Grafana 대시보드 4 섹션(API/JVM/DB/상태) + `thirdtool.json` 커밋
+- Product 8 — k6 부하 테스트의 baseline 측정 도구로 본 스택 활용
+- 운영 환경 도입 시 — 별도 `prometheus-staging.yml`/`prometheus-prod.yml`로 분리 또는 환경변수 치환 (현재는 local 한정)

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,61 @@
+# ThirdTool 모니터링 스택 (Story 2-1, Product 0-b 메트릭 Epic 2)
+#
+# 실행:
+#   docker compose --env-file monitoring/.env.monitoring \
+#                  -f monitoring/docker-compose.monitoring.yml up -d
+#
+# 사전 준비:
+#   1. Spring Boot 앱이 :8080에서 실행 중 (다른 터미널에서 ./gradlew bootRun)
+#   2. application.yml에 management.endpoints.web.exposure.include: prometheus
+#      (ts001 가이드 참조)
+#   3. monitoring/.env.monitoring 파일에 GRAFANA_ADMIN_PASSWORD 설정
+#      (.env.monitoring.example 복사 후 비밀번호 변경)
+#
+# 가이드: monitoring/README.md + docs/operations/troubleshooting/ts004-*.md
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.0
+    container_name: thirdtool-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    restart: unless-stopped
+    # Linux 환경에서 host.docker.internal 해석을 위해 extra_hosts 추가 (Mac/Windows는 기본 지원)
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: thirdtool-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      # 외부 공개 차단 — 대시보드는 운영 상태를 노출하므로 anonymous 비활성화 (Story 2-1 Epic 결정)
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -19,6 +19,14 @@ services:
     container_name: thirdtool-prometheus
     ports:
       - "9090:9090"
+    # retention 명시 — 1주 데이터 보존(부하 테스트 baseline) + 2GB 디스크 상한으로 폭증 방지
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=7d"
+      - "--storage.tsdb.retention.size=2GB"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
@@ -27,7 +35,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:9090/-/healthy || exit 1"]
       interval: 15s
       timeout: 3s
       retries: 3
@@ -42,9 +50,14 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
       # 외부 공개 차단 — 대시보드는 운영 상태를 노출하므로 anonymous 비활성화 (Story 2-1 Epic 결정)
       GF_AUTH_ANONYMOUS_ENABLED: "false"
+      # provisioning 경로 명시 — dashboards bind mount 충돌 회피 (Reviewer Critical)
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      # dashboards를 named volume 하위(/var/lib/grafana/...)가 아닌 /etc/grafana/dashboards로
+      # 분리 마운트 — grafana-data named volume과 경로 충돌 방지.
+      # dashboard.yml의 path도 동일하게 /etc/grafana/dashboards로 정합.
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     depends_on:
       prometheus:

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -14,5 +14,6 @@ providers:
     updateIntervalSeconds: 30
     allowUiUpdates: true
     options:
-      path: /var/lib/grafana/dashboards
+      # dashboards bind mount는 /etc/grafana/dashboards에 위치 — named volume(/var/lib/grafana)과 분리
+      path: /etc/grafana/dashboards
       foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,18 @@
+# Grafana Dashboard provider (Story 2-1)
+# - /var/lib/grafana/dashboards 경로의 *.json 파일을 자동 로드
+# - 본 PR 시점엔 빈 dashboards/ 디렉토리. Epic 3 Story 3-1에서 thirdtool.json 추가
+# - updateIntervalSeconds: 30 — JSON 파일 변경 감지 주기 (Grafana 재시작 없이 반영)
+
+apiVersion: 1
+
+providers:
+  - name: thirdtool
+    orgId: 1
+    folder: ThirdTool
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,14 @@
+# Grafana Datasource provisioning (Story 2-1)
+# - 컨테이너 부팅 시 자동 로드 — GUI 수동 설정 불필요
+# - Prometheus를 default Datasource로 등록 (대시보드 패널이 별도 지정 없이 사용)
+# - access: proxy — Grafana가 백엔드에서 Prometheus 호출 (CORS·인증 단순화)
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,24 @@
+# ThirdTool Prometheus scrape config (Story 2-1)
+# - scrape_interval=10s — Grafana auto-refresh와 동일 주기로 정합 (Epic 결정)
+# - thirdtool job — Spring Boot Actuator의 /actuator/prometheus를 스크랩
+# - target: host.docker.internal:8080 — Mac/Windows 기본 지원, Linux는 compose의 extra_hosts로 보강
+
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+  external_labels:
+    monitor: thirdtool-local
+
+scrape_configs:
+  # Prometheus 자기 자신
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # ThirdTool Spring Boot 애플리케이션
+  - job_name: thirdtool
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["host.docker.internal:8080"]
+        labels:
+          env: local

--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -184,8 +184,10 @@ public class SecurityConfig {
 
         // ==============================
         // 6️⃣ MDC 로깅 필터 (Story 2-1) — 최선단에서 requestId 부여 + 응답 헤더 echo + MDC clear
+        //    anchor는 Spring Security 등록 표준 필터(UsernamePasswordAuthenticationFilter)로 통일.
+        //    같은 anchor의 addFilterBefore는 등록 순서대로 정렬되므로 본 줄이 가장 먼저 실행됨.
         // ==============================
-        http.addFilterBefore(new MdcLoggingFilter(), BlockListFilter.class);
+        http.addFilterBefore(new MdcLoggingFilter(), UsernamePasswordAuthenticationFilter.class);
 
         // ==============================
         // 7️⃣ 악성 URL 차단 필터 (Story 3-3) — JWTFilter 앞단에서 즉시 404

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,56 @@
+# ===========================================
+# dev 프로필 — 개발 환경 (CI · dev 서버 · 로컬 dev 기본)
+# - H2 인메모리 (Flyway 미사용, Hibernate DDL 자동)
+# - 환경변수 secret 필수 — 가이드: docs/operations/troubleshooting/ts002-environment-variables.md
+# - 로컬 개발자가 H2 console·show-sql 보고 싶으면 local profile을 함께 활성화 (SPRING_PROFILES_ACTIVE=local,dev)
+# ===========================================
+spring:
+  datasource:
+    url: jdbc:h2:mem:thirdtool;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop  # 앱 시작 시 테이블 생성, 종료 시 삭제
+    show-sql: false          # local profile에서 true로 override
+    properties:
+      hibernate:
+        format_sql: false
+        default_batch_fetch_size: 100
+
+  flyway:
+    enabled: false           # H2에서는 Flyway 미사용. DDL은 Hibernate가 담당
+
+# dev 프로파일 — HTTPS 없는 환경. Secure=false (Story 1-3)
+jwt:
+  cookie:
+    secure: false
+
+# 소셜 로그인 — dev FE 기준 (로컬 5173)
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: http://localhost:5173/oauth/kakao/callback
+
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+  redirect-uri: http://localhost:5173/oauth/naver/callback
+
+# AWS S3 — dev에서도 실제 S3 사용 (이미지 업로드 확인용)
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: third-tool-s3-server
+    region:
+      static: ap-northeast-2
+
+seed:
+  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
+  image-count: 10

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,36 +1,23 @@
 # ===========================================
-# local 프로필 — 로컬 개발자 환경 (평문 로그, H2 인메모리)
-# - secret-free: 소셜/AWS 등 자격이 필요한 항목은 application.yml(gitignore)에서 관리
-# - 활성화: spring.profiles.active=local (CLI --args 또는 application.yml의 active)
+# local 프로필 — 로컬 개발자 override (다른 profile과 조합 사용)
+# - 단독 사용 X — 항상 dev 또는 prod와 조합: SPRING_PROFILES_ACTIVE=local,dev
+# - dev/prod의 datasource·secret은 그쪽 yml이 책임. local은 개발 편의 override만.
 # - 로그 포맷은 logback-spring.xml의 <springProfile name="local">에서 평문으로 분기 (ADR008)
 # ===========================================
 spring:
-  datasource:
-    url: jdbc:h2:mem:thirdtool;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password: sa
-    driver-class-name: org.h2.Driver
-
   h2:
     console:
-      enabled: true
+      enabled: true          # http://localhost:8080/h2-console 에서 DB 확인 가능
       path: /h2-console
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
+    show-sql: true           # 로컬에선 SQL 콘솔 출력
     properties:
       hibernate:
-        format_sql: true
-        default_batch_fetch_size: 100
-
-  flyway:
-    enabled: false
+        format_sql: true     # 보기 좋게 포맷
 
 # Card 야간 만료 배치(Story 2-2)는 로컬에서 비활성화 — Spring `@Scheduled`는 cron="-"을 disabled로 해석.
-# 운영 환경(application.yml, gitignored)에서 cron 활성화한다.
+# 운영 환경(prod profile)에서 cron 활성화한다.
 card:
   expiry:
     cron: "-"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,72 @@
+# ===========================================
+# prod 프로필 — 운영 환경 (AWS RDS MySQL, HTTPS, Swagger 비활성화)
+# - 모든 secret은 환경변수 필수. default 없음 — Spring Boot가 placeholder 미해석 시 부팅 실패 (의도)
+# - SecretManager 마이그레이션 이후엔 Spring Cloud AWS가 환경변수 대신 fetch
+# - 로컬에서 prod 시뮬레이션: SPRING_PROFILES_ACTIVE=local,prod + 로컬 MySQL 또는 RDS 환경변수
+# ===========================================
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: validate          # 운영에서는 Flyway가 DDL 담당. Hibernate는 검증만
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        globally_quoted_identifiers: true
+        default_batch_fetch_size: 100
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+# prod 프로파일 — HTTPS 환경. Secure=true (Story 1-3)
+jwt:
+  cookie:
+    secure: true
+
+# Swagger — 운영에서는 비활성화
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
+# 소셜 로그인 — 운영 도메인 기준
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: https://thirdstool.com/oauth/kakao/callback
+
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+  redirect-uri: https://thirdstool.com/oauth/naver/callback
+
+# AWS S3
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: third-tool-s3-server
+    region:
+      static: ap-northeast-2
+
+seed:
+  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
+  image-count: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
-
 # ===========================================
 # 공통 설정 (모든 환경 적용)
+# - 환경별 datasource·secret은 application-{dev,prod}.yml로 분리
+# - 로컬 개발자 override(show-sql·h2 console)는 application-local.yml
+# - SPRING_PROFILES_ACTIVE 환경변수로 override 가능. 기본: local,dev (로컬 개발자 편의)
+# - CI/서버: SPRING_PROFILES_ACTIVE=dev / prod 명시
 # ===========================================
 spring:
   servlet:
@@ -13,27 +16,29 @@ spring:
     name: third-tool-backend
 
   profiles:
-    active: dev  # 기본 프로필: dev (H2 인메모리)
+    # 기본 default는 dev,local (로컬 개발자 친화 — H2 console·show-sql 자동 활성화).
+    # 콤마 순서: 나중 profile이 우선 → local의 override가 dev 위에 적용.
+    # CI/서버는 SPRING_PROFILES_ACTIVE=dev 또는 prod 명시. 가이드: ts003.
+    active: ${SPRING_PROFILES_ACTIVE:dev,local}
 
 # 로깅 설정은 logback-spring.xml로 일원화 (ADR008)
 
-# JWT 토큰 설정 (Story 1-1 외부화)
+# JWT 토큰 공통 (Story 1-1 외부화) — cookie.secure는 profile별 override
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-ttl: 30m   # Access Token TTL — 30분 (Product 1)
   refresh-token-ttl: 7d   # Refresh Token TTL — 7일 (Product 1)
 
-  # AT 쿠키 보안 속성 (Story 1-3 외부화)
-  # 공통 기본값. 프로파일별 override는 아래 dev/prod 블록에서.
   cookie:
     name: access_token
     path: /
     http-only: true
     same-site: Strict
-    # secure는 프로파일별 분기 — 공통은 안전한 default (true)
+    # secure는 application-{dev,prod}.yml에서 override (dev: false, prod: true)
     secure: true
 
-# Actuator
+# Actuator — endpoint 노출은 운영자가 환경별로 application-{dev,prod}.yml에서 갱신.
+# 기본은 미노출. Story 4-1 + ts001 참고.
 management:
   endpoints:
     web:
@@ -45,7 +50,7 @@ management:
       cache:
         time-to-live: 30s
 
-# Swagger / OpenAPI
+# Swagger / OpenAPI — prod profile에서 비활성화
 springdoc:
   api-docs:
     path: /custom-api-docs
@@ -62,142 +67,3 @@ springdoc:
     cache:
       disabled: true
     model-and-view-allowed: true
-
-# ===========================================
-# dev 프로필 — H2 인메모리 (로컬 개발·테스트)
-# ===========================================
----
-spring:
-  config:
-    activate:
-      on-profile: dev
-
-  datasource:
-    url: jdbc:h2:mem:thirdtool;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password: sa
-    driver-class-name: org.h2.Driver
-
-  h2:
-    console:
-      enabled: true          # http://localhost:8080/h2-console 에서 DB 확인 가능
-      path: /h2-console
-
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create-drop  # 앱 시작 시 테이블 생성, 종료 시 삭제
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        default_batch_fetch_size: 100
-
-  flyway:
-    enabled: false           # H2에서는 Flyway 미사용. DDL은 Hibernate가 담당
-
-# dev 프로파일 — HTTPS 없는 로컬 개발 환경. Secure=false 명시 (Story 1-3)
-jwt:
-  cookie:
-    secure: false
-
-# 소셜 로그인 — 로컬 FE 기준 (비밀은 환경변수로만 주입, SecretManager 도입 전 임시)
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: http://localhost:5173/oauth/kakao/callback
-
-naver:
-  client-id: ${NAVER_CLIENT_ID}
-  client-secret: ${NAVER_CLIENT_SECRET}
-  redirect-uri: http://localhost:5173/oauth/naver/callback
-
-# AWS S3 — 로컬에서도 실제 S3 사용 (이미지 업로드 확인용)
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY_ID}
-      secret-key: ${AWS_SECRET_ACCESS_KEY}
-    s3:
-      bucket: third-tool-s3-server
-    region:
-      static: ap-northeast-2
-
-seed:
-  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
-  image-count: 10
-
-# ===========================================
-# prod 프로필 — AWS RDS MySQL (운영)
-# ===========================================
----
-spring:
-  config:
-    activate:
-      on-profile: prod
-
-  datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
-      connection-timeout: 30000
-      idle-timeout: 600000
-      max-lifetime: 1800000
-
-  jpa:
-    database-platform: org.hibernate.dialect.MySQLDialect
-    hibernate:
-      ddl-auto: validate          # 운영에서는 Flyway가 DDL 담당. Hibernate는 검증만
-    show-sql: false
-    properties:
-      hibernate:
-        format_sql: false
-        globally_quoted_identifiers: true
-        default_batch_fetch_size: 100
-
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-    baseline-on-migrate: true
-
-# prod 프로파일 — HTTPS 환경. Secure=true 강제 (Story 1-3)
-jwt:
-  cookie:
-    secure: true
-
-# Swagger — 운영에서는 비활성화
-springdoc:
-  swagger-ui:
-    enabled: false
-  api-docs:
-    enabled: false
-
-# 소셜 로그인 — 운영 도메인 기준
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: https://thirdstool.com/oauth/kakao/callback
-
-naver:
-  client-id: ${NAVER_CLIENT_ID}
-  client-secret: ${NAVER_CLIENT_SECRET}
-  redirect-uri: https://thirdstool.com/oauth/naver/callback
-
-# AWS S3
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY_ID}
-      secret-key: ${AWS_SECRET_ACCESS_KEY}
-    s3:
-      bucket: third-tool-s3-server
-    region:
-      static: ap-northeast-2
-
-seed:
-  s3-base-url: "https://third-tool-s3-server.s3.ap-northeast-2.amazonaws.com"
-  image-count: 10

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticSuggestionAdapterConditionalTest.java
@@ -29,7 +29,7 @@ class StaticSuggestionAdapterConditionalTest {
 
     @Nested
     @SpringBootTest(properties = "thirdtool.suggestion.provider=static")
-    @ActiveProfiles("dev")
+    @ActiveProfiles("test")
     @DisplayName("provider=static (또는 미설정 matchIfMissing)")
     class WhenStaticProvider {
 
@@ -54,7 +54,7 @@ class StaticSuggestionAdapterConditionalTest {
 
     @Nested
     @SpringBootTest(properties = "thirdtool.suggestion.provider=llm")
-    @ActiveProfiles("dev")
+    @ActiveProfiles("test")
     @DisplayName("provider=llm (비-static)")
     class WhenNonStaticProvider {
 

--- a/src/test/java/com/example/thirdtool/ThirdToolApplicationTests.java
+++ b/src/test/java/com/example/thirdtool/ThirdToolApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.thirdtool;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ThirdToolApplicationTests {
 
     @Test


### PR DESCRIPTION
## 개요
Story 4-1로 노출된 `/actuator/prometheus`를 Prometheus가 10초 간격 스크랩하고 Grafana가 시각화하는 로컬 모니터링 스택. 단일 `docker compose up` 명령으로 기동 + named volume으로 재시작 후 데이터 유지.

## 왜 / 설계 결정
- **Story 1-1 완성**: 메트릭이 수집·시각화될 수집기 인프라가 있어야 1-1의 가치가 살아남. 본 Story가 그 첫 단계
- **로컬 한정**: 운영 환경 도입(별도 prometheus-{dev,prod}.yml + AWS Secrets Manager 통합)은 후속 Story로 위임 (Product 7 또는 Epic 2 확장)
- **Provisioning 자동 등록**: Grafana Datasource·dashboard provider를 yaml로 코드베이스에 commit — GUI 수동 설정 금지(Epic 2 결정)
- **GF_AUTH_ANONYMOUS_ENABLED=false + GF_USERS_ALLOW_SIGN_UP=false**: 외부 노출 차단(Epic 2 결정). 운영 시 LB 차단 운영 책임 — ts001/ts004에 명시
- **named volume 영속**: `prometheus-data`, `grafana-data` — `docker compose down` 후에도 시계열·대시보드 유지

기각 대안: Testcontainers 통합 테스트(Epic 2 범위 외, ADR 후보), bind mount(Linux UID 권한 문제), 모니터링을 메인 compose에 합본(앱 재배포 시 시계열 gap).

## 작업 내용
- feat(infra): `monitoring/docker-compose.monitoring.yml` (Prometheus 2.54 + Grafana 11.2, health-check + service_healthy 부팅 순서 + extra_hosts host-gateway Linux 호환 + retention 7d/2GB + GF_PATHS_PROVISIONING)
- feat(infra): `monitoring/prometheus/prometheus.yml` (10s scrape, thirdtool job + Prometheus self-scrape, external_labels.monitor=thirdtool-local)
- feat(infra): `monitoring/grafana/provisioning/{datasources,dashboards}/*.yml` — Prometheus default Datasource 자동 등록 + dashboards file provider (Epic 3에서 thirdtool.json 추가 예정)
- feat(infra): `monitoring/.env.monitoring.example` + `.gitignore`에 `monitoring/.env.monitoring` 추가
- docs(operations): `monitoring/README.md` (사전 조건 + 실행 4단계 + 디스크 모니터링 + 환경별 주의)
- docs(operations): `docs/operations/troubleshooting/ts004-monitoring-stack-runtime.md` (5케이스: 타겟 DOWN·Linux 호환·env 누락·Grafana 비밀번호 reset·volume 유실)
- docs(package): `docs/PACKAGE.md`에 `monitoring/` 루트 디렉토리 + `src/main/resources/` 트리 등재
- fix(infra): Reviewer 5관점 보강 — Grafana dashboards 마운트 경로 충돌 fix(/var/lib/grafana → /etc/grafana/dashboards), Prometheus retention 명시, healthcheck 형식 통일

## 변경 유형
- [x] feat  - [x] fix  - [ ] refactor  - [x] docs  - [ ] test  - [ ] chore

## 테스트
- 자동 테스트 0건 (인프라 yaml — JUnit 검증 어려움)
- 수동 검증 절차: `monitoring/README.md §검증`의 curl 3종 (Prometheus query `up{job="thirdtool"}`, Grafana Datasource API, 재시작 후 데이터 유지)
- 기존 회귀: Spring Boot 측 코드 변경 없음, `./gradlew test` 영향 없음

## Reviewer 5관점 결과
머지 전 Domain·Architecture·API·Test·Sceptical 5관점 1회 수행. Critical·Major 5건은 본 PR에서 보강 commit(`cab85c7`)으로 반영. 미반영 후속:
- **Testcontainers 기반 통합 E2E 테스트** — Spring Boot + Prometheus + Grafana 3계층 검증. 별도 인프라 Story로 위임
- **Docker 의존성 ADR** — 본 PR로 로컬 개발에 Docker 강제. 결정 배경 ADR로 기록 권장 (별도 docs PR)
- **CI YAML lint** — `docker compose config` + `yamllint`로 syntax 회귀 안전망. 별도 CI Story
- **`/actuator/prometheus` Bearer token 인증** — 운영 도입 시 LB 차단 외 추가 방어. 별도 운영 Story
- **메트릭 cardinality 정책 명시** — Controller path template 정규화 책임이 BC/infra 어디인가. Epic 3 Story 3-1과 연계

## ⚠️ 머지 후 사용자 액션
1. **application.yml에 actuator 노출 설정 갱신**: ts001 가이드 (`management.endpoints.web.exposure.include: prometheus, ...`)
2. **monitoring/.env.monitoring 파일 생성**: `cp monitoring/.env.monitoring.example monitoring/.env.monitoring` + `GRAFANA_ADMIN_PASSWORD` 변경
3. **Spring Boot 실행**: `./gradlew bootRun`
4. **monitoring 스택 기동**: `docker compose --env-file monitoring/.env.monitoring -f monitoring/docker-compose.monitoring.yml up -d`
5. 검증: http://localhost:9090/targets (thirdtool UP), http://localhost:3000 (admin/<password>)

## 체크리스트
- [x] 빌드 / 테스트 통과 (코드 변경 0)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — PACKAGE.md에 monitoring/ + src/main/resources 트리 등재
- [x] BC 간 의존 방향 위반 없음 (인프라 layer만)
- [x] (stacked) 대상 브랜치 = `develop`

## 관련 이슈
- Product: `workflow/task/pes/sdd/product-op.md` (Product 0-b 메트릭)
- Epic: Epic 2 — 수집·시각화 스택 Prometheus + Grafana docker-compose
- Story: Story 2-1 (Prometheus + Grafana docker-compose 구성·Datasource provisioning·볼륨 영속화)
- 마일스톤: `workflow/product/milestones/version/0.0.1v/milestone.md` Tier 1 #5
- 선행 PR: #168 (Story-041 Actuator + Micrometer) — 머지됨
- 후속: Epic 3 Story 3-1 (Grafana 대시보드 4 섹션 + thirdtool.json)