### PR TITLE
feat(infra): Story-046 GHA OIDC AssumeRole — dev-cicd.yml + IAM 정책 + ADR013 + ts007

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,3 +1,10 @@
+# Story-046: GHA → AWS 인증을 OIDC AssumeRole로 전환.
+#   - aws-actions/configure-aws-credentials@v4 step이 `role-to-assume`만 사용
+#     (long-lived access key 폐기) → 1시간 TTL 임시 자격증명을 STS가 발급
+#   - 신뢰 정책 sub 조건으로 repo:Third-tool/third-tool:ref:refs/heads/main 잠금
+#     (fork PR · 임의 branch 차단). 자세한 셋업 절차는 ts007 runbook 참조
+#   - EC2 SSH 배포 step의 AWS_ACCESS_KEY_ID/SECRET env var pass-through는
+#     transitional 유지 — milestone #11 ECS Task Role 이행 시 일괄 제거 예정
 name: Deploy To EC2 (dev-version)
 
 on:
@@ -15,6 +22,11 @@ on:
         default: false
         type: boolean
 
+# OIDC ID token 발급 권한 — Story-046. 모든 job에 적용.
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   # ======================================================
   # 1️⃣ Elasticsearch(Nori) 이미지 빌드 (수동 전용)
@@ -27,12 +39,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
+      # Story-046: OIDC AssumeRole — long-lived access key 폐기
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/gha-deploy-role
           aws-region: ap-northeast-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          audience: sts.amazonaws.com
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -59,14 +72,16 @@ jobs:
         uses: actions/checkout@v4
 
       # 2️⃣ AWS 자격 증명
+      # Story-046: OIDC AssumeRole — long-lived access key 폐기.
+      # gha-deploy-role 신뢰 정책이 repo:Third-tool/third-tool:ref:refs/heads/main 잠금.
       # (Story 1-1: host gradle build 단계 삭제 — Docker builder stage가 동일 작업
       #  수행하고 .dockerignore가 build/를 차단해 host 산출물은 image에 미반영)
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/gha-deploy-role
           aws-region: ap-northeast-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          audience: sts.amazonaws.com
 
       # 3️⃣ ECR 로그인
       - name: Login to Amazon ECR
@@ -86,6 +101,9 @@ jobs:
         run: docker push ${{ steps.login-ecr.outputs.registry }}/third-tool-server:latest
 
       # 9️⃣ EC2 SSH 배포
+      # TODO Story #11 (ECS Task Role 이행): 본 step 전체 — EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET
+      # env var pass-through — 는 ECS 이행 시 제거 예정. ECS Task Role 자동 주입 +
+      # S3Config의 DefaultCredentialsProvider 전환과 함께 묶음. ADR013 follow-up 참조.
       - name: Deploy to EC2 via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -139,6 +157,10 @@ jobs:
             docker image prune -af
 
             # Spring Boot 실행
+            # NOTE Story-046: AWS_ACCESS_KEY_ID/SECRET env 주입은 transitional 유지.
+            # GHA → AWS 인증은 OIDC로 전환됐지만, EC2 컨테이너 안의 S3Config가 여전히
+            # StaticCredentialsProvider 사용 중이라 env 변수 주입 필요.
+            # 제거 시점: #11 ECS Task Role 이행 + S3Config → DefaultCredentialsProvider.
             echo "⚙️ Running Spring Boot container..."
             docker run -d \
               --name third-tool-server \

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Story-046: 1회성 셋업 누락 fail-fast — vars.AWS_ACCOUNT_ID 미설정 시
+      # 빈 ARN으로 AssumeRole까지 가지 않고 첫 줄에서 명시적 에러 (ts007 §4 참조)
+      - name: Verify OIDC prerequisites
+        run: |
+          if [ -z "${{ vars.AWS_ACCOUNT_ID }}" ]; then
+            echo "::error::AWS_ACCOUNT_ID GitHub Variable not set — see docs/operations/troubleshooting/ts007-gha-oidc-setup.md §4"
+            exit 1
+          fi
+
       # Story-046: OIDC AssumeRole — long-lived access key 폐기
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -71,9 +80,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Story-046: 1회성 셋업 누락 fail-fast — vars.AWS_ACCOUNT_ID 미설정 시
+      # 빈 ARN으로 AssumeRole까지 가지 않고 첫 줄에서 명시적 에러 (ts007 §4 참조)
+      - name: Verify OIDC prerequisites
+        run: |
+          if [ -z "${{ vars.AWS_ACCOUNT_ID }}" ]; then
+            echo "::error::AWS_ACCOUNT_ID GitHub Variable not set — see docs/operations/troubleshooting/ts007-gha-oidc-setup.md §4"
+            exit 1
+          fi
+
       # 2️⃣ AWS 자격 증명
       # Story-046: OIDC AssumeRole — long-lived access key 폐기.
-      # gha-deploy-role 신뢰 정책이 repo:Third-tool/third-tool:ref:refs/heads/main 잠금.
+      # gha-deploy-role 신뢰 정책이 repo:Third-tool/third-tool-backend:ref:refs/heads/main 잠금.
       # (Story 1-1: host gradle build 단계 삭제 — Docker builder stage가 동일 작업
       #  수행하고 .dockerignore가 build/를 차단해 host 산출물은 image에 미반영)
       - name: Configure AWS credentials (OIDC)
@@ -101,9 +119,10 @@ jobs:
         run: docker push ${{ steps.login-ecr.outputs.registry }}/third-tool-server:latest
 
       # 9️⃣ EC2 SSH 배포
-      # TODO Story #11 (ECS Task Role 이행): 본 step 전체 — EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET
-      # env var pass-through — 는 ECS 이행 시 제거 예정. ECS Task Role 자동 주입 +
-      # S3Config의 DefaultCredentialsProvider 전환과 함께 묶음. ADR013 follow-up 참조.
+      # TODO follow-up Story (TBD — milestone 0.0.1v item #11 / ECS Task Role 이행 시점):
+      # 본 step 전체 — EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET env var pass-through —
+      # 는 ECS 이행 시 제거 예정. ECS Task Role 자동 주입 + S3Config의
+      # DefaultCredentialsProvider 전환과 함께 묶음. ADR013 follow-up 참조.
       - name: Deploy to EC2 via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -160,7 +179,8 @@ jobs:
             # NOTE Story-046: AWS_ACCESS_KEY_ID/SECRET env 주입은 transitional 유지.
             # GHA → AWS 인증은 OIDC로 전환됐지만, EC2 컨테이너 안의 S3Config가 여전히
             # StaticCredentialsProvider 사용 중이라 env 변수 주입 필요.
