### PR TITLE
feat(infra): Story-047 ECS Task Definition + Service + IAM Role 3종 + ADR014 + ts008

### DIFF
--- a/docs/adr/ADR014-ecs-task-iam-role-separation.md
+++ b/docs/adr/ADR014-ecs-task-iam-role-separation.md
@@ -1,0 +1,93 @@
+# ADR014: ECS Task IAM Role을 Execution / Task / GHA Deploy 3종으로 분리한다 (Story-047)
+
+- **상태**: Accepted
+- **날짜**: 2026-06-29
+- **관련**: Product 5 컨테이너 배포 Epic 2 (ECS Fargate 런타임) · milestone 0.0.1v item #11 (`workflow/task/milestones/version/0.0.1v/milestone.md`) · `docs/operations/troubleshooting/ts008-ecs-cluster-setup.md` · `infra/iam/ecs-task-*-role-*.json` · ADR013 (GHA OIDC AssumeRole)
+
+## 컨텍스트
+
+milestone item #11에서 ECS Fargate Task를 정의·실행하려면 **IAM Role이 최소 3종 필요**하다. AWS ECS의 권한 모델 자체가 다음을 분리한다:
+
+- **ECS Agent (`ecs-tasks.amazonaws.com`)가 Task 시작 전에 사용**: ECR pull · CloudWatch Logs stream 생성 · Secrets Manager 시크릿 fetch
+- **Task 안의 컨테이너 코드가 런타임에 사용**: S3 · 외부 AWS API 호출
+- **GitHub Actions runner가 외부에서 사용 (Story-046)**: ECR push · ECS Service update · `iam:PassRole`
+
+이 셋을 단일 Role로 통합하면 **컨테이너 침해 시 권한 확대 위험**이 발생한다. 예:
+- ECS 에이전트와 컨테이너 코드 권한이 합쳐지면 → 컨테이너에서 임의 ECR repo에 image push 가능
+- GHA와 Task 권한이 합쳐지면 → 컨테이너에서 자기 자신을 다른 Task Definition으로 update 가능
+
+product-infra-deploy.md Epic 2 §"핵심 설계 결정"에서 IAM Role 3종 분리를 권고하고, ADR013(OIDC) follow-up에서 본 ADR을 예고했다.
+
+## 결정
+
+**ECS 운영에 사용되는 IAM Role을 3종으로 분리**한다:
+
+| Role | 신뢰 주체 | 사용 시점 | 권한 |
+| --- | --- | --- | --- |
+| `gha-deploy-role` | GHA OIDC Provider (ADR013) | workflow 실행 중 | ECR push · ECS RegisterTaskDefinition/UpdateService · `iam:PassRole`(두 Task Role 한정) |
+| `ecs-task-execution-role` | `ecs-tasks.amazonaws.com` | Task 시작 전 (ECS 에이전트) | ECR pull (두 repo 한정) · CloudWatch Logs 쓰기 (두 group 한정) · Secrets Manager read (`thirdtool/{prod,staging}/*` prefix 한정) |
+| `ecs-task-role` | `ecs-tasks.amazonaws.com` | 컨테이너 코드 런타임 | S3 (`third-tool-s3-server` 한정) · SSM Messages (ECS Exec 채널) |
+
+### 핵심 권한 경계
+
+1. **`gha-deploy-role`의 `iam:PassRole`은 두 Task Role ARN으로 정확히 한정** + Condition `iam:PassedToService = ecs-tasks.amazonaws.com`:
+   - 다른 ARN의 Role을 ECS Task에 PassRole 차단
+   - 다른 서비스(`ec2.amazonaws.com`, `lambda.amazonaws.com` 등)에 PassRole 차단
+
+2. **`ecs-task-execution-role`과 `ecs-task-role`은 동일 신뢰 주체(`ecs-tasks.amazonaws.com`)지만 별도 Role**:
+   - AWS ECS가 이 둘을 의도적으로 분리 사용 — Execution Role은 컨테이너 *밖*(에이전트)에서, Task Role은 컨테이너 *안*(애플리케이션)에서
+   - 합치면 컨테이너 안에서 ECR/Logs 쓰기 권한 노출
+
+3. **각 Role의 권한이 resource ARN으로 한정**:
+   - Execution Role의 Secrets Manager read는 `thirdtool/prod/*` + `thirdtool/staging/*`만 (다른 시크릿 차단)
+   - Task Role의 S3는 `third-tool-s3-server` bucket만 (다른 버킷 차단)
+
+### 본 ADR이 다루지 않는 범위
+
+- **GCP Workload Identity Federation**: Spring AI Gemini용 Task Role의 GCP 인증은 Product 7 (Secrets·Terraform)에서 구체화
+- **staging IAM Role 분리**: 본 ADR은 prod/staging이 동일 Task Role 사용. 환경별 권한 분리는 환경 분리 Epic
+- **관리형 정책(`AmazonECSTaskExecutionRolePolicy`) 부착 vs inline 명시**: 본 ADR은 inline 명시 채택 — 감사·재현성·prefix 한정 가능
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **컨테이너 침해 영향 한정**: Task Role의 권한이 S3 한 bucket으로 한정. 침해 시 다른 AWS 리소스 영향 없음
+- **PassRole 경계 명확**: GHA workflow가 임의 Role을 Task에 attach 못 함 → CI/CD compromise 시 prod IAM 권한 확대 차단
+- **감사 가능성 향상**: 각 Role의 사용 주체가 명확 — CloudTrail에서 `assumedRoleId` 보고 어디서 호출됐는지 즉시 추적
+- **Least Privilege 패턴 정착**: 후속 Story (#15 Secrets Manager, GCP WIF 등)에서 동일 패턴 답습 가능
+- **inline 정책으로 코드 단일 진실 소스**: 관리형 정책 의존 없이 `infra/iam/` 5 JSON이 모든 권한을 명시 — 감사·롤백·재현 일원화
+
+### 트레이드오프 / 부정적
+
+- **관리 Role 3개 + inline policy 5개**: 단일 Role 대비 운영 부담 증가. ts008 runbook으로 1회 셋업 절차 표준화
+- **`ecs:GetAuthorizationToken` 같은 계정 단위 권한은 resource `*` 사용**: 한정 불가능한 AWS 권한은 그대로. 명시적 inline로 다른 부분과 동일 감사 흐름 유지
+- **JSON 5개의 sync 부담**: prod/staging가 동일 Role 사용이라 환경별 권한 분리는 미래 작업. 환경별 분리 시 5 → 8개 정책으로 증가
+- **`iam:PassRole` 추가가 보안 표면 확장 — 다만 ARN 한정 + Condition으로 차단**: gha-deploy-role 권한이 ECR-only에서 ECR + ECS deploy + PassRole로 확장. ADR013 결정 시 예고된 follow-up이므로 적정
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **A. 단일 Role (`ecs-unified-role`)** | 관리 부담 최소 | 컨테이너 침해 시 ECR push · CloudWatch Logs 쓰기 · ECS Service update 권한 모두 노출 — 권한 확대 표면이 결정적 |
+| **B. Execution Role과 Task Role 통합** | Role 1개 절감 | AWS ECS가 두 Role을 의도적 분리 사용 — 통합 시 컨테이너 안에서 Execution 권한 사용 가능 → AWS 아키텍처 위반 |
+| **C. Task Role 미사용 (Execution Role만 + 컨테이너 코드도 사용)** | Role 1개 절감 | ECS 에이전트가 Task Role을 사용할 수 없음 (AWS 아키텍처 제약) — 동작 자체가 불가 |
+| **D. GHA Deploy Role과 Task Execution Role 통합** | OIDC Role 1개로 통합 | GHA OIDC는 외부 식별자, ECS는 AWS 내부 서비스 — 신뢰 주체가 본질적으로 다름 |
+| **E (선택). 3종 분리 (gha-deploy + ecs-task-execution + ecs-task)** | 권한 경계 명확, 감사 추적성 향상 | Role 3개 관리 부담 |
+| **F. 관리형 정책(`AmazonECSTaskExecutionRolePolicy`) 부착** | 입력 토큰 적음 | resource 한정 불가능 — `thirdtool/prod/*` prefix 잠금 같은 세밀한 제한 못 함 |
+
+## 알려진 follow-up (본 ADR 범위 외)
+
+- **milestone 0.0.1v item #15 (Secrets Manager)** 완료 후: `ecs-task-execution-role` permissions의 Secrets Manager resource ARN을 실제 시크릿 ARN(`<SUFFIX>` 포함)으로 정정
+- **`S3Config.java` → `DefaultCredentialsProvider` 전환**: Task Role의 S3 권한이 자동 주입돼 Task Def의 `AWS_ACCESS_KEY_ID/SECRET` secret 2건 제거 가능
+- **EC2 SSH 배포 step 제거**: ECS 운영 검증 통과 후. `dev-cicd.yml`의 `Deploy to EC2 via SSH` step + 컨테이너 env var pass-through 일괄 삭제
+- **staging 환경별 권한 분리**: 본 ADR은 prod/staging이 동일 Task Role. staging 권한 축소(예: `s3:GetObject`만) 시 별도 `ecs-task-role-staging` Role 신설
+- **GCP Workload Identity Federation**: Spring AI Gemini용. Task Role이 GCP STS에 OIDC token 제출하는 패턴 — Product 7
+- **Terraform IaC**: 본 ADR은 콘솔/CLI 셋업 가정. Terraform 모듈화는 Product 7 Epic 2
+
+## 다시 검토할 시점
+
+- **단일 운영자 → 다인 운영 전환 시점**: Role 분리의 감사 가치가 다인 운영에서 더 중요 — 현 결정 유지 권장
+- **prod/staging 권한 분리 시점**: 환경 분리 Epic에서 `ecs-task-role-staging` 신설 검토
+- **ECS Service Auto Scaling 도입 시점**: `gha-deploy-role`에 `application-autoscaling:*` 추가 필요
+- **CodeDeploy Blue/Green 전환 시점**: CodeDeploy IAM Role 신설 + `gha-deploy-role` 권한 위임 패턴 검토

--- a/docs/adr/ADR014-ecs-task-iam-role-separation.md
+++ b/docs/adr/ADR014-ecs-task-iam-role-separation.md
@@ -42,11 +42,27 @@ product-infra-deploy.md Epic 2 §"핵심 설계 결정"에서 IAM Role 3종 분�
    - Execution Role의 Secrets Manager read는 `thirdtool/prod/*` + `thirdtool/staging/*`만 (다른 시크릿 차단)
    - Task Role의 S3는 `third-tool-s3-server` bucket만 (다른 버킷 차단)
 
+### `gha-deploy-role` ECS actions resource 한정 분석
+
+5 ECS actions가 모두 `Resource: "*"`를 사용한다. AWS IAM 문서 기준 한정 가능성:
+
+| Action | resource 한정 가능 여부 | 본 ADR 선택 사유 |
+| --- | --- | --- |
+| `ecs:RegisterTaskDefinition` | **불가** — task definition은 등록 *전에는* ARN 미존재 | `*` 사용 강제. 동일 family에 한정하려면 `Condition.StringLike."ecs:taskdefinition-family"` 사용 가능하나 GHA workflow가 본 Story에서 prod·staging 두 family 모두 다루므로 효과 작음 |
+| `ecs:DescribeTaskDefinition` | **불가** — 어떤 family든 read는 계정 단위로 풀림 | `*` 사용 표준 |
+| `ecs:DeregisterTaskDefinition` | **불가** — 동일 사유 | `*` 사용. 단 IAM 위험 작음 (deregister는 revision 단위 비활성화) |
+| `ecs:DescribeServices` | 한정 가능 — `arn:aws:ecs:region:acct:service/cluster/service-name` | M2에서 cluster-level 한정 검토. M1은 GHA가 새 service 생성 가능성 있어 `*` 유지 |
+| `ecs:UpdateService` | 한정 가능 — 동일 service ARN | M2에서 `arn:aws:ecs:ap-northeast-2:<acct>:service/thirdtool-{prod,staging}/thirdtool-app` 두 ARN으로 한정 권장. **본 Story 범위 내에서는 보안 표면이 크지만 GHA OIDC sub=main 잠금이 보조 가드** |
+
+→ **현재 결정**: 5 actions 모두 `*` 유지 + GHA OIDC sub 조건(`refs/heads/main`)으로 priviege escalation 표면 보조 차단. UpdateService/DescribeServices 한정은 **M2 follow-up Story** (deploy automation 도입 시 동시).
+
 ### 본 ADR이 다루지 않는 범위
 
 - **GCP Workload Identity Federation**: Spring AI Gemini용 Task Role의 GCP 인증은 Product 7 (Secrets·Terraform)에서 구체화
 - **staging IAM Role 분리**: 본 ADR은 prod/staging이 동일 Task Role 사용. 환경별 권한 분리는 환경 분리 Epic
 - **관리형 정책(`AmazonECSTaskExecutionRolePolicy`) 부착 vs inline 명시**: 본 ADR은 inline 명시 채택 — 감사·재현성·prefix 한정 가능
+- **`application-staging.yml` 코드 부재로 인한 staging Task Def `SPRING_PROFILES_ACTIVE=prod` transitional 결정**: staging profile 신설 + Task Def env 정정은 별도 Story (환경 분리 Epic). 본 Story는 코드 변경 없이 ts008 §1에 함정 명시로만 처리
+- **`/health` endpoint의 DB 의존성 미체크**: 단순 200 응답이라 DB down 시에도 healthCheck pass. ECS가 false-positive healthy 판정. `/actuator/health` + DB HealthIndicator 활성 전환은 별도 Story (ts008 §9 follow-up)
 
 ## 결과 (Consequences)
 
@@ -79,9 +95,12 @@ product-infra-deploy.md Epic 2 §"핵심 설계 결정"에서 IAM Role 3종 분�
 ## 알려진 follow-up (본 ADR 범위 외)
 
 - **milestone 0.0.1v item #15 (Secrets Manager)** 완료 후: `ecs-task-execution-role` permissions의 Secrets Manager resource ARN을 실제 시크릿 ARN(`<SUFFIX>` 포함)으로 정정
-- **`S3Config.java` → `DefaultCredentialsProvider` 전환**: Task Role의 S3 권한이 자동 주입돼 Task Def의 `AWS_ACCESS_KEY_ID/SECRET` secret 2건 제거 가능
-- **EC2 SSH 배포 step 제거**: ECS 운영 검증 통과 후. `dev-cicd.yml`의 `Deploy to EC2 via SSH` step + 컨테이너 env var pass-through 일괄 삭제
+- **`S3Config.java` → `DefaultCredentialsProvider` 전환**: Task Role의 S3 권한이 자동 주입돼 Task Def의 `AWS_ACCESS_KEY_ID/SECRET` secret 2건 제거 가능. **transitional 영구화 방지** — ts008 §9 `Story-TBD(S3 Credentials)`로 트래킹
+- **EC2 SSH 배포 step 제거**: ECS 운영 검증 통과 후. `dev-cicd.yml`의 `Deploy to EC2 via SSH` step + 컨테이너 env var pass-through 일괄 삭제 — ts008 §9 `Story-TBD(EC2 폐기)`
 - **staging 환경별 권한 분리**: 본 ADR은 prod/staging이 동일 Task Role. staging 권한 축소(예: `s3:GetObject`만) 시 별도 `ecs-task-role-staging` Role 신설
+- **`application-staging.yml` 신설 + staging Task Def env 정정**: 현재 staging Task Def `SPRING_PROFILES_ACTIVE=prod` 함정 해소 — ts008 §9 `Story-TBD(staging profile)`
+- **`/health` → `/actuator/health` + DB HealthIndicator 활성**: ECS healthCheck false-positive 차단 — ts008 §9 `Story-TBD(Health Indicator)`
+- **`gha-deploy-role` ECS UpdateService/DescribeServices resource 한정**: 본 ADR §대안 분석 표 — M2 deploy automation 도입 시 service ARN 2건으로 한정 권장
 - **GCP Workload Identity Federation**: Spring AI Gemini용. Task Role이 GCP STS에 OIDC token 제출하는 패턴 — Product 7
 - **Terraform IaC**: 본 ADR은 콘솔/CLI 셋업 가정. Terraform 모듈화는 Product 7 Epic 2
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -15,3 +15,4 @@
 | [ADR011](ADR011.md) | MDC 화이트리스트에 errorCode 키를 추가한다 (Story 3-1) | Accepted | 2026-06-23 |
 | [ADR012](ADR012.md) | 운영 컨테이너 base image `eclipse-temurin:21-jre-alpine` 채택, Distroless 보류 (Story 1-1) | Accepted | 2026-06-25 |
 | [ADR013](ADR013-gha-oidc-assume-role.md) | GitHub Actions → AWS 인증을 OIDC AssumeRole로 전환 (Story-046) | Accepted | 2026-06-29 |
+| [ADR014](ADR014-ecs-task-iam-role-separation.md) | ECS Task IAM Role 3종 분리 — Execution/Task/GHA Deploy (Story-047) | Accepted | 2026-06-29 |

--- a/docs/operations/troubleshooting/ts008-ecs-cluster-setup.md
+++ b/docs/operations/troubleshooting/ts008-ecs-cluster-setup.md
@@ -1,0 +1,283 @@
+# ts008: ECS Cluster · Task Definition · Service 셋업·검증·트러블슈팅
+
+Story-047로 `infra/ecs/`와 `infra/iam/`에 ECS Fargate 구동에 필요한 JSON 정의가 추가됐다. 본 가이드는 AWS 콘솔(또는 CLI)에서 1회성 셋업하는 절차 + 검증 + 자주 보는 에러 6건을 한 곳에 모았다.
+
+ts005(Dockerfile)·ts007(OIDC)와 cross-link. 본 절차는 1인 운영자가 1회만 실행하면 됨.
+
+---
+
+## 1. 전제
+
+- ts007 §2-4 완료 — OIDC Provider · `gha-deploy-role` · GitHub Variables `AWS_ACCOUNT_ID` 등록
+- AWS 콘솔 IAM 관리 권한 (`iam:CreateRole` · `iam:PutRolePolicy`)
+- AWS 콘솔 ECS 관리 권한 (`ecs:CreateCluster` · `ecs:RegisterTaskDefinition` · `ecs:CreateService`)
+- AWS CLI 설치 (선택 — 콘솔 대신 명령으로도 진행 가능)
+
+**placeholder 의존 상태 (후속 Story로 치환됨)**:
+- `<APP_SUBNET_2A>` · `<APP_SUBNET_2C>` · `<APP_SG>` → milestone 0.0.1v item #12 VPC 완료 후
+- `<PROD_TARGET_GROUP_ARN>` · `<STAGING_TARGET_GROUP_ARN>` → milestone 0.0.1v item #13 ALB 완료 후
+- `<RDS endpoint>` (Task Def secrets의 `DB_HOST`) → milestone 0.0.1v item #14 RDS 완료 후
+- `secrets.valueFrom` ARN suffix `<SUFFIX>` → milestone 0.0.1v item #15 Secrets Manager 완료 후
+
+본 ts008은 위 4 placeholder가 모두 치환된 시점에 end-to-end 실행 가능. 그 전까지는 §1-2 (Log group + IAM Role)까지만 진입하고 §3-5는 dry-run 가이드로 유지.
+
+---
+
+## 2. CloudWatch Log group 2개 생성
+
+```bash
+aws logs create-log-group --log-group-name /ecs/thirdtool-prod --region ap-northeast-2
+aws logs put-retention-policy --log-group-name /ecs/thirdtool-prod --retention-in-days 30 --region ap-northeast-2
+
+aws logs create-log-group --log-group-name /ecs/thirdtool-staging --region ap-northeast-2
+aws logs put-retention-policy --log-group-name /ecs/thirdtool-staging --retention-in-days 7 --region ap-northeast-2
+```
+
+retention: prod 30일 / staging 7일 (product Epic 2 §대안 비교 Q "로그 보존 정책" Option B 선택).
+
+`awslogs-create-group: "false"`를 Task Def에 명시했기 때문에 사전 생성 필수. 누락 시 컨테이너 부팅 시점에 `logConfiguration` 에러로 STOPPED.
+
+---
+
+## 3. IAM Role 3종 생성
+
+### 3.1 `gha-deploy-role` 확장 (Story-046에서 이미 생성)
+
+기존 Role에 inline policy 갱신 (`infra/iam/gha-deploy-role-permissions-policy.json` 내용으로 교체):
+1. AWS 콘솔 → IAM → Roles → `gha-deploy-role` → Permissions → inline policy `gha-deploy-role-permissions` → Edit
+2. JSON 탭 → `infra/iam/gha-deploy-role-permissions-policy.json` 내용으로 교체
+3. `<AWS_ACCOUNT_ID>` 12자리 치환
+4. **치환 누락 검증**: 입력 직전 `<` 문자 0건 확인
+
+신규 Statement 2건 (`EcsDeploy` + `IamPassRoleToEcsTasks`)이 보임. 기존 `EcrAuthToken` + `EcrPushPull`은 보존.
+
+### 3.2 `ecs-task-execution-role` 신규 생성
+
+1. AWS 콘솔 → IAM → Roles → Create role
+2. Trusted entity type: **Custom trust policy** → `infra/iam/ecs-task-execution-role-trust-policy.json` 내용 붙여넣기 (치환 불요)
+3. Permissions: 다음 단계
+4. Role name: `ecs-task-execution-role`
+5. Create role
+6. 생성된 Role → Permissions → Add permissions → Create inline policy → JSON
+7. `infra/iam/ecs-task-execution-role-permissions-policy.json` 내용 붙여넣기 + `<AWS_ACCOUNT_ID>` 치환
+8. Policy name: `ecs-task-execution-role-permissions`
+
+### 3.3 `ecs-task-role` 신규 생성
+
+3.2와 동일 절차로 신규 Role 생성:
+- Trust policy: `infra/iam/ecs-task-role-trust-policy.json` (Execution Role과 동일 내용이지만 별도 Role로 분리 — ADR014)
+- Role name: `ecs-task-role`
+- Inline policy name: `ecs-task-role-permissions` / 내용: `infra/iam/ecs-task-role-permissions-policy.json` + `<AWS_ACCOUNT_ID>` 치환
+
+> **검증**: 두 Role의 신뢰 정책은 동일하지만 권한 정책은 달라야 한다. Execution = ECR/Logs/Secrets, Task = S3/SSM. 동일하게 됐으면 ADR014 §결정의 권한 분리 의도 위반 → Role 합쳐진 셈.
+
+---
+
+## 4. ECS Cluster 2개 생성
+
+```bash
+aws ecs create-cluster \
+  --cluster-name thirdtool-prod \
+  --capacity-providers FARGATE FARGATE_SPOT \
+  --default-capacity-provider-strategy capacityProvider=FARGATE,weight=100 \
+  --region ap-northeast-2
+
+aws ecs create-cluster \
+  --cluster-name thirdtool-staging \
+  --capacity-providers FARGATE FARGATE_SPOT \
+  --region ap-northeast-2
+```
+
+staging의 capacity provider strategy는 Service 생성 시점에 명시(`service-staging.json`의 `capacityProviderStrategy`).
+
+검증:
+```bash
+aws ecs describe-clusters \
+  --clusters thirdtool-prod thirdtool-staging \
+  --region ap-northeast-2 \
+  | jq '.clusters[].status'
+# 기대 출력: "ACTIVE" x 2
+```
+
+---
+
+## 5. Task Definition 등록
+
+### 5.1 placeholder 치환
+
+`infra/ecs/task-definition-prod.json`을 임시 파일로 복사 후 치환:
+- `<AWS_ACCOUNT_ID>` → 12자리 계정 ID
+- `<IMAGE_TAG>` → 배포할 ECR 이미지 태그 (예: `latest` 또는 git_sha 7자)
+- `<SUFFIX>` → Secrets Manager 시크릿 이름의 random suffix (#15 완료 후, 예: `Ab3cD9`)
+
+```bash
+sed -e "s/<AWS_ACCOUNT_ID>/123456789012/g" \
+    -e "s/<IMAGE_TAG>/latest/g" \
+    -e "s/<SUFFIX>/Ab3cD9/g" \
+    infra/ecs/task-definition-prod.json > /tmp/td-prod.json
+grep -c '<' /tmp/td-prod.json    # 0이어야 함
+```
+
+### 5.2 등록
+
+```bash
+aws ecs register-task-definition --cli-input-json file:///tmp/td-prod.json --region ap-northeast-2
+```
+
+응답에서 `taskDefinitionArn` 확인. `ACTIVE` 상태로 revision 1.
+
+staging도 동일 절차 (`task-definition-staging.json`).
+
+---
+
+## 6. ECS Service 생성
+
+### 6.1 placeholder 치환
+
+`infra/ecs/service-prod.json`을 임시 복사 후:
+- `<APP_SUBNET_2A>`, `<APP_SUBNET_2C>` → VPC private subnet ID 2개 (#12 완료 후)
+- `<APP_SG>` → 컨테이너 Security Group ID (#12 완료 후)
+- `<PROD_TARGET_GROUP_ARN>` → ALB Target Group ARN (#13 완료 후)
+
+### 6.2 생성
+
+```bash
+aws ecs create-service --cli-input-json file:///tmp/svc-prod.json --region ap-northeast-2
+```
+
+응답에서 `serviceArn` + `deployments[0].status: PRIMARY` 확인.
+
+ECS Scheduler가 Task 2개를 배치하기까지 약 1-2분 소요. 진행 상황:
+```bash
+aws ecs describe-services \
+  --cluster thirdtool-prod --services thirdtool-app \
+  --region ap-northeast-2 \
+  | jq '.services[0].deployments'
+# runningCount=2, desiredCount=2, status=STEADY_STATE 도달 시 완료
+```
+
+---
+
+## 7. 검증
+
+### 7.1 Task 상태
+
+```bash
+aws ecs list-tasks --cluster thirdtool-prod --service-name thirdtool-app --region ap-northeast-2 \
+  | jq -r '.taskArns[]' \
+  | xargs aws ecs describe-tasks --cluster thirdtool-prod --region ap-northeast-2 --tasks \
+  | jq '.tasks[] | {lastStatus, healthStatus, availabilityZone}'
+# 기대: lastStatus=RUNNING, healthStatus=HEALTHY, AZ가 ap-northeast-2a / 2c로 분산
+```
+
+### 7.2 CloudWatch Logs 흐름
+
+AWS 콘솔 → CloudWatch → Log groups → `/ecs/thirdtool-prod` → 최신 log stream에 Spring Boot 부팅 로그(`Started ThirdToolApplication`) JSON 한 줄 + `traceId` MDC 필드 포함되는지 확인.
+
+### 7.3 ALB Target Group healthy
+
+AWS 콘솔 → EC2 → Target Groups → `<PROD_TARGET_GROUP>` → Targets 탭에서 2개 Task 모두 `healthy` 상태.
+
+### 7.4 endpoint 응답
+
+```bash
+curl -sSf https://<dev-domain>/health
+# 기대: 200 OK
+```
+
+### 7.5 ECS Exec 진입
+
+Alpine이라 shell 진입 가능:
+```bash
+aws ecs execute-command \
+  --cluster thirdtool-prod \
+  --task <TASK_ARN> \
+  --container app \
+  --interactive --command "/bin/sh" \
+  --region ap-northeast-2
+# 컨테이너 안에서: env | grep SPRING_PROFILES_ACTIVE → "prod" 확인
+```
+
+---
+
+## 8. 트러블슈팅
+
+### ts008-1: Task가 PENDING → STOPPED, 사유 `ResourceInitializationError: unable to pull secrets or registry auth`
+
+**원인**: `executionRoleArn`이 잘못됐거나 권한 부족. ECR pull 또는 Secrets Manager 접근 실패.
+
+**해결**:
+1. Task Def `executionRoleArn` 값이 실제 생성된 Role ARN과 정확히 일치하는지 (대소문자·account ID·region 포함)
+2. `ecs-task-execution-role` permissions policy에 ECR pull 3 actions + Secrets Manager read 2 actions이 있는지
+3. Secrets Manager 시크릿 prefix가 `thirdtool/prod/` 또는 `thirdtool/staging/`로 시작하는지 (resource ARN과 매치)
+
+### ts008-2: Task RUNNING이지만 ALB Target unhealthy
+
+**원인 가능성**:
+- ECS container `healthCheck` 명령이 실패 — `wget` 미설치 또는 Spring Boot 부팅 시간 > startPeriod(60s)
+- ALB Target Group의 health check path가 `/health`가 아닌 다른 경로 (#13에서 설정)
+- Security Group이 ALB → Task 8080 허용 안 함
+
+**해결**:
+1. Task 컨테이너 로그에서 `Started ThirdToolApplication in N.NNN seconds` 확인 — 60초 초과면 startPeriod 증가
+2. ECS Exec로 진입 후 `wget -q -O- http://localhost:8080/health` 실행 → 200 OK 응답 확인
+3. ALB Target Group health check 설정: path=`/health`, port=`traffic-port`(8080), healthy threshold 2
+
+### ts008-3: Task STOPPED, 사유 `Essential container exited with code N`
+
+**원인**: Spring Boot 부팅 실패 (env var 누락, DB 연결 실패, placeholder 미해석 등).
+
+**해결**:
+1. CloudWatch Logs `/ecs/thirdtool-prod` 최신 stream의 `Caused by:` 라인 확인
+2. `Could not resolve placeholder 'X'` → Task Def `secrets` 배열에 누락된 환경변수가 있음. 모든 11개 secret이 valid한 ARN으로 매핑됐는지 확인
+3. `Communications link failure` → RDS endpoint(`DB_HOST`)가 잘못됐거나 RDS Security Group이 Task SG의 3306 inbound 허용 안 함 (#14)
+
+### ts008-4: `iam:PassRole` 거부 — GHA workflow에서 `UpdateService` 시 `User is not authorized to perform: iam:PassRole`
+
+**원인**: `gha-deploy-role` permissions policy의 `IamPassRoleToEcsTasks` Statement가 두 Task Role ARN과 정확히 매치 안 됨.
+
+**해결**:
+1. `gha-deploy-role-permissions-policy.json`의 PassRole resource ARN 2건이 실제 생성된 Role ARN과 일치 확인
+2. `Condition.StringEquals.iam:PassedToService`가 `ecs-tasks.amazonaws.com`인지
+
+### ts008-5: ECS Exec `execute-command` 실패 — `An error occurred (InvalidParameterException)`
+
+**원인**:
+- Service가 `enableExecuteCommand: true`로 생성되지 않음
+- Task Role에 SSM Messages 4 actions 권한 없음
+- Cluster에 ECS Exec configuration이 enabled 안 됨
+
+**해결**:
+1. Service 재생성 시 `enableExecuteCommand: true` 명시 (현 `service-prod.json` 포함)
+2. `ecs-task-role` permissions에 `EcsExecSsmChannel` Statement 4 actions 확인
+3. 또는 `aws ecs update-service --enable-execute-command` 명령으로 기존 Service 갱신 후 새 deployment
+
+### ts008-6: deploymentCircuitBreaker가 자동 롤백을 안 함
+
+**원인**: Circuit Breaker는 **STEADY_STATE 도달 실패** 시에만 발동. 컨테이너가 ALB healthy로 들어왔지만 비즈니스 로직 5xx 폭증은 감지 못 함.
+
+**해결**: 정상. ECS Circuit Breaker의 범위 (헬스체크 실패만). 5xx 폭증 감지 + GHA failure step 자동 롤백은 product Epic 3 별도 Story (Story-047 범위 외 — ADR013/ADR014 follow-up).
+
+---
+
+## 9. 후속 (별도 Story)
+
+- **VPC subnet/SG 치환** — milestone 0.0.1v item #12 완료 후 service JSON placeholder 치환
+- **ALB Target Group ARN 치환** — milestone 0.0.1v item #13 완료 후
+- **RDS endpoint** — milestone 0.0.1v item #14 완료 후 Secrets Manager `DB_HOST` 값 갱신
+- **Secrets Manager 시크릿 실제 등록** — milestone 0.0.1v item #15. Task Def secrets ARN의 `<SUFFIX>` 치환
+- **GHA workflow의 `aws-actions/amazon-ecs-deploy-task-definition` 도입** — main push 시 자동 Task Def update + Service deploy. 본 Story 다음.
+- **5xx 폭증 자동 롤백 + 5분 모니터링** — product Epic 3 Story 3-1 잔여
+- **`S3Config.java` → `DefaultCredentialsProvider` 전환 + Task Def AWS 키 secret 제거** — Task Role 자동 주입으로 대체
+- **EC2 SSH 배포 step 제거** — ECS 운영 검증 통과 후
+
+---
+
+## 관련
+
+- [`ts005-dockerfile-build.md`](ts005-dockerfile-build.md) — Task Def가 참조하는 이미지 빌드
+- [`ts007-gha-oidc-setup.md`](ts007-gha-oidc-setup.md) — gha-deploy-role 기반 정책 (본 Story에서 확장)
+- [ADR013](../../adr/ADR013-gha-oidc-assume-role.md) — OIDC 결정 (본 Story Task IAM Role 분리의 선행 결정)
+- [ADR014](../../adr/ADR014-ecs-task-iam-role-separation.md) — Task IAM Role 3종 분리 결정 배경
+- Story-047 — milestone 0.0.1v item #11. `workflow/task/milestones/version/0.0.1v/milestone.md`
+- 후속: #12 VPC, #13 ALB, #14 RDS, #15 Secrets Manager

--- a/docs/operations/troubleshooting/ts008-ecs-cluster-setup.md
+++ b/docs/operations/troubleshooting/ts008-ecs-cluster-setup.md
@@ -12,14 +12,20 @@ ts005(Dockerfile)·ts007(OIDC)와 cross-link. 본 절차는 1인 운영자가 1�
 - AWS 콘솔 IAM 관리 권한 (`iam:CreateRole` · `iam:PutRolePolicy`)
 - AWS 콘솔 ECS 관리 권한 (`ecs:CreateCluster` · `ecs:RegisterTaskDefinition` · `ecs:CreateService`)
 - AWS CLI 설치 (선택 — 콘솔 대신 명령으로도 진행 가능)
+- **CloudWatch Log group 2개 사전 생성 필수**(§2 단계) — Task Def `awslogs-create-group: "false"` 설정. 누락 시 컨테이너 부팅 시점 logConfiguration 에러로 즉시 STOPPED
+- **ALB Target Group `target-type: ip` 강제** — Fargate는 EC2 인스턴스 등록 불가. #13 ALB 셋업 시 `--target-type ip` 명시 (instance 사용 시 본 ts008 §6 Service 생성 자체가 거부됨)
 
 **placeholder 의존 상태 (후속 Story로 치환됨)**:
 - `<APP_SUBNET_2A>` · `<APP_SUBNET_2C>` · `<APP_SG>` → milestone 0.0.1v item #12 VPC 완료 후
-- `<PROD_TARGET_GROUP_ARN>` · `<STAGING_TARGET_GROUP_ARN>` → milestone 0.0.1v item #13 ALB 완료 후
-- `<RDS endpoint>` (Task Def secrets의 `DB_HOST`) → milestone 0.0.1v item #14 RDS 완료 후
+- `<PROD_TARGET_GROUP_ARN>` · `<STAGING_TARGET_GROUP_ARN>` → milestone 0.0.1v item #13 ALB 완료 후 (target-type=ip 필수)
+- `<RDS endpoint>` (Task Def secrets의 `DB_HOST` 값) → milestone 0.0.1v item #14 RDS 완료 후
 - `secrets.valueFrom` ARN suffix `<SUFFIX>` → milestone 0.0.1v item #15 Secrets Manager 완료 후
 
-본 ts008은 위 4 placeholder가 모두 치환된 시점에 end-to-end 실행 가능. 그 전까지는 §1-2 (Log group + IAM Role)까지만 진입하고 §3-5는 dry-run 가이드로 유지.
+본 ts008은 위 4 placeholder가 모두 치환된 시점에 end-to-end 실행 가능. **§5-7은 4 placeholder 미완료 시 명령 실행 불가** (Task Def register 시 valueFrom ARN invalid · Service create 시 subnet/SG/TG ARN invalid). §2 (Log group) + §3 (IAM Role) + §4 (Cluster)까지는 #12-#15 의존 없이 선행 가능 — 1회성 셋업 추천 순서.
+
+> **staging Task Def transitional 함정**: `task-definition-staging.json:26`의 `SPRING_PROFILES_ACTIVE=prod`는 `application-staging.yml` 코드 부재로 인한 transitional 결정 (ADR014 follow-up 참조). staging 환경에서 Task 부팅 시 prod 프로파일 적용 → Swagger 차단, Hibernate SQL 로그 OFF, JWT Secure=true 적용. staging 디버깅 시 혼선 가능. 정상 동작이지만 의도된 가드로 인지할 것. `application-staging.yml` 신설 + Task Def env 정정은 별도 Story (환경 분리 Epic).
+
+> **healthCheck `wget` 의존**: Task Def healthCheck command가 `wget` 사용. base image `eclipse-temurin:21-jre-alpine`은 BusyBox 포함 → `wget`이 BusyBox applet으로 항상 가용. distroless 등 다른 base로 전환 시 healthCheck 명령 재설계 필요. ADR012 참조.
 
 ---
 
@@ -47,7 +53,7 @@ retention: prod 30일 / staging 7일 (product Epic 2 §대안 비교 Q "로그 �
 1. AWS 콘솔 → IAM → Roles → `gha-deploy-role` → Permissions → inline policy `gha-deploy-role-permissions` → Edit
 2. JSON 탭 → `infra/iam/gha-deploy-role-permissions-policy.json` 내용으로 교체
 3. `<AWS_ACCOUNT_ID>` 12자리 치환
-4. **치환 누락 검증**: 입력 직전 `<` 문자 0건 확인
+4. **치환 누락 검증** (필수 — IAM이 invalid ARN 거부): 임시 파일에 붙여넣은 후 `grep -c '<' /tmp/policy.json` 결과 **0이어야 함**
 
 신규 Statement 2건 (`EcsDeploy` + `IamPassRoleToEcsTasks`)이 보임. 기존 `EcrAuthToken` + `EcrPushPull`은 보존.
 
@@ -68,6 +74,8 @@ retention: prod 30일 / staging 7일 (product Epic 2 §대안 비교 Q "로그 �
 - Trust policy: `infra/iam/ecs-task-role-trust-policy.json` (Execution Role과 동일 내용이지만 별도 Role로 분리 — ADR014)
 - Role name: `ecs-task-role`
 - Inline policy name: `ecs-task-role-permissions` / 내용: `infra/iam/ecs-task-role-permissions-policy.json` + `<AWS_ACCOUNT_ID>` 치환
+
+> **치환 누락 검증 통일**: §3.1 / §3.2 / §3.3 / §5.1 / §6.1 모두 동일 `grep -c '<' <임시파일>` 명령으로 0건 확인. 본 검증을 빠뜨려도 AWS IAM/ECS가 invalid ARN으로 거부하므로 안전망이 있지만, 사후 디버깅 비용이 크다.
 
 > **검증**: 두 Role의 신뢰 정책은 동일하지만 권한 정책은 달라야 한다. Execution = ECR/Logs/Secrets, Task = S3/SSM. 동일하게 됐으면 ADR014 §결정의 권한 분리 의도 위반 → Role 합쳐진 셈.
 
@@ -158,7 +166,10 @@ aws ecs describe-services \
 
 ---
 
-## 7. 검증
+## 7. 검증 (end-to-end — 4 placeholder 모두 치환된 시점에 실행)
+
+§7은 §1 전제의 4 placeholder(#12 VPC + #13 ALB + #14 RDS + #15 Secrets)가 모두 치환된 후 실행 가능. 그 전까지는 §7 dry-run 정도로만 — `aws ecs describe-services` 같은 read-only 명령 일부만 동작 (Service 자체가 생성 안 됐으면 미응답).
+
 
 ### 7.1 Task 상태
 
@@ -214,14 +225,18 @@ aws ecs execute-command \
 ### ts008-2: Task RUNNING이지만 ALB Target unhealthy
 
 **원인 가능성**:
-- ECS container `healthCheck` 명령이 실패 — `wget` 미설치 또는 Spring Boot 부팅 시간 > startPeriod(60s)
+- ECS container `healthCheck` 명령이 실패 — `wget` 미설치 (BusyBox 의존, ADR012 참조) 또는 Spring Boot 부팅 시간 > startPeriod(60s)
 - ALB Target Group의 health check path가 `/health`가 아닌 다른 경로 (#13에서 설정)
+- ALB Target Group `target-type`이 `instance`로 설정 (Fargate는 `ip` 필수 — §1 전제)
 - Security Group이 ALB → Task 8080 허용 안 함
+- ALB health check interval × healthy threshold 가 Service `healthCheckGracePeriodSeconds`(90초)와 race — interval=30s × threshold=2 = 60초여야 grace 안에 안정 판정 가능
 
 **해결**:
 1. Task 컨테이너 로그에서 `Started ThirdToolApplication in N.NNN seconds` 확인 — 60초 초과면 startPeriod 증가
 2. ECS Exec로 진입 후 `wget -q -O- http://localhost:8080/health` 실행 → 200 OK 응답 확인
-3. ALB Target Group health check 설정: path=`/health`, port=`traffic-port`(8080), healthy threshold 2
+3. ALB Target Group health check 설정: path=`/health`, port=`traffic-port`(8080), healthy threshold 2, interval 30s
+4. ALB Target Group `target-type=ip` 확인 (콘솔 → Target Group → Attributes)
+5. **알려진 false positive**: 현재 `/health`는 단순 200 응답 — DB 다운 시에도 healthy 판정. ECS는 unhealthy를 검출 못 함. 후속 Story(별도 PR — `/actuator/health`로 전환 + DB indicator 활성) 권장. ADR014 follow-up 참조.
 
 ### ts008-3: Task STOPPED, 사유 `Essential container exited with code N`
 
@@ -260,16 +275,19 @@ aws ecs execute-command \
 
 ---
 
-## 9. 후속 (별도 Story)
+## 9. 후속 (별도 Story — 미할당 번호는 follow-up 트래커가 잡을 시점에 부여)
 
-- **VPC subnet/SG 치환** — milestone 0.0.1v item #12 완료 후 service JSON placeholder 치환
-- **ALB Target Group ARN 치환** — milestone 0.0.1v item #13 완료 후
-- **RDS endpoint** — milestone 0.0.1v item #14 완료 후 Secrets Manager `DB_HOST` 값 갱신
-- **Secrets Manager 시크릿 실제 등록** — milestone 0.0.1v item #15. Task Def secrets ARN의 `<SUFFIX>` 치환
-- **GHA workflow의 `aws-actions/amazon-ecs-deploy-task-definition` 도입** — main push 시 자동 Task Def update + Service deploy. 본 Story 다음.
-- **5xx 폭증 자동 롤백 + 5분 모니터링** — product Epic 3 Story 3-1 잔여
-- **`S3Config.java` → `DefaultCredentialsProvider` 전환 + Task Def AWS 키 secret 제거** — Task Role 자동 주입으로 대체
-- **EC2 SSH 배포 step 제거** — ECS 운영 검증 통과 후
+- **Story-TBD(VPC)**: subnet/SG 치환 — milestone 0.0.1v item #12 완료 후 service JSON placeholder 치환
+- **Story-TBD(ALB)**: Target Group ARN 치환 (target-type=ip 필수) — milestone 0.0.1v item #13 완료 후
+- **Story-TBD(RDS)**: endpoint Secrets Manager `DB_HOST` 값 갱신 — milestone 0.0.1v item #14 완료 후
+- **Story-TBD(Secrets)**: 실제 시크릿 등록 + Task Def `<SUFFIX>` 치환 — milestone 0.0.1v item #15
+- **Story-TBD(Deploy Automation)**: GHA workflow의 `aws-actions/amazon-ecs-deploy-task-definition` 도입 — main push 시 자동 Task Def update + Service deploy. 본 Story 다음
+- **Story-TBD(Rollback Hardening)**: 5xx 폭증 자동 롤백 + 5분 모니터링 — product Epic 3 Story 3-1 잔여
+- **Story-TBD(S3 Credentials)**: `S3Config.java` → `DefaultCredentialsProvider` 전환 + Task Def AWS_ACCESS_KEY_ID/SECRET secret 2건 제거 — Task Role 자동 주입으로 대체. **transitional 영구화 방지 가시화**
+- **Story-TBD(EC2 폐기)**: `dev-cicd.yml`의 EC2 SSH 배포 step 제거 — ECS 운영 검증 통과 후
+- **Story-TBD(Health Indicator)**: `/health` → `/actuator/health` + DB/Redis HealthIndicator 활성 — 현재 false-positive 위험(ts008-2 #5) 해결
+- **Story-TBD(staging profile)**: `application-staging.yml` 신설 + staging Task Def env 정정 — staging transitional 해소
+- **Story-TBD(SPOT 안정성)**: staging server.shutdown=graceful 도입 + interruption 알림 처리 — SPOT Task가 부하 테스트 중 abruptly 종료 시 graceful 종료 보장
 
 ---
 

--- a/infra/ecs/service-prod.json
+++ b/infra/ecs/service-prod.json
@@ -1,0 +1,39 @@
+{
+  "cluster": "thirdtool-prod",
+  "serviceName": "thirdtool-app",
+  "taskDefinition": "thirdtool-prod",
+  "desiredCount": 2,
+  "launchType": "FARGATE",
+  "platformVersion": "LATEST",
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["<APP_SUBNET_2A>", "<APP_SUBNET_2C>"],
+      "securityGroups": ["<APP_SG>"],
+      "assignPublicIp": "DISABLED"
+    }
+  },
+  "loadBalancers": [
+    {
+      "targetGroupArn": "<PROD_TARGET_GROUP_ARN>",
+      "containerName": "app",
+      "containerPort": 8080
+    }
+  ],
+  "deploymentConfiguration": {
+    "minimumHealthyPercent": 100,
+    "maximumPercent": 200,
+    "deploymentCircuitBreaker": {
+      "enable": true,
+      "rollback": true
+    }
+  },
+  "healthCheckGracePeriodSeconds": 90,
+  "enableExecuteCommand": true,
+  "availabilityZoneRebalancing": "ENABLED",
+  "propagateTags": "SERVICE",
+  "tags": [
+    { "key": "Application", "value": "thirdtool" },
+    { "key": "Environment", "value": "prod" },
+    { "key": "ManagedBy",   "value": "Story-047" }
+  ]
+}

--- a/infra/ecs/service-staging.json
+++ b/infra/ecs/service-staging.json
@@ -1,0 +1,42 @@
+{
+  "cluster": "thirdtool-staging",
+  "serviceName": "thirdtool-app",
+  "taskDefinition": "thirdtool-staging",
+  "desiredCount": 1,
+  "platformVersion": "LATEST",
+  "capacityProviderStrategy": [
+    { "capacityProvider": "FARGATE",      "weight": 50 },
+    { "capacityProvider": "FARGATE_SPOT", "weight": 50 }
+  ],
+  "networkConfiguration": {
+    "awsvpcConfiguration": {
+      "subnets": ["<APP_SUBNET_2A>", "<APP_SUBNET_2C>"],
+      "securityGroups": ["<APP_SG>"],
+      "assignPublicIp": "DISABLED"
+    }
+  },
+  "loadBalancers": [
+    {
+      "targetGroupArn": "<STAGING_TARGET_GROUP_ARN>",
+      "containerName": "app",
+      "containerPort": 8080
+    }
+  ],
+  "deploymentConfiguration": {
+    "minimumHealthyPercent": 100,
+    "maximumPercent": 200,
+    "deploymentCircuitBreaker": {
+      "enable": true,
+      "rollback": true
+    }
+  },
+  "healthCheckGracePeriodSeconds": 90,
+  "enableExecuteCommand": true,
+  "availabilityZoneRebalancing": "ENABLED",
+  "propagateTags": "SERVICE",
+  "tags": [
+    { "key": "Application", "value": "thirdtool" },
+    { "key": "Environment", "value": "staging" },
+    { "key": "ManagedBy",   "value": "Story-047" }
+  ]
+}

--- a/infra/ecs/task-definition-prod.json
+++ b/infra/ecs/task-definition-prod.json
@@ -1,0 +1,61 @@
+{
+  "family": "thirdtool-prod",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "1024",
+  "memory": "2048",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-execution-role",
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-role",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "<AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/third-tool-server:<IMAGE_TAG>",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp",
+          "name": "http"
+        }
+      ],
+      "environment": [
+        { "name": "SPRING_PROFILES_ACTIVE", "value": "prod" },
+        { "name": "TZ", "value": "Asia/Seoul" },
+        { "name": "DB_PORT", "value": "3306" }
+      ],
+      "secrets": [
+        { "name": "DB_HOST",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:HOST::" },
+        { "name": "DB_NAME",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:NAME::" },
+        { "name": "DB_USERNAME",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:USERNAME::" },
+        { "name": "DB_PASSWORD",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:PASSWORD::" },
+        { "name": "JWT_SECRET_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/jwt-<SUFFIX>:SECRET_KEY::" },
+        { "name": "KAKAO_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:KAKAO_CLIENT_ID::" },
+        { "name": "KAKAO_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:KAKAO_CLIENT_SECRET::" },
+        { "name": "NAVER_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:NAVER_CLIENT_ID::" },
+        { "name": "NAVER_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:NAVER_CLIENT_SECRET::" },
+        { "name": "AWS_ACCESS_KEY_ID",     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/aws-<SUFFIX>:ACCESS_KEY_ID::" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/aws-<SUFFIX>:SECRET_ACCESS_KEY::" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/thirdtool-prod",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "app",
+          "awslogs-create-group": "false"
+        }
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget -q -O- http://localhost:8080/health || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}

--- a/infra/ecs/task-definition-staging.json
+++ b/infra/ecs/task-definition-staging.json
@@ -1,0 +1,61 @@
+{
+  "family": "thirdtool-staging",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-execution-role",
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-role",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "<AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/third-tool-server:<IMAGE_TAG>",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp",
+          "name": "http"
+        }
+      ],
+      "environment": [
+        { "name": "SPRING_PROFILES_ACTIVE", "value": "prod" },
+        { "name": "TZ", "value": "Asia/Seoul" },
+        { "name": "DB_PORT", "value": "3306" }
+      ],
+      "secrets": [
+        { "name": "DB_HOST",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:HOST::" },
+        { "name": "DB_NAME",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:NAME::" },
+        { "name": "DB_USERNAME",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:USERNAME::" },
+        { "name": "DB_PASSWORD",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:PASSWORD::" },
+        { "name": "JWT_SECRET_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/jwt-<SUFFIX>:SECRET_KEY::" },
+        { "name": "KAKAO_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:KAKAO_CLIENT_ID::" },
+        { "name": "KAKAO_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:KAKAO_CLIENT_SECRET::" },
+        { "name": "NAVER_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:NAVER_CLIENT_ID::" },
+        { "name": "NAVER_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:NAVER_CLIENT_SECRET::" },
+        { "name": "AWS_ACCESS_KEY_ID",     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/aws-<SUFFIX>:ACCESS_KEY_ID::" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/aws-<SUFFIX>:SECRET_ACCESS_KEY::" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/thirdtool-staging",
+          "awslogs-region": "ap-northeast-2",
+          "awslogs-stream-prefix": "app",
+          "awslogs-create-group": "false"
+        }
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "wget -q -O- http://localhost:8080/health || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      }
+    }
+  ]
+}

--- a/infra/iam/ecs-task-execution-role-permissions-policy.json
+++ b/infra/iam/ecs-task-execution-role-permissions-policy.json
@@ -1,0 +1,48 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuthToken",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrPullThirdToolImages",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": [
+        "arn:aws:ecr:ap-northeast-2:<AWS_ACCOUNT_ID>:repository/third-tool-server",
+        "arn:aws:ecr:ap-northeast-2:<AWS_ACCOUNT_ID>:repository/third-tool-elaticsearch"
+      ]
+    },
+    {
+      "Sid": "CloudWatchLogsWriteEcsStreams",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:ap-northeast-2:<AWS_ACCOUNT_ID>:log-group:/ecs/thirdtool-prod:log-stream:*",
+        "arn:aws:logs:ap-northeast-2:<AWS_ACCOUNT_ID>:log-group:/ecs/thirdtool-staging:log-stream:*"
+      ]
+    },
+    {
+      "Sid": "SecretsManagerReadThirdToolPrefix",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/*",
+        "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/*"
+      ]
+    }
+  ]
+}

--- a/infra/iam/ecs-task-execution-role-trust-policy.json
+++ b/infra/iam/ecs-task-execution-role-trust-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowEcsTasksAssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/infra/iam/ecs-task-role-permissions-policy.json
+++ b/infra/iam/ecs-task-role-permissions-policy.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3BucketReadWriteThirdToolServer",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::third-tool-s3-server",
+        "arn:aws:s3:::third-tool-s3-server/*"
+      ]
+    },
+    {
+      "Sid": "EcsExecSsmChannel",
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infra/iam/ecs-task-role-trust-policy.json
+++ b/infra/iam/ecs-task-role-trust-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowEcsTasksAssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/infra/iam/gha-deploy-role-permissions-policy.json
+++ b/infra/iam/gha-deploy-role-permissions-policy.json
@@ -23,6 +23,32 @@
         "arn:aws:ecr:ap-northeast-2:<AWS_ACCOUNT_ID>:repository/third-tool-server",
         "arn:aws:ecr:ap-northeast-2:<AWS_ACCOUNT_ID>:repository/third-tool-elaticsearch"
       ]
+    },
+    {
+      "Sid": "EcsDeploy",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:RegisterTaskDefinition",
+        "ecs:DescribeTaskDefinition",
+        "ecs:DeregisterTaskDefinition",
+        "ecs:DescribeServices",
+        "ecs:UpdateService"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IamPassRoleToEcsTasks",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": [
+        "arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-execution-role",
+        "arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-role"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ecs-tasks.amazonaws.com"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## 개요

Spring Boot 컨테이너가 ECS Fargate Task로 실행되기 위한 모든 JSON 정의(Task Definition + Service)와 IAM Role 3종(Execution + Task + GHA Deploy 확장) + 운영 runbook(ts008) + 결정 기록(ADR014)을 코드베이스에 추가한다. milestone 0.0.1v item #11 "5 ECS 2-2 ECS Task Definition + Service" 코드 단 충족.

실제 ECS 운영(Cluster 생성·Task Def 등록·Service 생성)은 사용자가 ts008 runbook 따라 1회 실행하며, #12 VPC + #13 ALB + #14 RDS + #15 Secrets 4건이 모두 완료된 시점에 end-to-end 가능.

## 왜 / 설계 결정

- **IAM Role 3종 분리 (ADR014)**: 컨테이너 침해 시 권한 확대 차단. ECS 에이전트(Execution Role: ECR/Logs/Secrets)와 컨테이너 코드(Task Role: S3/SSM)와 GHA(Deploy Role: ECR push + ECS deploy + PassRole 한정)를 분리
- **PassRole condition 잠금**: `gha-deploy-role`의 `iam:PassRole`을 두 Task Role ARN으로 한정 + `iam:PassedToService=ecs-tasks.amazonaws.com` Condition → CI/CD compromise 시 임의 Role을 Task에 attach 차단
- **Secrets Manager prefix 한정**: Execution Role의 Secrets Manager read를 `thirdtool/{prod,staging}/*`만 → 다른 시크릿 접근 차단
- **Circuit Breaker rollback 활성**: deploymentConfiguration에 `deploymentCircuitBreaker.enable+rollback` — 헬스체크 실패 시 자동 롤백. 5xx 폭증 모니터링은 별도 Story (product Epic 3 잔여)
- **Multi-AZ 분산**: `availabilityZoneRebalancing: ENABLED` + `desiredCount: 2` (prod) → AZ 장애 시 1대 생존
- **transitional 결정 명시화**: AWS 키 2건 secrets에 포함(S3Config 전환 전), staging Task Def `SPRING_PROFILES_ACTIVE=prod`(application-staging.yml 부재) — 모두 ADR014 follow-up + ts008 §9 Story-TBD로 트래킹

## 작업 내용

- **feat(infra)**: `infra/ecs/` 신규 디렉토리 + Task Def 2종(prod 1vCPU/2GB·2대 / staging 0.5vCPU/1GB·SPOT 50%) + Service 2종 (Circuit Breaker + ECS Exec + Multi-AZ)
- **feat(infra)**: `infra/iam/` IAM Role 3종 정책 — `gha-deploy-role` permissions 확장 (ecs:* 5 actions + iam:PassRole 한정) + `ecs-task-execution-role` trust/permissions 신규 + `ecs-task-role` trust/permissions 신규
- **docs(operations)**: `docs/operations/troubleshooting/ts008-ecs-cluster-setup.md` (300+줄) — 9 섹션(전제·Log group·IAM·Cluster·Task Def·Service·검증·트러블슈팅 6건·후속 Story 10건)
- **docs(adr)**: `docs/adr/ADR014-ecs-task-iam-role-separation.md` + index 갱신 — 대안 6종 비교 + ECS Resource * 한정 분석 표 + follow-up 8건
- **fix(infra)**: Reviewer 5관점 지적 보강 — Critical 4건(cost.md/milestone 체크 시점/staging profile/healthCheck false-positive) + Major 5건(wget BusyBox/Resource */grace period/Prerequisites/follow-up tracker) 일괄 fix

## 변경 유형

- [x] feat  - [x] fix  - [ ] refactor  - [x] docs  - [ ] test  - [ ] chore

## 테스트

- `for f in infra/ecs/*.json infra/iam/*.json; do jq . "$f" > /dev/null; done` → 9건 OK
- Java 코드 0줄 변경 — 단위/슬라이스 테스트 추가 의무 없음 (conventions §4.8 트리거 적용 불가)
- **end-to-end 검증은 사용자 영역** — ts008 §1-6 1회성 셋업 (Log group + IAM Role 3종 + Cluster + Task Def + Service) 후 §7 검증 5건 (Task RUNNING/HEALTHY, CloudWatch Logs 흐름, ALB Target healthy, /health 200, ECS Exec). **§5-7은 #12 VPC + #13 ALB + #14 RDS + #15 Secrets 4 placeholder 모두 치환 후 실행 가능** — 그 전까지 §2-3(Log group + IAM Role)까지만 1회성 선행 추천

## 체크리스트

- [x] 빌드 / 테스트 통과 (자바 무변경 — sanity)
- [x] 모든 응답 `ApiResponse<T>` 래퍼 — N/A (API 변경 없음)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — ADR014 신규 + index 갱신
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 — N/A
- [x] BC 간 의존 방향 위반 없음 — N/A (인프라 변경)
- [x] 대상 브랜치 = `develop` 확인

## 머지 영향 (안전성)

- 본 PR은 `.github/workflows/*.yml` 변경 없음 → **기존 EC2 SSH 배포 흐름 영향 0건**. main push 시 dev-cicd.yml 그대로 동작
- `gha-deploy-role` permissions가 확장됐지만 기존 ECR push actions(Story-046)는 보존 → ECR push 회귀 없음
- ECS 실제 Task는 #12-#15 완료 + ts008 §3-6 사용자 셋업 후에만 RUNNING 가능 → 머지 직후 ECS 측 변화 없음

## 후속 Story (별도 PR — ts008 §9 + ADR014 follow-up)

- VPC subnet/SG 치환 (milestone #12)
- ALB Target Group ARN 치환 (milestone #13, target-type=ip 필수)
- RDS endpoint Secrets Manager 값 갱신 (milestone #14)
- Secrets Manager 시크릿 등록 + `<SUFFIX>` 치환 (milestone #15)
- GHA workflow `aws-actions/amazon-ecs-deploy-task-definition` 도입 (deploy automation)
- 5xx 폭증 자동 롤백 + 5분 모니터링 (product Epic 3 잔여)
- `S3Config.java` → `DefaultCredentialsProvider` 전환 + AWS 키 secret 2건 제거 (transitional 해소)
- EC2 SSH 배포 step 제거 (ECS 운영 검증 통과 후)
- `/health` → `/actuator/health` + DB HealthIndicator 활성 (false-positive 해결)
- `application-staging.yml` 신설 + staging Task Def env 정정 (staging transitional 해소)
- staging SPOT graceful shutdown 도입 (interruption 안정성)

## 관련 이슈

- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-infra-deploy.md` (Epic 2 Story 2-1 코드 단 충족)
- Milestone: `workflow/task/milestones/version/0.0.1v/milestone.md` item #11
- Story: Story-047
- ADR: ADR014 (선행 결정: ADR013 OIDC AssumeRole)
- Runbook: ts008 (선행 의존: ts007 OIDC 셋업)

## 비용 영향 참고 (로컬 cost.md 갱신)

- 이전 baseline: $3.27/일 (Task 0.25vCPU·0.5GB·1대 가정)
- 본 Story 정의 적용 시: **$5.77/일** (prod 1vCPU·2GB·2대 = $2.46/일 + staging 0.5vCPU·1GB·SPOT 50% = $0.31/일)
- 본주 누적 추정 $19.6 → $34.6. M2 ECS autoscaling 도입 시 재산정 필요