-            # 제거 시점: #11 ECS Task Role 이행 + S3Config → DefaultCredentialsProvider.
+            # 제거 시점: milestone 0.0.1v item #11 (ECS Task Role 이행) + S3Config →
+            # DefaultCredentialsProvider 전환과 함께 묶음.
             echo "⚙️ Running Spring Boot container..."
             docker run -d \
               --name third-tool-server \

--- a/docs/adr/ADR013-gha-oidc-assume-role.md
+++ b/docs/adr/ADR013-gha-oidc-assume-role.md
@@ -1,0 +1,98 @@
+# ADR013: GitHub Actions → AWS 인증은 OIDC AssumeRole로 전환한다 (Story-046)
+
+- **상태**: Accepted
+- **날짜**: 2026-06-29
+- **관련**: Product 5 컨테이너 배포 Epic 3 (GHA OIDC → ECS 무중단 배포) · milestone item #10 (`workflow/task/milestones/version/0.0.1v/milestone.md`) · `docs/operations/troubleshooting/ts007-gha-oidc-setup.md` · `.github/workflows/dev-cicd.yml`
+
+## 컨텍스트
+
+`.github/workflows/dev-cicd.yml`은 ECR push를 위해 `aws-actions/configure-aws-credentials@v4` step에 `secrets.AWS_ACCESS_KEY_ID` · `secrets.AWS_SECRET_ACCESS_KEY`를 넘기는 IAM User access key 패턴을 사용 중이다. 이 패턴은 다음 한계를 가진다:
+
+- **long-lived 자격증명**: 회전(rotate) 작업이 정책 의지에 의존 → 실무에서 1~2년 방치 흔함
+- **노출 영향 큼**: GitHub Secret이 외부에 유출되면 AWS 리소스에 대한 무제한 시간 접근 허용 (TTL 없음). revoke까지 발견·조치 시간 동안 무방비
+- **GitHub Secrets에 영구 보관**: milestone "종료 신호 — 비밀 신호: GitHub Secrets 의존 0건" 요건과 직접 충돌
+- **branch별 권한 경계 부재**: 어떤 branch에서 워크플로 실행하든 동일한 IAM User 권한 사용 → fork PR · 임의 branch에서의 prod 자격증명 획득 가능 (current workflow는 `push: main`만 트리거이지만 IAM 수준 경계는 없음)
+
+`product-infra-deploy.md` KPI "GitHub Secrets에 저장된 AWS access key = 0" 목표 + milestone Tier 1 #10 "EC2 SSH 키 폐기 진입점"이 본 ADR의 의사결정 트리거다.
+
+## 결정
+
+**GitHub Actions → AWS 인증은 OIDC AssumeRoleWithWebIdentity로 단독 전환**한다.
+
+### 인증 흐름
+
+1. GitHub Actions runner가 workflow 시작 시 OIDC ID token 발급 (workflow에 `permissions: id-token: write` 명시 필수)
+2. workflow의 `aws-actions/configure-aws-credentials@v4` step이 `role-to-assume`만 입력으로 받음
+3. AWS STS가 OIDC token 검증 (issuer `token.actions.githubusercontent.com` + 신뢰 정책 `sub`/`aud` 조건 매치)
+4. 검증 성공 시 1시간 TTL 임시 자격증명 발급 → workflow에서 ECR push 등 수행
+
+### 신뢰 정책 sub 조건
+
+`gha-deploy-role` 신뢰 정책의 `Condition.StringLike."token.actions.githubusercontent.com:sub"`를 다음으로 잠근다:
+
+```
+repo:Third-tool/third-tool:ref:refs/heads/main
+```
+
+→ main branch에서의 workflow 실행만 허용. fork PR · 임의 branch에서의 prod 자격증명 획득 차단.
+
+### 권한 정책 최소화
+
+`gha-deploy-role`에 부여하는 inline policy는 현 ECR push 동작에 필요한 최소 actions만 포함:
+- `ecr:GetAuthorizationToken` (resource `*` — STS endpoint 호출용)
+- `ecr:BatchCheckLayerAvailability` · `BatchGetImage` · `GetDownloadUrlForLayer` · `InitiateLayerUpload` · `UploadLayerPart` · `CompleteLayerUpload` · `PutImage` (resource: `third-tool-server` · `third-tool-elaticsearch` 두 ECR repo로 한정)
+
+milestone #11 (ECS Task Def + Service) 이행 시 `ecs:UpdateService` · `iam:PassRole`을 동일 Role에 추가 — 별도 Story로 위임.
+
+### Account ID 노출 정책
+
+`vars.AWS_ACCOUNT_ID`를 GitHub Actions **Variable**(Secret 아님)로 등록. AWS 계정 ID는 CloudTrail 등에서 자연 노출되는 값이라 비밀이 아니며, workflow ARN(`arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/gha-deploy-role`) 가독성을 우선한다.
+
+### 본 ADR이 다루지 않는 범위
+
+- **EC2 컨테이너 → AWS S3 인증**: EC2 SSH 배포 step에서 `-e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=...` env var pass-through는 transitional 유지. 실제 제거는 milestone #11 ECS Task Role 이행 시.
+- **`S3Config.java`의 `StaticCredentialsProvider`**: Task Role 도입과 묶어 `DefaultCredentialsProvider`로 전환하는 별도 Story로 위임.
+- **staging IAM Role**: `refs/heads/develop` 잠금된 별도 Role은 환경 분리 Epic(Product 5 Epic 4)에서 추가.
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **GitHub Secrets에 저장된 AWS access key (workflow 측 의존) 0건**: milestone "비밀 신호" 요건의 선행 차단 항목 해결
+- **1시간 TTL 임시 자격증명**: 노출 시 영향 시간이 분~시간 단위로 줄어듦. revoke 자동 (시간 경과)
+- **Branch별 권한 경계**: sub 조건 잠금으로 fork PR · 임의 branch에서의 prod 자격증명 획득 원천 차단
+- **회전 운영 부담 0**: long-lived key 회전 절차·캘린더 불필요
+- **감사 추적 향상**: CloudTrail `AssumeRoleWithWebIdentity` 이벤트가 workflow run 1건당 1건으로 매핑 → IAM User access key 사용 시보다 훨씬 명확한 사용 이력
+
+### 트레이드오프 / 부정적
+
+- **AWS 콘솔 1회 셋업 비용**: OIDC Identity Provider 등록 + IAM Role 생성 + trust policy/permissions policy 입력 (수동, ~15분). ts007 runbook으로 절차 표준화.
+- **GitHub Enterprise Server 환경 사용 불가**: OIDC issuer는 `token.actions.githubusercontent.com` (GitHub.com)만 지원. self-hosted GHES는 별도 OIDC issuer 등록 필요 — 본 프로젝트는 GitHub.com 사용이라 비현실적 제약은 아님.
+- **`vars.AWS_ACCOUNT_ID` 미설정 시 ARN 깨짐**: workflow 신규 환경 deploy 시 한 단계 추가. ts007-4로 트러블슈팅 명시.
+- **EC2 SSH 배포 step의 access key 잔존**: workflow 측은 OIDC지만 컨테이너 env var pass-through에 access key가 남아 있어 milestone "GitHub Secrets 0건"은 #11까지 부분 달성 상태. 본 ADR의 명시적 follow-up 항목.
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **A. IAM User access key (기존)** | 친숙, 즉시 사용 가능 | long-lived 자격증명, 회전 의지 의존, branch 경계 부재, milestone "비밀 신호" 위반 |
+| **B. AssumeRoleWithSAML** | 기업 IdP 연동 시 가치 | GitHub Actions OIDC issuer 직접 신뢰 가능하므로 SAML 어셈블리 불필요. 운영 복잡도 증가 |
+| **C (선택). OIDC AssumeRoleWithWebIdentity** | TTL 1h, branch sub 잠금, 회전 0, CloudTrail 깔끔 | 1회 셋업 비용 + GHES 미지원 (본 프로젝트는 GitHub.com이므로 무영향) |
+| **D. AWS IAM Identity Center (SSO) + assume-role** | 인간 사용자에는 표준 | GitHub Actions runner는 사람이 아니므로 SSO 흐름 부적합. CI 자동화에 어색 |
+| **E. EC2 Instance Profile로 ECR push (현재 self-hosted runner 없음)** | OIDC 셋업 불요 | self-hosted runner 운영 부담이 OIDC 셋업 비용을 압도. 현 GitHub-hosted runner 정책과 충돌 |
+
+## 알려진 follow-up (본 ADR 범위 외)
+
+- **milestone #11 (ECS Task Definition + Service)**: 동일 `gha-deploy-role`에 `ecs:UpdateService` · `iam:PassRole(ecs-task-execution-role, ecs-task-role)` 추가. permissions policy JSON 확장.
+- **staging IAM Role 분리**: `refs/heads/develop` 잠금된 `gha-deploy-role-staging`을 환경 분리 Epic에서 생성. trust policy `sub` 조건이 prod와 다름.
+- **EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET env var pass-through 폐기**: milestone #11 ECS 이행 시점에 일괄. S3Config `DefaultCredentialsProvider` 전환과 함께.
+- **`S3Config.java` 리팩터링**: `StaticCredentialsProvider` 제거 + `DefaultCredentialsProvider.create()`로 전환. ECS Task Role 도입 시 자동 픽업.
+- **GitHub Secrets `AWS_ACCESS_KEY_ID/SECRET` 영구 삭제**: 위 두 follow-up 완료 후 GitHub repo Settings에서 직접 삭제. 그 시점에 ts007 §6 갱신.
+- **GCP Workload Identity Federation (Spring AI Gemini용)**: ECS Task Role이 `sts:AssumeRoleWithWebIdentity`로 GCP 인증하는 패턴은 Product 7 (Secrets·Terraform)에서 구체화.
+
+## 다시 검토할 시점
+
+- **GHES로 이전하는 시점**: GitHub Enterprise Server 도입 시 OIDC issuer 변경 필요 → trust policy 재작성.
+- **multi-account 운영 시점**: 현재 단일 AWS 계정. dev/prod 계정 분리 시 `gha-deploy-role`을 prod 계정에 두고 dev에서 cross-account AssumeRole 패턴 추가 필요.
+- **OIDC sub claim 형식 변경 시점**: GitHub Actions의 OIDC token claim 구조 변경 가능성. 정책 검토 주기 6~12개월.
+- **CodeBuild/CodePipeline 도입 시점**: GHA를 대체하거나 병행하면 OIDC issuer를 codebuild로 분기.

--- a/docs/adr/ADR013-gha-oidc-assume-role.md
+++ b/docs/adr/ADR013-gha-oidc-assume-role.md
@@ -28,13 +28,13 @@
 
 ### 신뢰 정책 sub 조건
 
-`gha-deploy-role` 신뢰 정책의 `Condition.StringLike."token.actions.githubusercontent.com:sub"`를 다음으로 잠근다:
+`gha-deploy-role` 신뢰 정책의 `Condition.StringEquals."token.actions.githubusercontent.com:sub"`를 다음으로 잠근다:
 
 ```
-repo:Third-tool/third-tool:ref:refs/heads/main
+repo:Third-tool/third-tool-backend:ref:refs/heads/main
 ```
 
-→ main branch에서의 workflow 실행만 허용. fork PR · 임의 branch에서의 prod 자격증명 획득 차단.
+→ main branch에서의 workflow 실행만 허용. fork PR · 임의 branch에서의 prod 자격증명 획득 차단. `StringEquals` 사용(`StringLike` 아님)은 와일드카드 미포함 정책에서 정확 매치가 가능하기 때문 — AWS IAM best practice.
 
 ### 권한 정책 최소화
 
@@ -42,7 +42,7 @@ repo:Third-tool/third-tool:ref:refs/heads/main
 - `ecr:GetAuthorizationToken` (resource `*` — STS endpoint 호출용)
 - `ecr:BatchCheckLayerAvailability` · `BatchGetImage` · `GetDownloadUrlForLayer` · `InitiateLayerUpload` · `UploadLayerPart` · `CompleteLayerUpload` · `PutImage` (resource: `third-tool-server` · `third-tool-elaticsearch` 두 ECR repo로 한정)
 
-milestone #11 (ECS Task Def + Service) 이행 시 `ecs:UpdateService` · `iam:PassRole`을 동일 Role에 추가 — 별도 Story로 위임.
+milestone 0.0.1v item #11 (ECS Task Def + Service) 이행 시 `ecs:UpdateService` · `iam:PassRole`을 동일 Role에 추가 — 별도 Story로 위임.
 
 ### Account ID 노출 정책
 
@@ -50,7 +50,7 @@ milestone #11 (ECS Task Def + Service) 이행 시 `ecs:UpdateService` · `iam:Pa
 
 ### 본 ADR이 다루지 않는 범위
 
-- **EC2 컨테이너 → AWS S3 인증**: EC2 SSH 배포 step에서 `-e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=...` env var pass-through는 transitional 유지. 실제 제거는 milestone #11 ECS Task Role 이행 시.
+- **EC2 컨테이너 → AWS S3 인증**: EC2 SSH 배포 step에서 `-e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=...` env var pass-through는 transitional 유지. 실제 제거는 milestone 0.0.1v item #11 ECS Task Role 이행 시.
 - **`S3Config.java`의 `StaticCredentialsProvider`**: Task Role 도입과 묶어 `DefaultCredentialsProvider`로 전환하는 별도 Story로 위임.
 - **staging IAM Role**: `refs/heads/develop` 잠금된 별도 Role은 환경 분리 Epic(Product 5 Epic 4)에서 추가.
 
@@ -83,9 +83,9 @@ milestone #11 (ECS Task Def + Service) 이행 시 `ecs:UpdateService` · `iam:Pa
 
 ## 알려진 follow-up (본 ADR 범위 외)
 
-- **milestone #11 (ECS Task Definition + Service)**: 동일 `gha-deploy-role`에 `ecs:UpdateService` · `iam:PassRole(ecs-task-execution-role, ecs-task-role)` 추가. permissions policy JSON 확장.
+- **milestone 0.0.1v item #11 (ECS Task Definition + Service)**: 동일 `gha-deploy-role`에 `ecs:UpdateService` · `iam:PassRole(ecs-task-execution-role, ecs-task-role)` 추가. permissions policy JSON 확장.
 - **staging IAM Role 분리**: `refs/heads/develop` 잠금된 `gha-deploy-role-staging`을 환경 분리 Epic에서 생성. trust policy `sub` 조건이 prod와 다름.
-- **EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET env var pass-through 폐기**: milestone #11 ECS 이행 시점에 일괄. S3Config `DefaultCredentialsProvider` 전환과 함께.
+- **EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET env var pass-through 폐기**: milestone 0.0.1v item #11 ECS 이행 시점에 일괄. S3Config `DefaultCredentialsProvider` 전환과 함께.
 - **`S3Config.java` 리팩터링**: `StaticCredentialsProvider` 제거 + `DefaultCredentialsProvider.create()`로 전환. ECS Task Role 도입 시 자동 픽업.
 - **GitHub Secrets `AWS_ACCESS_KEY_ID/SECRET` 영구 삭제**: 위 두 follow-up 완료 후 GitHub repo Settings에서 직접 삭제. 그 시점에 ts007 §6 갱신.
 - **GCP Workload Identity Federation (Spring AI Gemini용)**: ECS Task Role이 `sts:AssumeRoleWithWebIdentity`로 GCP 인증하는 패턴은 Product 7 (Secrets·Terraform)에서 구체화.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -14,3 +14,4 @@
 | [ADR010](ADR010.md) | AI 제안 호출 실패는 5xx 미노출 — 빈 목록 + suggestionsAvailable 플래그로 변환 | Accepted | 2026-06-22 |
 | [ADR011](ADR011.md) | MDC 화이트리스트에 errorCode 키를 추가한다 (Story 3-1) | Accepted | 2026-06-23 |
 | [ADR012](ADR012.md) | 운영 컨테이너 base image `eclipse-temurin:21-jre-alpine` 채택, Distroless 보류 (Story 1-1) | Accepted | 2026-06-25 |
+| [ADR013](ADR013-gha-oidc-assume-role.md) | GitHub Actions → AWS 인증을 OIDC AssumeRole로 전환 (Story-046) | Accepted | 2026-06-29 |

--- a/docs/operations/troubleshooting/ts007-gha-oidc-setup.md
+++ b/docs/operations/troubleshooting/ts007-gha-oidc-setup.md
@@ -1,0 +1,186 @@
+# ts007: GHA OIDC AssumeRole 1회성 셋업·검증·트러블슈팅
+
+Story-046로 `.github/workflows/dev-cicd.yml`이 `secrets.AWS_ACCESS_KEY_ID/SECRET` 대신 OIDC AssumeRole 패턴으로 전환됐다. 본 가이드는 AWS 콘솔 측 1회성 셋업 절차 + 검증 + 자주 보는 에러 5건을 한 곳에 모았다.
+
+ts005(Dockerfile)·ts006(로컬 실행)과 cross-link. 본 절차는 repository 합당 권한자(또는 1인 운영자) 1회만 실행하면 됨.
+
+---
+
+## 1. 전제
+
+- AWS 콘솔 IAM 관리 권한 (`iam:CreateOpenIDConnectProvider` · `iam:CreateRole` · `iam:PutRolePolicy`)
+- GitHub repository `Third-tool/third-tool` Settings 접근 권한 (Actions Variables 등록)
+- repository 코드에 `infra/iam/gha-deploy-role-trust-policy.json` + `gha-deploy-role-permissions-policy.json` 존재 확인 (Story-046 머지 후)
+
+---
+
+## 2. AWS 콘솔 — OIDC Identity Provider 생성
+
+AWS 계정당 **1회만**. 이미 다른 GHA workflow에서 등록한 적이 있으면 skip.
+
+1. AWS 콘솔 → **IAM** → **Identity providers** → **Add provider**
+2. Provider type: **OpenID Connect**
+3. Provider URL: `https://token.actions.githubusercontent.com`
+4. **Get thumbprint** 클릭 → 자동 fetch (현재 AWS는 thumbprint 검증을 더 이상 강제하지 않지만 콘솔 입력은 필수)
+5. Audience: `sts.amazonaws.com`
+6. **Add provider** 클릭
+
+생성된 Provider ARN 예: `arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com`
+
+---
+
+## 3. AWS 콘솔 — `gha-deploy-role` IAM Role 생성
+
+1. AWS 콘솔 → **IAM** → **Roles** → **Create role**
+2. Trusted entity type: **Custom trust policy**
+3. Custom trust policy 입력란에 **`infra/iam/gha-deploy-role-trust-policy.json` 내용 붙여넣기**
+   - **`<AWS_ACCOUNT_ID>` 12자리 자기 계정 ID로 치환** (콘솔 우측 상단에서 확인)
+4. Permission policies: 다음 단계에서 별도 정의 (skip)
+5. Role name: `gha-deploy-role`
+6. **Create role** 클릭
+7. 생성된 Role 상세 → **Permissions** → **Add permissions** → **Create inline policy** → JSON
+8. **`infra/iam/gha-deploy-role-permissions-policy.json` 내용 붙여넣기** + `<AWS_ACCOUNT_ID>` 치환
+9. Policy name: `gha-deploy-role-permissions`
+10. **Create policy** 클릭
+
+---
+
+## 4. GitHub repo Settings — `AWS_ACCOUNT_ID` Variable 등록
+
+1. GitHub repo `Third-tool/third-tool` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
+2. **New repository variable** 클릭
+3. Name: `AWS_ACCOUNT_ID`
+4. Value: 12자리 AWS 계정 ID (Secret이 아닌 Variable — 비밀 아님)
+5. **Add variable** 클릭
+
+> Variable로 등록하는 이유: AWS Account ID는 비밀이 아님 (CloudTrail 등에서 노출). 비밀이 아닌 값은 `secrets.*`가 아니라 `vars.*`로 관리하는 것이 GitHub Actions 권장 패턴.
+
+---
+
+## 5. 검증
+
+### 5.1 workflow_dispatch 트리거 (Elasticsearch 이미지 빌드)
+
+```bash
+gh workflow run dev-cicd.yml --ref main -f build_es=true
+```
+
+또는 GitHub 콘솔 → Actions → Deploy To EC2 → Run workflow → `build_es=true` 체크 → Run.
+
+이 시도는 OIDC 인증 + ECR push만 검증하고 EC2 SSH 배포는 발생 안 함.
+
+### 5.2 GHA workflow 로그 확인
+
+`Configure AWS credentials (OIDC)` step 출력에서 다음 라인 확인:
+
+```
+Configuring AWS credentials...
+Assuming role with OIDC
+Authenticated as assumedRoleId: AROA...:GitHubActions
+```
+
+`AccessDenied` 또는 `Could not retrieve OIDC token` 발생 시 §6 트러블슈팅.
+
+### 5.3 CloudTrail에서 AssumeRoleWithWebIdentity 이벤트 확인
+
+AWS 콘솔 → **CloudTrail** → **Event history** → Filter: `Event name = AssumeRoleWithWebIdentity`
+
+직전 GHA run 시각에 1건 이벤트가 떠야 한다. 상세에서:
+- `userIdentity.principalId`에 `token.actions.githubusercontent.com` 포함
+- `requestParameters.roleArn`이 `arn:aws:iam::<ACCT>:role/gha-deploy-role`
+- `responseElements.assumedRoleUser.assumedRoleId`로 임시 자격증명 발급 확인
+
+### 5.4 ECR push 검증
+
+`Build and Push ES Image` step이 성공하면 push가 발생한 것. AWS 콘솔 → **ECR** → `third-tool-elaticsearch` 리포 → 최신 image tag 시각 확인.
+
+---
+
+## 6. GitHub Secrets `AWS_ACCESS_KEY_ID/SECRET` 제거 시점
+
+- **즉시 제거 가능한 부분**: 없음. workflow 측은 OIDC로 전환됐지만 **EC2 SSH 배포 step**의 컨테이너 env var pass-through(`-e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" ...`)에서 여전히 참조.
+- **완전 제거 시점**: milestone #11 (ECS Task Definition + Service) 이행 + S3Config가 `StaticCredentialsProvider` → `DefaultCredentialsProvider`로 전환된 이후. 그 시점에 EC2 SSH 배포 step 자체가 폐기 → 두 GitHub Secret 영구 삭제.
+- 그 전까지는 Variable `AWS_ACCOUNT_ID` + Secret `AWS_ACCESS_KEY_ID/SECRET` **공존** 상태가 정상.
+
+---
+
+## 7. 트러블슈팅
+
+### ts007-1: `Not authorized to perform sts:AssumeRoleWithWebIdentity`
+
+**원인**: 신뢰 정책 `sub` 조건이 실제 GHA workflow context와 불일치.
+- repo 슬러그 오타 (`Third-tool/third-tool` 대문자/하이픈 정확)
+- branch 다름 (main 외 branch에서 워크플로 실행했는데 신뢰 정책은 `refs/heads/main`만 허용)
+- `aud` 조건 불일치 (`sts.amazonaws.com` 아닌 다른 값)
+
+**해결**:
+1. CloudTrail `AssumeRoleWithWebIdentity` 이벤트 상세에서 `requestParameters.subjectFromWebIdentityToken` 값 확인
+2. trust policy `sub` 조건과 정확히 매치하는지 검토 (`StringLike`이므로 와일드카드 사용 시 패턴 점검)
+3. 핫픽스 branch 등 main 외에서 배포 필요 시 staging Role을 별도로 만드는 것이 정석 (Story-046은 main 잠금 의도)
+
+**검증**: 수정 후 §5.1 재실행 → §5.3 CloudTrail에서 새 이벤트 successful 확인.
+
+### ts007-2: `Could not assume role with OIDC: AccessDenied`
+
+**원인**: AWS 계정에 OIDC Identity Provider가 등록 안 됨 또는 ARN 불일치.
+
+**해결**:
+1. AWS 콘솔 → IAM → Identity providers → `token.actions.githubusercontent.com` 존재 확인
+2. 없으면 §2 절차로 등록
+3. Provider ARN이 신뢰 정책 `Principal.Federated` 값과 정확히 일치하는지 비교 (`<AWS_ACCOUNT_ID>` 치환 누락 여부)
+
+### ts007-3: `Error: Could not retrieve OIDC token`
+
+**원인**: workflow 또는 job 레벨에 `permissions: id-token: write` 누락. workflow runner가 OIDC token 발급 자체를 못 함.
+
+**해결**: `.github/workflows/dev-cicd.yml` 상단 `permissions:` 블록에 `id-token: write` 명시 (Story-046 적용 상태 — 본 에러 발생 시 머지 후 브랜치 stale 의심).
+
+**검증**:
+```bash
+grep -A2 '^permissions:' .github/workflows/dev-cicd.yml
+# 기대 출력: id-token: write
+```
+
+### ts007-4: `vars.AWS_ACCOUNT_ID` 미설정 → 빈 ARN → AssumeRole 실패
+
+GHA workflow 로그에서 다음 형태:
+```
+role-to-assume: arn:aws:iam:::role/gha-deploy-role
+                              ^^ 빈 account id
+```
+
+**원인**: §4 GitHub Variables에 `AWS_ACCOUNT_ID` 미등록. `vars.AWS_ACCOUNT_ID`가 빈 문자열로 해석돼 ARN이 깨짐.
+
+**해결**: §4 절차로 Variable 등록 → workflow 재실행.
+
+**검증**: workflow 로그에서 `role-to-assume: arn:aws:iam::123456789012:role/...` 형태 정상 ARN 확인 (Variable은 로그에 마스킹 없이 출력 — 비밀 아님).
+
+### ts007-5: ECR push 시 `denied: ... ecr:PutImage` 권한 부족
+
+**원인**: `gha-deploy-role` permissions 정책의 `Resource`가 실제 ECR repository ARN과 불일치.
+
+**해결**:
+1. `infra/iam/gha-deploy-role-permissions-policy.json` `Resource` 라인에서 repo 이름 확인 (`third-tool-server`, `third-tool-elaticsearch`)
+2. AWS 콘솔 → ECR → 리포 목록에서 실제 이름과 정확 매치 확인 (오타 포함 — `third-tool-elaticsearch` 그대로)
+3. `<AWS_ACCOUNT_ID>` 치환이 됐는지 확인 (AWS 콘솔 IAM Role policy 탭에서 직접 본 값으로 비교)
+4. 다른 region에 리포가 있다면 region prefix(`ap-northeast-2`) 확인
+
+---
+
+## 8. 후속 (별도 Story)
+
+- **`ecs:UpdateService` · `iam:PassRole` 권한 추가** — milestone #11 (Task Definition + Service)에서 동일 `gha-deploy-role` 정책 확장
+- **staging IAM Role 분리** — `refs/heads/develop` 잠금된 별도 Role, 환경 분리 Epic
+- **EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET env var 제거** — milestone #11 이후
+- **`S3Config.java` → `DefaultCredentialsProvider` 전환** — ECS Task Role 도입과 함께
+- **`workflow_dispatch`로 무인 검증 step 추가** — `aws sts get-caller-identity` 호출만 하는 dry-run job. 1회성 셋업 검증용 (옵션)
+
+---
+
+## 관련
+
+- [`ts005-dockerfile-build.md`](ts005-dockerfile-build.md) — 본 OIDC 적용된 workflow가 빌드하는 이미지
+- [`ts006-local-run-checklist.md`](ts006-local-run-checklist.md) — 로컬 IAM 사용자 access key 발급 (개발자 본인용, 본 OIDC와 별도)
+- [ADR013](../../adr/ADR013-gha-oidc-assume-role.md) — GHA OIDC AssumeRole 결정 배경 + 대안 비교
+- Story-046 — milestone item #10. `workflow/task/milestones/version/0.0.1v/milestone.md`
+- 후속: milestone #11 (ECS Task Def + Service)에서 동일 Role에 `ecs:*` 권한 추가

--- a/docs/operations/troubleshooting/ts007-gha-oidc-setup.md
+++ b/docs/operations/troubleshooting/ts007-gha-oidc-setup.md
@@ -9,7 +9,7 @@ ts005(Dockerfile)·ts006(로컬 실행)과 cross-link. 본 절차는 repository 
 ## 1. 전제
 
 - AWS 콘솔 IAM 관리 권한 (`iam:CreateOpenIDConnectProvider` · `iam:CreateRole` · `iam:PutRolePolicy`)
-- GitHub repository `Third-tool/third-tool` Settings 접근 권한 (Actions Variables 등록)
+- GitHub repository `Third-tool/third-tool-backend` Settings 접근 권한 (Actions Variables 등록)
 - repository 코드에 `infra/iam/gha-deploy-role-trust-policy.json` + `gha-deploy-role-permissions-policy.json` 존재 확인 (Story-046 머지 후)
 
 ---
@@ -43,11 +43,13 @@ AWS 계정당 **1회만**. 이미 다른 GHA workflow에서 등록한 적이 있
 9. Policy name: `gha-deploy-role-permissions`
 10. **Create policy** 클릭
 
+> **치환 누락 검증 (필수)**: 두 JSON 모두 콘솔에 붙여넣기 **직전에** `<` 문자가 0건임을 시각 확인. `<AWS_ACCOUNT_ID>` 그대로 콘솔에 입력 시 AWS가 invalid ARN으로 거부 → Role/Policy 생성 자체가 실패. (CLI 사용 시: `grep -c '<' /tmp/role-policy.json` → 0이어야 함)
+
 ---
 
 ## 4. GitHub repo Settings — `AWS_ACCOUNT_ID` Variable 등록
 
-1. GitHub repo `Third-tool/third-tool` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
+1. GitHub repo `Third-tool/third-tool-backend` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
 2. **New repository variable** 클릭
 3. Name: `AWS_ACCOUNT_ID`
 4. Value: 12자리 AWS 계정 ID (Secret이 아닌 Variable — 비밀 아님)
@@ -90,9 +92,29 @@ AWS 콘솔 → **CloudTrail** → **Event history** → Filter: `Event name = As
 - `requestParameters.roleArn`이 `arn:aws:iam::<ACCT>:role/gha-deploy-role`
 - `responseElements.assumedRoleUser.assumedRoleId`로 임시 자격증명 발급 확인
 
-### 5.4 ECR push 검증
+### 5.4 ECR push 검증 + 리포명 정합성
 
 `Build and Push ES Image` step이 성공하면 push가 발생한 것. AWS 콘솔 → **ECR** → `third-tool-elaticsearch` 리포 → 최신 image tag 시각 확인.
+
+> **리포명 오타 주의**: `infra/iam/gha-deploy-role-permissions-policy.json`의 `Resource`와 `dev-cicd.yml`의 docker push tag가 **`third-tool-elaticsearch`** (오타 — "elasticsearch"가 아님)로 일치돼 있다. 실제 AWS ECR 리포 이름과 정확히 매치되는지 사전 확인:
+> ```bash
+> aws ecr describe-repositories --region ap-northeast-2 \
+>   | jq -r '.repositories[].repositoryName' | sort
+> ```
+> 출력에 `third-tool-elaticsearch`가 그대로 있으면 OK. `third-tool-elasticsearch`(정확 철자)로 존재하면 ECR 리포 이름과 정책/workflow 양쪽 정합성 정정 필요 — 별도 Story로 분리.
+
+### 5.5 End-to-end 검증 (main branch push 배포)
+
+§5.1-5.4는 ECR push까지만 검증한다. EC2 SSH 배포 step + 컨테이너 부팅 + S3 접근까지의 end-to-end는 **main branch 실제 push로만** 검증된다:
+
+1. small one-line change(예: README 1줄)로 main push trigger
+2. GHA workflow 로그에서 `Configure AWS credentials (OIDC)` step 성공 (§5.2 동일)
+3. `Push to Amazon ECR` step 성공
+4. `Deploy to EC2 via SSH` step에서 `🎉 Deployment Success!` 라인 확인
+5. `curl https://<dev-domain>/health` 200 OK (또는 EC2 host:8080)
+6. EC2 컨테이너 안에서 S3 접근 동작 확인 — 파일 업로드 endpoint 호출 1회 (transitional env var pass-through가 정상 작동하는지)
+
+본 5단계 통과해야 Story-046이 진짜로 끝난 것. §5.1-5.4까지만 통과 후 머지하면 EC2 배포 회귀를 catch 못 함.
 
 ---
 
@@ -109,7 +131,7 @@ AWS 콘솔 → **CloudTrail** → **Event history** → Filter: `Event name = As
 ### ts007-1: `Not authorized to perform sts:AssumeRoleWithWebIdentity`
 
 **원인**: 신뢰 정책 `sub` 조건이 실제 GHA workflow context와 불일치.
-- repo 슬러그 오타 (`Third-tool/third-tool` 대문자/하이픈 정확)
+- repo 슬러그 오타 (`Third-tool/third-tool-backend` 대문자/하이픈 정확)
 - branch 다름 (main 외 branch에서 워크플로 실행했는데 신뢰 정책은 `refs/heads/main`만 허용)
 - `aud` 조건 불일치 (`sts.amazonaws.com` 아닌 다른 값)
 
@@ -164,6 +186,26 @@ role-to-assume: arn:aws:iam:::role/gha-deploy-role
 2. AWS 콘솔 → ECR → 리포 목록에서 실제 이름과 정확 매치 확인 (오타 포함 — `third-tool-elaticsearch` 그대로)
 3. `<AWS_ACCOUNT_ID>` 치환이 됐는지 확인 (AWS 콘솔 IAM Role policy 탭에서 직접 본 값으로 비교)
 4. 다른 region에 리포가 있다면 region prefix(`ap-northeast-2`) 확인
+
+### ts007-6: EC2 배포 step에서 `AWS_ACCESS_KEY_ID/SECRET` 빈 값 → S3 인증 실패
+
+GHA workflow 로그에서 EC2 step은 성공했으나, EC2 컨테이너 로그에서:
+```
+software.amazon.awssdk.services.s3.model.S3Exception: The AWS Access Key Id you provided does not exist (Status Code: 403)
+```
+또는 부팅 단계에서:
+```
+Could not resolve placeholder 'AWS_ACCESS_KEY_ID'
+```
+
+**원인**: GitHub repo Settings에서 `AWS_ACCESS_KEY_ID` 또는 `AWS_SECRET_ACCESS_KEY` Secret이 **이미 삭제됨**. Story-046 머지 후 milestone "비밀 신호" 달성 의도로 선제 삭제했지만, EC2 컨테이너 step이 여전히 두 Secret을 참조 중 → 빈 값 주입.
+
+**해결**:
+1. GitHub repo Settings → Secrets and variables → Actions → Secrets tab에서 `AWS_ACCESS_KEY_ID` · `AWS_SECRET_ACCESS_KEY` 존재 여부 확인
+2. 없으면 §6 가이드대로 milestone 0.0.1v item #11 (ECS Task Role) 이행 **전까지는 보존** — 두 Secret을 다시 등록
+3. milestone item #11 머지 + S3Config가 `DefaultCredentialsProvider`로 전환 + EC2 SSH 배포 step 제거 완료 후에 영구 삭제
+
+**검증**: ts006 §6 (진단 정보 수집)의 환경변수 length 확인 명령 EC2 host에서 실행. length 0이면 Secret 미주입 상태.
 
 ---
 

--- a/infra/iam/gha-deploy-role-permissions-policy.json
+++ b/infra/iam/gha-deploy-role-permissions-policy.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuthToken",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrPushPull",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": [
+        "arn:aws:ecr:ap-northeast-2:<AWS_ACCOUNT_ID>:repository/third-tool-server",
+        "arn:aws:ecr:ap-northeast-2:<AWS_ACCOUNT_ID>:repository/third-tool-elaticsearch"
+      ]
+    }
+  ]
+}

--- a/infra/iam/gha-deploy-role-trust-policy.json
+++ b/infra/iam/gha-deploy-role-trust-policy.json
@@ -10,10 +10,8 @@
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-        },
-        "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:Third-tool/third-tool:ref:refs/heads/main"
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:Third-tool/third-tool-backend:ref:refs/heads/main"
         }
       }
     }

--- a/infra/iam/gha-deploy-role-trust-policy.json
+++ b/infra/iam/gha-deploy-role-trust-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowGitHubActionsAssumeRoleViaOIDC",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:Third-tool/third-tool:ref:refs/heads/main"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 개요

GitHub Actions → AWS 인증을 `secrets.AWS_ACCESS_KEY_ID/SECRET` (long-lived IAM User access key)에서 **OIDC AssumeRoleWithWebIdentity** 패턴으로 전환한다. milestone 0.0.1v item #10 "5 ECS 2-1 GHA OIDC AssumeRole + Workload Identity" 충족.

## 왜 / 설계 결정

- **long-lived 자격증명 폐기**: GitHub Secrets에 영구 보관된 access key는 회전이 의지에 의존하고 노출 시 영향이 영구적. OIDC는 1시간 TTL 임시 자격증명을 STS가 발급 → 노출 영향 시간 압축
- **branch sub 잠금**: 신뢰 정책에 `sub: repo:Third-tool/third-tool-backend:ref:refs/heads/main` 명시(`StringEquals`) → fork PR · 임의 branch에서의 prod 자격증명 획득 원천 차단
- **transitional 범위 한정**: workflow → AWS 인증 경로만 OIDC 전환. EC2 SSH 배포 step의 컨테이너 env var pass-through(`AWS_ACCESS_KEY_ID/SECRET`)는 follow-up Story(milestone 0.0.1v item #11, ECS Task Role 이행)에서 일괄 제거. ADR013 §결과 트레이드오프 + ts007 §6에 gap 명시
- **fail-fast 가드**: workflow 첫 step에 `vars.AWS_ACCOUNT_ID` 미설정 시 즉시 명시적 에러 — 빈 ARN으로 AssumeRole까지 가지 않음 (Reviewer Sceptical C-1 보강)

ADR013 본문에 대안 5종(IAM User key · SAML · OIDC · Identity Center · Instance Profile) 비교 + follow-up 6건 명시.

## 작업 내용

- **feat(infra)**: `.github/workflows/dev-cicd.yml` — `permissions: id-token: write` + `Verify OIDC prerequisites` fail-fast + 두 job의 `Configure AWS credentials` step OIDC 전환
- **feat(infra)**: `infra/iam/gha-deploy-role-trust-policy.json` (신규) — OIDC Federated principal + sub/aud 잠금
- **feat(infra)**: `infra/iam/gha-deploy-role-permissions-policy.json` (신규) — ECR push 최소 권한 7 actions, 두 ECR repo 한정
- **docs(operations)**: `docs/operations/troubleshooting/ts007-gha-oidc-setup.md` (신규, 228줄) — AWS 콘솔 1회 셋업 절차 + 검증 5장 + 트러블슈팅 6건(ts007-1~6)
- **docs(adr)**: `docs/adr/ADR013-gha-oidc-assume-role.md` (신규) + `docs/adr/index.md` 행 추가
- **fix(infra)**: Reviewer 5관점 지적 보강 — Critical 2건(슬러그 정정·fail-fast 가드) + Major 5건(StringEquals·TODO 명시화·치환 검증·E2E 검증·secret 시나리오 트러블슈팅)

## 변경 유형

- [x] feat  - [x] fix  - [ ] refactor  - [x] docs  - [ ] test  - [x] chore

## 테스트

- `jq . infra/iam/gha-deploy-role-trust-policy.json` → OK
- `jq . infra/iam/gha-deploy-role-permissions-policy.json` → OK
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/dev-cicd.yml', encoding='utf-8'))"` → OK
- 자바 코드 0줄 변경 — 단위/슬라이스 테스트 추가 의무 없음 (conventions §4.8 트리거 적용 불가)
- **end-to-end 검증은 사용자 영역** — AWS 콘솔에서 ts007 §2-4 (OIDC Provider + IAM Role + GitHub Variables) 1회 셋업 완료 후 `gh workflow run dev-cicd.yml --ref main -f build_es=true`로 검증 → CloudTrail `AssumeRoleWithWebIdentity` 이벤트 1건 + ECR push 시각 확인 (ts007 §5)

## 체크리스트

- [x] 빌드 / 테스트 통과 (자바 코드 무변경 — sanity)
- [x] 모든 응답 `ApiResponse<T>` 래퍼 + `ApiResponses` 헬퍼 사용 — N/A (API 변경 없음)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — ADR013 신규 + index 갱신
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 — N/A
- [x] BC 간 의존 방향 위반 없음 — N/A (인프라 변경)
- [x] 대상 브랜치 = `develop` 확인

## 머지 전 필독 (사용자 작업)

**본 PR 머지 즉시 main push 시점에 다음 셋업이 끝나 있어야 합니다** (없으면 첫 main push 배포 실패):

1. AWS 콘솔 → IAM → Identity providers에 `token.actions.githubusercontent.com` 등록 (ts007 §2)
2. AWS 콘솔 → IAM → `gha-deploy-role` Role 생성 + 두 JSON 정책 입력 + `<AWS_ACCOUNT_ID>` 치환 (ts007 §3)
3. GitHub repo Settings → Actions Variables → `AWS_ACCOUNT_ID` 12자리 등록 (ts007 §4)

위 3건 미완 상태에서 머지하면 fail-fast 가드가 `AWS_ACCOUNT_ID GitHub Variable not set — see docs/operations/troubleshooting/ts007-gha-oidc-setup.md §4` 메시지로 첫 step에서 워크플로 fail. 깨끗한 에러로 멈춤이지 영구 손상 없음.

## 관련 이슈

- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-infra-deploy.md` (Epic 3 Story 3-1 일부)
- Milestone: `workflow/task/milestones/version/0.0.1v/milestone.md` item #10
- Story: Story-046
- ADR: ADR013

## 후속 Story (별도 PR)

- milestone 0.0.1v item #11 (ECS Task Definition + Service) — 동일 `gha-deploy-role`에 `ecs:UpdateService` · `iam:PassRole` 권한 추가
- EC2 SSH 배포 + AWS_ACCESS_KEY_ID/SECRET env var 폐기 — ECS 이행 시점
- `S3Config.java` `StaticCredentialsProvider` → `DefaultCredentialsProvider` 전환 — Task Role 도입과 함께
- staging IAM Role 분리 (`refs/heads/develop` 잠금) — 환경 분리 Epic