### PR TITLE
feat(infra): Story-048 VPC 10.0.0.0/16 + 6 subnet + 5 SG + IGW + NAT + ADR015 + ts009

### DIFF
--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -210,6 +210,16 @@ public LearningFacadeResponse.UpdateAxisName updateAxisName(
 - `Ai/presentation/` — AI 관련 (사용 중)
 - `redis/` — 빈 디렉토리 (인프라만 docker-compose에 존재)
 
+### AWS 인프라 자원 정의 (프로젝트 루트 `infra/` — 코드 아닌 IaC spec)
+
+`src/main/java/.../infra`(BC 횡단 어댑터)와 별개로 프로젝트 루트의 `infra/`는 AWS 리소스 spec JSON을 둔다. Terraform 모듈화(M2 Product 7) 이전까지 ts0NN runbook과 함께 단일 진실 소스 역할.
+
+- `infra/iam/` — IAM Role 신뢰·권한 정책 JSON (Story-046 OIDC + Story-047 ECS Task Role 3종)
+- `infra/ecs/` — ECS Task Definition + Service JSON (Story-047, prod/staging 2종씩)
+- `infra/vpc/` — VPC + 6 subnet + IGW + NAT + 2 route table + 5 SG spec JSON (Story-048)
+
+각 디렉토리의 JSON과 매핑되는 운영 runbook은 `docs/operations/troubleshooting/ts00N-*.md`, 결정 배경은 `docs/adr/ADR0NN-*.md`. 본 디렉토리 변경은 도메인 코드와 무관 — 코드 컨벤션·BC 의존 규칙 적용 대상 아님.
+
 ---
 
 ## 6. BC 간 의존 규칙

--- a/docs/adr/ADR015-vpc-3-layer-network-design.md
+++ b/docs/adr/ADR015-vpc-3-layer-network-design.md
@@ -25,8 +25,9 @@ milestone 0.0.1v 의존 chain에서 **VPC가 가장 큰 unblocker**다. #13 ALB�
 | --- | --- | --- |
 | Region | `ap-northeast-2` (서울) | 기존 dev-cicd / S3 / ECR 모두 동일 region. 한국 사용자 latency |
 | VPC CIDR | `10.0.0.0/16` (65,536 IP) | 향후 service 확장 여유. /20보다 큰 표준 |
-| AZ 수 | 2 (2a, 2c) | 서울 region 사용 가능 AZ — 2a/2c/2d 중 가장 안정 2개. 최소 multi-AZ 구성 |
+| AZ 수 | 2 (2a, 2c) | ap-northeast-2 사용 가능 AZ는 2a/2b/2c/2d 모두 — 본 ADR은 2a/2c 채택 (Default VPC 사용 AZ와 동일하여 기존 자원 마이그레이션 시 IP 회피 부담 최소화 + 2개 분산으로 multi-AZ 최소 구성). 어느 2개 조합이든 가용성 동등 |
 | Subnet | 3 layer × 2 AZ = 6개 | layer 분리로 보안 경계 명확. /24(251 호스트)로 충분 |
+| Subnet CIDR 예약 공간 | 10.0.2-9/24, 10.0.12-19/24, 10.0.22-255/24 (총 244 블록) | 의도된 reserve — 향후 신규 layer(ElastiCache 10.0.30.0/24, OpenSearch 10.0.40.0/24, Kubernetes worker 10.0.50.0/24 등) 추가 시 layer별 10번 단위 분리 패턴 유지. 임의 신규 subnet 추가 시 본 패턴 따를 것 |
 | public subnet (`10.0.0.0/24`, `10.0.1.0/24`) | ALB target + NAT Gateway | 인터넷 직접 노출 자원만 |
 | app subnet (`10.0.10.0/24`, `10.0.11.0/24`) | ECS Fargate Task | 외부 inbound 차단, NAT 경유 outbound |
 | data subnet (`10.0.20.0/24`, `10.0.21.0/24`) | RDS MySQL | 외부·ALB 어디서도 직접 접근 불가 |
@@ -64,7 +65,7 @@ vpc-endpoint-sg (app-sg → 443, M2 VPC Endpoint 대비)
 ### 긍정적
 
 - **보안 경계 명확**: RDS가 외부·ALB에서 직접 접근 불가. 침해 시 폭발 반경 한정. layer 별 SG 분리로 침해 1점이 다른 layer로 확산 차단
-- **multi-AZ 분산 즉시 가능**: ECS Service `availabilityZoneRebalancing: ENABLED`(Story-047)가 2a/2c에 Task 자동 분산. RDS도 multi-AZ 전환 시 data-2c 즉시 활용
+- **multi-AZ 분산 즉시 가능 (부분)**: ECS Service `availabilityZoneRebalancing: ENABLED`(Story-047)가 2a/2c에 Task 자동 분산. RDS도 multi-AZ 전환 시 data-2c 즉시 활용. **단 단일 NAT(public-2a) 때문에 2a 장애 시 app-2c Task의 outbound도 차단 — inbound 가용성만 부분 유지. 완전 multi-AZ 가용성은 multi-AZ NAT(M2) 도입 후 달성**
 - **CIDR 여유**: `/16` 65K IP 중 1.5K만 사용 — 향후 service 4-5배 확장 가능. peering 시 conflict 회피 여유 (10.x.x.x private는 흔하지만 우리 /16 한 블록만 사용)
 - **single source of truth**: `vpc-spec.json` + `security-groups.json`이 단일 진실 소스. ts009 runbook이 그대로 재현. M2 Terraform 모듈화 시 입력으로 활용
 - **SSH 키 폐기**: Bastion이 SSM 채택 → `bastion-sg` inbound 없음. SSH 키 관리·회전 불필요

--- a/docs/adr/ADR015-vpc-3-layer-network-design.md
+++ b/docs/adr/ADR015-vpc-3-layer-network-design.md
@@ -1,0 +1,109 @@
+# ADR015: VPC 10.0.0.0/16 + 2 AZ × 3-layer subnet + 단일 NAT Gateway (Story-048)
+
+- **상태**: Accepted
+- **날짜**: 2026-06-29
+- **관련**: Product 6 AWS 네트워크 Epic 1 (VPC 구축) · milestone 0.0.1v item #12 (`workflow/task/milestones/version/0.0.1v/milestone.md`) · `docs/architecture/vpc-topology.md` · `docs/operations/troubleshooting/ts009-vpc-setup.md` · `infra/vpc/vpc-spec.json` · `infra/vpc/security-groups.json`
+
+## 컨텍스트
+
+milestone 0.0.1v 의존 chain에서 **VPC가 가장 큰 unblocker**다. #13 ALB·#14 RDS·#11 ECS Service(Story-047 `service-prod.json`의 `<APP_SUBNET_*>`/`<APP_SG>` placeholder) 모두 VPC 자원 ID 선행 필요. ThirdTool은 portfolio 프로젝트로 트래픽 0명 상태이지만, 1인 운영자가 다음을 만족하는 네트워크 토폴로지를 정의해야 한다:
+
+- **보안 경계 명확화**: RDS가 인터넷에서 직접 접근 불가, ECS Task가 ALB 외 inbound 차단, 각 layer 간 트래픽이 SG로 제어
+- **multi-AZ 분산 가능성**: Fargate Task가 2 AZ에 분산되어 AZ 장애 시 부분 가용성 유지
+- **IP 주소 여유**: 향후 신규 service 추가(예: ElastiCache, Bastion, VPC Endpoint) 시 CIDR 재설계 불요
+- **비용 최소화**: M1 트래픽 미발생 단계에서 NAT Gateway 과도 운영 방지
+
+기존 dev-cicd.yml은 EC2 단일 인스턴스 + default VPC에서 운영 중 — 보안 경계 부재, 향후 ECS Fargate 전환 시 재현 불가. 본 ADR이 새 VPC의 1차 설계 결정을 기록한다.
+
+## 결정
+
+**VPC `10.0.0.0/16` + 2 AZ(ap-northeast-2a/2c) × 3 layer(public/app/data) = 6 subnet + IGW 1 + NAT Gateway 1(public-2a 단일) + 5종 SG**.
+
+### 핵심 구성
+
+| 항목 | 결정 | 근거 |
+| --- | --- | --- |
+| Region | `ap-northeast-2` (서울) | 기존 dev-cicd / S3 / ECR 모두 동일 region. 한국 사용자 latency |
+| VPC CIDR | `10.0.0.0/16` (65,536 IP) | 향후 service 확장 여유. /20보다 큰 표준 |
+| AZ 수 | 2 (2a, 2c) | 서울 region 사용 가능 AZ — 2a/2c/2d 중 가장 안정 2개. 최소 multi-AZ 구성 |
+| Subnet | 3 layer × 2 AZ = 6개 | layer 분리로 보안 경계 명확. /24(251 호스트)로 충분 |
+| public subnet (`10.0.0.0/24`, `10.0.1.0/24`) | ALB target + NAT Gateway | 인터넷 직접 노출 자원만 |
+| app subnet (`10.0.10.0/24`, `10.0.11.0/24`) | ECS Fargate Task | 외부 inbound 차단, NAT 경유 outbound |
+| data subnet (`10.0.20.0/24`, `10.0.21.0/24`) | RDS MySQL | 외부·ALB 어디서도 직접 접근 불가 |
+| Internet Gateway | 1개 | VPC 표준 |
+| **NAT Gateway** | **1개 (public-2a 단일)** | multi-AZ NAT 비용 대비 M1 가용성 요구 낮음. **trade-off**: 2a 장애 시 private 트래픽 전체 차단 |
+| Route Table | 2개 (public-rt + private-rt) | layer 분리에 정합 |
+| Security Group | 5종 명확 분리 (alb/app/db/bastion/vpc-endpoint) | 참조 체인 alb→app→db로 데이터 흐름 일치 |
+
+### SG 참조 체인 (단방향)
+
+```
+alb-sg          (인터넷 → 80/443)
+  ↓ 참조
+app-sg          (alb-sg → 8080)
+  ↓ 참조
+db-sg           (app-sg → 3306, egress 없음)
+
+bastion-sg      (inbound 없음 — SSM Session Manager 채택)
+vpc-endpoint-sg (app-sg → 443, M2 VPC Endpoint 대비)
+```
+
+순방향 참조만 — 순환 없음. RDS는 ALB·인터넷 어디서도 직접 접근 불가.
+
+### 본 ADR이 다루지 않는 범위
+
+- **Terraform IaC 모듈화**: 본 ADR은 `infra/vpc/*.json` spec + ts009 콘솔/CLI 셋업 가정. Terraform 모듈은 M2 Product 7 Epic 2
+- **VPC Endpoint 실제 생성**: 본 ADR은 `vpc-endpoint-sg` 정의만 (M2 대비). 4종 endpoint(s3·ecr·secretsmanager·logs) 실제 생성은 NAT 비용 임계 도달 시
+- **VPC Flow Logs**: 네트워크 관측성 별도 Story (보안 사고 추적 필요 시점)
+- **Network ACL 커스터마이즈**: default(allow all) 유지 — SG로 차단
+- **staging 전용 VPC 분리**: 현재 prod/staging 동일 VPC 공유. 환경 분리 Epic
+- **Bastion EC2 실제 생성**: SG만 정의. SSM Session Manager 채택 — 인스턴스 자체는 운영 진입 필요 시점에 별도 Story
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **보안 경계 명확**: RDS가 외부·ALB에서 직접 접근 불가. 침해 시 폭발 반경 한정. layer 별 SG 분리로 침해 1점이 다른 layer로 확산 차단
+- **multi-AZ 분산 즉시 가능**: ECS Service `availabilityZoneRebalancing: ENABLED`(Story-047)가 2a/2c에 Task 자동 분산. RDS도 multi-AZ 전환 시 data-2c 즉시 활용
+- **CIDR 여유**: `/16` 65K IP 중 1.5K만 사용 — 향후 service 4-5배 확장 가능. peering 시 conflict 회피 여유 (10.x.x.x private는 흔하지만 우리 /16 한 블록만 사용)
+- **single source of truth**: `vpc-spec.json` + `security-groups.json`이 단일 진실 소스. ts009 runbook이 그대로 재현. M2 Terraform 모듈화 시 입력으로 활용
+- **SSH 키 폐기**: Bastion이 SSM 채택 → `bastion-sg` inbound 없음. SSH 키 관리·회전 불필요
+
+### 트레이드오프 / 부정적
+
+- **단일 NAT Gateway 장애점**: public-2a 장애 시 private subnet 4개 모두 outbound 트래픽 차단(ECR pull·Secrets Manager·외부 API 모두 실패). M1 트래픽 0명이라 수용. M2 multi-AZ NAT(`Story-TBD`) 전환 시점은 트래픽 발생 후
+- **NAT Gateway 데이터 전송 비용**: 모든 private outbound 트래픽이 NAT 경유 → $0.045/GB. VPC Endpoint 미구축으로 AWS API 호출도 NAT 경유. M2 Endpoint 도입 시 절감
+- **layer 분리 운영 부담**: 6 subnet + 5 SG + 2 route table을 사용자가 수동 생성(ts009). drift 위험 — 콘솔에서 수동 변경 시 spec과 불일치. Terraform 도입 전까지 ts009 절차 엄수 필요
+- **2a 편향**: NAT가 public-2a 단독이라 트래픽 패턴이 2a 편중. 2a CloudWatch 메트릭이 다른 AZ보다 항상 높음 — 모니터링 알림 임계 조정 필요
+- **bastion EC2 부재 — 디버깅 도구 부족**: SSM Session Manager는 IAM 권한 기반이지만 SSM 미설치 환경에서 즉시 접근 불가. ECS Exec 가능 시점까지는 운영 진입 채널 부족
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **A. Default VPC 그대로 사용** | 셋업 0, 즉시 사용 | 보안 경계 부재 (모든 subnet이 public). RDS 외부 노출 위험. layer 개념 없음 — 침해 시 폭발 반경 최대 |
+| **B. 1-layer subnet (public만)** | subnet 2개로 간소 | RDS·ECS Task가 인터넷 직접 노출. 보안 경계 부재 |
+| **C. 2-layer subnet (public + private)** | subnet 4개. 보안 적정 | ECS Task와 RDS가 동일 private subnet. SG로만 격리 — layer 명시성 약함. data 전용 격리 의도 표현 불가 |
+| **D (선택). 3-layer subnet (public/app/data) + 단일 NAT** | layer 경계 명확, SG 참조 체인 + 라우팅이 일치, M2 확장 가능 | 단일 NAT 장애점 (수용 — M1 가용성 요구 낮음). 6 subnet 셋업 부담 (ts009로 표준화) |
+| **E. 4+ layer subnet (예: public/app/data/cache 분리)** | 더 세밀한 경계 | 현재 cache(Redis) 미사용. 미래에 도입 시 별도 subnet 추가 가능 — 과도한 선제 분리 |
+| **F. Multi-AZ NAT Gateway (NAT 2개)** | 2a 장애 시에도 private 트래픽 유지 | NAT 시간 비용 2배 ($0.06/시간 × 2). M1 가용성 요구가 비용 대비 작음. M2 트래픽 발생 시 전환 |
+| **G. VPC Endpoint 즉시 도입** | NAT 데이터 전송 비용 절감 (특히 ECR pull) | Interface Endpoint 시간 비용 ($0.014/시간 × 4 endpoint = $0.056/시간). M1 트래픽 낮아 NAT 데이터 전송도 작음 — break-even 미달. M2에서 트래픽 측정 후 결정 |
+
+## 알려진 follow-up (본 ADR 범위 외)
+
+- **multi-AZ NAT Gateway 전환** (Story-TBD): public-2c에 NAT 추가 + `private-rt` 2개로 분리(2a용·2c용). 트래픽 발생 후 가용성 임계 도달 시
+- **VPC Interface Endpoint 4종 도입** (Story-TBD): s3·ecr·secretsmanager·logs. `vpc-endpoint-sg`가 본 ADR에서 미리 정의 — 그대로 활용. NAT 데이터 전송 비용 임계 도달 시
+- **VPC Flow Logs 활성** (Story-TBD): CloudWatch Logs 송신. 보안 감사·DDoS 탐지·트래픽 분석 필요 시
+- **Terraform IaC 모듈화** (M2 Product 7 Epic 2): 본 `vpc-spec.json` + `security-groups.json`을 Terraform 모듈 입력으로 변환. drift 차단 + 환경별 재현
+- **staging 전용 VPC 분리** (환경 분리 Epic): 현재 prod/staging 동일 VPC 공유. cross-environment 격리 필요 시
+- **Bastion EC2 인스턴스 실제 생성** (Story-TBD): `bastion-sg`만 정의됨. 운영 진입 채널 필요 시점에 SSM 활성 인스턴스 1대 띄움
+- **Network ACL 강화**: default(allow all) 유지 중. layer 간 격리 추가 필요 시
+- **IPv6 CIDR 추가** (M3+): 현재 IPv4 only. IPv6 트래픽 발생 시점에 검토
+
+## 다시 검토할 시점
+
+- **트래픽 발생 시점**: NAT 데이터 전송량 측정 → VPC Endpoint 도입 또는 multi-AZ NAT 결정
+- **AZ 장애 발생 시점**: 단일 NAT 장애점이 실제 영향 — multi-AZ 즉시 전환
+- **service 추가 시점**: ElastiCache·OpenSearch 등 신규 layer 도입 검토 (subnet 추가 또는 기존 layer 재사용)
+- **peering 도입 시점**: 다른 VPC와 연결 시 CIDR 충돌 확인 (`10.0.0.0/16` 다른 VPC에서 사용 중이면 재설계)
+- **multi-region 진입 시점**: ap-northeast-1(Tokyo) DR 리전 도입 시 IP 대역 분리 (예: `10.1.0.0/16`)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -16,3 +16,4 @@
 | [ADR012](ADR012.md) | 운영 컨테이너 base image `eclipse-temurin:21-jre-alpine` 채택, Distroless 보류 (Story 1-1) | Accepted | 2026-06-25 |
 | [ADR013](ADR013-gha-oidc-assume-role.md) | GitHub Actions → AWS 인증을 OIDC AssumeRole로 전환 (Story-046) | Accepted | 2026-06-29 |
 | [ADR014](ADR014-ecs-task-iam-role-separation.md) | ECS Task IAM Role 3종 분리 — Execution/Task/GHA Deploy (Story-047) | Accepted | 2026-06-29 |
+| [ADR015](ADR015-vpc-3-layer-network-design.md) | VPC 10.0.0.0/16 + 2 AZ × 3-layer subnet + 단일 NAT (Story-048) | Accepted | 2026-06-29 |

--- a/docs/architecture/vpc-topology.md
+++ b/docs/architecture/vpc-topology.md
@@ -1,0 +1,154 @@
+# VPC 토폴로지 (Story-048)
+
+> ThirdTool AWS 네트워크 단일 진실 소스 다이어그램. 신규 합류자가 30초 안에 토폴로지·데이터 흐름·보안 경계를 파악할 수 있도록 작성.
+>
+> 코드 단일 진실 소스: `infra/vpc/vpc-spec.json` + `infra/vpc/security-groups.json`.
+> 의사결정 배경: [ADR015](../adr/ADR015-vpc-3-layer-network-design.md).
+> 셋업 절차: [ts009](../operations/troubleshooting/ts009-vpc-setup.md).
+
+---
+
+## 1. 토폴로지
+
+```mermaid
+graph TB
+  subgraph Internet
+    USER[User Browser]
+  end
+
+  subgraph VPC["VPC thirdtool-vpc · 10.0.0.0/16 · ap-northeast-2"]
+    IGW[Internet Gateway<br/>thirdtool-igw]
+
+    subgraph AZ_2A["AZ ap-northeast-2a"]
+      direction TB
+      PUB_2A[public-2a<br/>10.0.0.0/24<br/>NAT + ALB target]
+      APP_2A[app-2a<br/>10.0.10.0/24<br/>ECS Task]
+      DATA_2A[data-2a<br/>10.0.20.0/24<br/>RDS primary]
+      NAT[NAT Gateway<br/>thirdtool-nat<br/>single-AZ]
+    end
+
+    subgraph AZ_2C["AZ ap-northeast-2c"]
+      direction TB
+      PUB_2C[public-2c<br/>10.0.1.0/24<br/>ALB target]
+      APP_2C[app-2c<br/>10.0.11.0/24<br/>ECS Task]
+      DATA_2C[data-2c<br/>10.0.21.0/24<br/>RDS standby M2]
+    end
+
+    ALB[ALB<br/>internet-facing<br/>alb-sg]
+    ECS1[ECS Task<br/>app-sg]
+    ECS2[ECS Task<br/>app-sg]
+    RDS[(RDS MySQL<br/>db-sg)]
+  end
+
+  USER -->|HTTPS| IGW
+  IGW --> PUB_2A
+  IGW --> PUB_2C
+  PUB_2A -.contains.-> ALB
+  PUB_2C -.contains.-> ALB
+  PUB_2A -.contains.-> NAT
+  APP_2A -.contains.-> ECS1
+  APP_2C -.contains.-> ECS2
+  DATA_2A -.contains.-> RDS
+
+  ALB -->|8080| ECS1
+  ALB -->|8080| ECS2
+  ECS1 -->|3306| RDS
+  ECS2 -->|3306| RDS
+  ECS1 -->|outbound HTTPS| NAT
+  ECS2 -->|outbound HTTPS| NAT
+  NAT --> IGW
+```
+
+---
+
+## 2. Subnet 표
+
+| subnet 이름 | CIDR | AZ | layer | route table | 용도 |
+| --- | --- | --- | --- | --- | --- |
+| `public-2a` | `10.0.0.0/24`  | ap-northeast-2a | public | public-rt  | ALB target + NAT Gateway |
+| `public-2c` | `10.0.1.0/24`  | ap-northeast-2c | public | public-rt  | ALB target (multi-AZ) |
+| `app-2a`    | `10.0.10.0/24` | ap-northeast-2a | app    | private-rt | ECS Fargate Task |
+| `app-2c`    | `10.0.11.0/24` | ap-northeast-2c | app    | private-rt | ECS Fargate Task |
+| `data-2a`   | `10.0.20.0/24` | ap-northeast-2a | data   | private-rt | RDS MySQL primary |
+| `data-2c`   | `10.0.21.0/24` | ap-northeast-2c | data   | private-rt | RDS standby (M2 multi-AZ 시) |
+
+각 /24 = 251 호스트 (AWS 예약 5개 차감). M1 트래픽에 충분.
+
+---
+
+## 3. 라우팅 표
+
+| route table | 연결 subnet | 라우트 |
+| --- | --- | --- |
+| `public-rt`  | `public-2a`, `public-2c` | `0.0.0.0/0 → thirdtool-igw` |
+| `private-rt` | `app-2a`, `app-2c`, `data-2a`, `data-2c` | `0.0.0.0/0 → thirdtool-nat` |
+
+private subnet 4개 모두 동일 `private-rt` 사용 → 모든 private 트래픽이 `thirdtool-nat`(public-2a) 경유. **NAT 단일 장애점** — ADR015 결정 trade-off.
+
+---
+
+## 4. Security Group 규칙 표
+
+| SG | inbound | outbound | 비고 |
+| --- | --- | --- | --- |
+| `alb-sg`         | `0.0.0.0/0 → 80, 443` | all | 인터넷 직접 노출 — 유일한 0.0.0.0/0 인바운드 |
+| `app-sg`         | `alb-sg → 8080`       | all | ECS Task — ALB만 진입 허용, 외부는 NAT 경유 outbound |
+| `db-sg`          | `app-sg → 3306`       | (none) | RDS — egress 없음. app-sg에서만 접근 가능 |
+| `bastion-sg`     | (none)                | all | SSM Session Manager 의존 — SSH 인바운드 없음 |
+| `vpc-endpoint-sg`| `app-sg → 443`        | (none) | M2 VPC Endpoint 도입 대비 |
+
+**참조 체인**: `alb-sg → app-sg → db-sg` — 데이터 흐름과 정확히 일치. RDS는 ALB·인터넷 어디서도 직접 접근 불가.
+
+---
+
+## 5. 데이터 흐름
+
+### 5.1 인바운드 (사용자 요청)
+
+```
+User → IGW → ALB(public-2{a,c}) → ECS Task(app-2{a,c}) → RDS(data-2a)
+       │      [alb-sg]            [app-sg]                [db-sg]
+       │      :80/:443            :8080                   :3306
+```
+
+### 5.2 아웃바운드 (ECS → 외부 API)
+
+```
+ECS Task(app-2{a,c}) → NAT(public-2a) → IGW → Internet
+[app-sg egress all]    [thirdtool-nat]   [thirdtool-igw]
+```
+
+ECR pull · Secrets Manager · CloudWatch Logs · 외부 OAuth API(카카오/네이버) 등이 본 경로 사용.
+
+### 5.3 운영 진입 (Bastion via SSM)
+
+```
+Operator AWS Console → SSM Session Manager → Bastion(any private subnet) → 내부 리소스
+[no inbound SG rule, outbound SSM endpoints]
+```
+
+SSH 키 관리 불필요 — IAM 권한 기반.
+
+---
+
+## 6. M2 확장 후보
+
+| 확장 | 영향 | 우선순위 |
+| --- | --- | --- |
+| Multi-AZ NAT Gateway (public-2c에 추가) | `private-rt`를 2a/2c용으로 분리. NAT 단일 장애점 제거 | 트래픽 발생 후 |
+| VPC Interface Endpoint (s3·ecr·secretsmanager·logs 4종) | app-sg → vpc-endpoint-sg → AWS API 경유. NAT 데이터 전송 비용 절감 | NAT 비용 임계 도달 시 |
+| VPC Flow Logs (CloudWatch Logs 송신) | 보안 감사·트래픽 분석. CloudWatch 저장 비용 발생 | 보안 사고 추적 필요 시 |
+| Terraform IaC 모듈화 | 본 spec JSON을 모듈 입력으로 변환. drift 차단 | M2 Product 7 Epic 2 |
+| staging 전용 VPC 분리 | 현재 shared. cross-environment 격리 필요 시 | 환경 분리 Epic |
+| Network ACL 커스터마이즈 | default(allow all) 유지 중. layer 간 격리 강화 시 | 보안 감사 결과 |
+
+---
+
+## 7. 관련 자산
+
+- `infra/vpc/vpc-spec.json` — VPC + subnet + IGW + NAT + route table 단일 진실 소스
+- `infra/vpc/security-groups.json` — 5종 SG 정의 + creationOrder
+- `infra/ecs/service-prod.json` — 본 Story 산출 subnet/SG ID로 placeholder 치환
+- `infra/ecs/service-staging.json` — 동일
+- [ADR015](../adr/ADR015-vpc-3-layer-network-design.md) — 설계 결정 배경
+- [ts009](../operations/troubleshooting/ts009-vpc-setup.md) — AWS 콘솔/CLI 1회성 셋업 절차

--- a/docs/operations/troubleshooting/ts009-vpc-setup.md
+++ b/docs/operations/troubleshooting/ts009-vpc-setup.md
@@ -268,6 +268,23 @@ aws ec2 attach-internet-gateway --vpc-id $VPC_ID --internet-gateway-id $IGW_ID -
 
 **해결**: 잘못 만든 subnet 삭제 후 재생성. ECS Service 생성 시 subnet 2개가 같은 AZ에 몰리면 Multi-AZ 분산 실패.
 
+### ts009-7: VPC peering 도입 시 CIDR 충돌 (`InvalidVpcPeeringConnectionId.Malformed` 또는 `OverlappingVpcCidrBlocks`)
+
+**원인**: 다른 VPC와 peering 시도 시 양쪽 VPC가 동일한 `10.0.0.0/16` CIDR 사용. `10.0.0.0/16`은 AWS Default VPC + 다른 회사·다른 프로젝트가 가장 흔히 사용하는 대역이라 충돌 가능성 높음.
+
+**해결 (사전 검증 — peering 시도 전에)**:
+1. peering 대상 VPC의 CIDR 확인:
+   ```bash
+   aws ec2 describe-vpcs --vpc-ids <PEER_VPC_ID> --region <peer-region> | jq '.Vpcs[].CidrBlock'
+   ```
+2. 본 VPC `10.0.0.0/16`과 겹치면 peering 불가 — 다음 중 1개 선택:
+   - 다른 쪽 VPC가 CIDR 변경 가능하면 그쪽 변경 요청
+   - 본 VPC를 별도 region (예: ap-northeast-1)에 `10.1.0.0/16`으로 재구축 후 peering
+   - peering 대신 PrivateLink·Transit Gateway 검토 (CIDR 충돌 우회)
+3. ADR015 §"다시 검토할 시점" — multi-region 진입 시 IP 대역 분리(`10.1.0.0/16` 등) 가이드
+
+> **예방**: 본 VPC를 portfolio 외에 다른 환경과 연결할 계획이 있으면, 초기 셋업 시점에 `10.0.0.0/16` 대신 사용 빈도 낮은 대역(`10.42.0.0/16` 등) 채택 검토. 현재는 단독 운영이라 그대로 진행.
+
 ### ts009-6: RDS 호스트명 미해석 (`Unknown host`) — DNS hostname OFF 인한
 
 **원인**: §2 단계의 `modify-vpc-attribute --enable-dns-hostnames` 누락. private VPC 안에서 RDS의 `*.rds.amazonaws.com` 도메인 해석 불가.

--- a/docs/operations/troubleshooting/ts009-vpc-setup.md
+++ b/docs/operations/troubleshooting/ts009-vpc-setup.md
@@ -1,0 +1,303 @@
+# ts009: VPC 1회성 셋업·검증·트러블슈팅
+
+Story-048로 `infra/vpc/`에 VPC 10.0.0.0/16 + 6 subnet + 5 SG + IGW + NAT + 2 route table의 단일 진실 소스 spec JSON과 토폴로지 다이어그램이 추가됐다. 본 가이드는 AWS 콘솔(또는 CLI)에서 1회성 셋업하는 절차 + 검증 + 자주 보는 에러 6건을 한 곳에 모았다.
+
+ts007(OIDC)·ts008(ECS)과 cross-link. 본 절차는 1인 운영자가 1회만 실행.
+
+---
+
+## 1. 전제
+
+- AWS 콘솔 VPC 관리 권한 (`ec2:CreateVpc`, `ec2:CreateSubnet`, `ec2:CreateInternetGateway`, `ec2:CreateNatGateway`, `ec2:CreateRouteTable`, `ec2:CreateSecurityGroup`)
+- AWS CLI 또는 콘솔. 본 가이드는 CLI 명령 위주 (재현성 + 자동화 진입점)
+- region 고정: **ap-northeast-2** (모든 명령에 `--region ap-northeast-2`)
+- 결제: NAT Gateway 시간 + 데이터 전송 비용 발생 (~$0.06/시간 + $0.045/GB). 셋업 후 즉시 과금 시작 — cost.md 추적
+- **본 셋업은 single-AZ NAT** (public-2a). 2a 장애 시 private 트래픽 차단 — 수용된 trade-off (ADR015)
+
+---
+
+## 2. VPC 생성
+
+```bash
+aws ec2 create-vpc \
+  --cidr-block 10.0.0.0/16 \
+  --tag-specifications 'ResourceType=vpc,Tags=[{Key=Name,Value=thirdtool-vpc},{Key=Project,Value=ThirdTool},{Key=Environment,Value=shared},{Key=ManagedBy,Value=Story-048}]' \
+  --region ap-northeast-2
+```
+
+응답 `Vpc.VpcId`(`vpc-xxxxxxxx`) 메모.
+
+DNS hostname + DNS resolution 활성화 (RDS 내부 도메인 해석 필수):
+```bash
+VPC_ID=vpc-xxxxxxxx
+aws ec2 modify-vpc-attribute --vpc-id $VPC_ID --enable-dns-support  --region ap-northeast-2
+aws ec2 modify-vpc-attribute --vpc-id $VPC_ID --enable-dns-hostnames --region ap-northeast-2
+```
+
+---
+
+## 3. 6 Subnet 생성
+
+각 subnet 명령. `<VPC_ID>` 치환 + `--map-public-ip-on-launch` (public만):
+
+```bash
+# public-2a
+aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.0.0/24 --availability-zone ap-northeast-2a \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=public-2a},{Key=Layer,Value=public}]' \
+  --region ap-northeast-2
+
+# public-2c
+aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.1.0/24 --availability-zone ap-northeast-2c \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=public-2c},{Key=Layer,Value=public}]' \
+  --region ap-northeast-2
+
+# app-2a
+aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.10.0/24 --availability-zone ap-northeast-2a \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=app-2a},{Key=Layer,Value=app}]' \
+  --region ap-northeast-2
+
+# app-2c
+aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.11.0/24 --availability-zone ap-northeast-2c \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=app-2c},{Key=Layer,Value=app}]' \
+  --region ap-northeast-2
+
+# data-2a
+aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.20.0/24 --availability-zone ap-northeast-2a \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=data-2a},{Key=Layer,Value=data}]' \
+  --region ap-northeast-2
+
+# data-2c
+aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block 10.0.21.0/24 --availability-zone ap-northeast-2c \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=data-2c},{Key=Layer,Value=data}]' \
+  --region ap-northeast-2
+```
+
+각 응답 `Subnet.SubnetId` 메모 (총 6개).
+
+public 2개에 `mapPublicIpOnLaunch=true` 설정:
+```bash
+PUB_2A=subnet-xxxxxxxx  # public-2a 결과
+PUB_2C=subnet-xxxxxxxx  # public-2c 결과
+aws ec2 modify-subnet-attribute --subnet-id $PUB_2A --map-public-ip-on-launch --region ap-northeast-2
+aws ec2 modify-subnet-attribute --subnet-id $PUB_2C --map-public-ip-on-launch --region ap-northeast-2
+```
+
+---
+
+## 4. Internet Gateway 생성 + VPC 연결
+
+```bash
+IGW_ID=$(aws ec2 create-internet-gateway \
+  --tag-specifications 'ResourceType=internet-gateway,Tags=[{Key=Name,Value=thirdtool-igw}]' \
+  --region ap-northeast-2 --query 'InternetGateway.InternetGatewayId' --output text)
+
+aws ec2 attach-internet-gateway --vpc-id $VPC_ID --internet-gateway-id $IGW_ID --region ap-northeast-2
+```
+
+> **IGW VPC attach 누락 시 ts009-4 발생**: public subnet에 0.0.0.0/0 route를 추가해도 인터넷 통신 불가. attach 명령 별도 실행 필수.
+
+---
+
+## 5. NAT Gateway 생성 (public-2a 단일)
+
+EIP 할당 → NAT 생성 → 약 1-2분 PENDING:
+
+```bash
+EIP_ALLOC_ID=$(aws ec2 allocate-address --domain vpc --region ap-northeast-2 --query 'AllocationId' --output text)
+
+NAT_ID=$(aws ec2 create-nat-gateway \
+  --subnet-id $PUB_2A \
+  --allocation-id $EIP_ALLOC_ID \
+  --connectivity-type public \
+  --tag-specifications 'ResourceType=natgateway,Tags=[{Key=Name,Value=thirdtool-nat}]' \
+  --region ap-northeast-2 --query 'NatGateway.NatGatewayId' --output text)
+
+# AVAILABLE 도달 대기
+aws ec2 wait nat-gateway-available --nat-gateway-ids $NAT_ID --region ap-northeast-2
+```
+
+---
+
+## 6. Route Table 2개 생성
+
+```bash
+# public-rt
+PUB_RT=$(aws ec2 create-route-table --vpc-id $VPC_ID \
+  --tag-specifications 'ResourceType=route-table,Tags=[{Key=Name,Value=public-rt}]' \
+  --region ap-northeast-2 --query 'RouteTable.RouteTableId' --output text)
+aws ec2 create-route --route-table-id $PUB_RT --destination-cidr-block 0.0.0.0/0 --gateway-id $IGW_ID --region ap-northeast-2
+aws ec2 associate-route-table --route-table-id $PUB_RT --subnet-id $PUB_2A --region ap-northeast-2
+aws ec2 associate-route-table --route-table-id $PUB_RT --subnet-id $PUB_2C --region ap-northeast-2
+
+# private-rt (4 subnet 연결)
+PRIV_RT=$(aws ec2 create-route-table --vpc-id $VPC_ID \
+  --tag-specifications 'ResourceType=route-table,Tags=[{Key=Name,Value=private-rt}]' \
+  --region ap-northeast-2 --query 'RouteTable.RouteTableId' --output text)
+aws ec2 create-route --route-table-id $PRIV_RT --destination-cidr-block 0.0.0.0/0 --nat-gateway-id $NAT_ID --region ap-northeast-2
+for SUBNET in $APP_2A $APP_2C $DATA_2A $DATA_2C; do
+  aws ec2 associate-route-table --route-table-id $PRIV_RT --subnet-id $SUBNET --region ap-northeast-2
+done
+```
+
+---
+
+## 7. Security Group 5종 생성 (참조 순서 강제)
+
+`creationOrder: ["alb-sg", "app-sg", "db-sg", "bastion-sg", "vpc-endpoint-sg"]` (`security-groups.json` 명시). 참조 SG가 먼저 존재해야 함.
+
+```bash
+# 7.1 alb-sg
+ALB_SG=$(aws ec2 create-security-group --vpc-id $VPC_ID --group-name alb-sg --description "ALB internet-facing" --region ap-northeast-2 --query 'GroupId' --output text)
+aws ec2 authorize-security-group-ingress --group-id $ALB_SG --protocol tcp --port 80  --cidr 0.0.0.0/0 --region ap-northeast-2
+aws ec2 authorize-security-group-ingress --group-id $ALB_SG --protocol tcp --port 443 --cidr 0.0.0.0/0 --region ap-northeast-2
+
+# 7.2 app-sg (alb-sg 참조)
+APP_SG=$(aws ec2 create-security-group --vpc-id $VPC_ID --group-name app-sg --description "ECS Task — alb-sg only" --region ap-northeast-2 --query 'GroupId' --output text)
+aws ec2 authorize-security-group-ingress --group-id $APP_SG --protocol tcp --port 8080 --source-group $ALB_SG --region ap-northeast-2
+
+# 7.3 db-sg (app-sg 참조)
+DB_SG=$(aws ec2 create-security-group --vpc-id $VPC_ID --group-name db-sg --description "RDS MySQL — app-sg only" --region ap-northeast-2 --query 'GroupId' --output text)
+aws ec2 authorize-security-group-ingress --group-id $DB_SG --protocol tcp --port 3306 --source-group $APP_SG --region ap-northeast-2
+aws ec2 revoke-security-group-egress --group-id $DB_SG --protocol -1 --port all --cidr 0.0.0.0/0 --region ap-northeast-2
+
+# 7.4 bastion-sg (SSM Session Manager — inbound 없음)
+BASTION_SG=$(aws ec2 create-security-group --vpc-id $VPC_ID --group-name bastion-sg --description "Bastion via SSM — no SSH inbound" --region ap-northeast-2 --query 'GroupId' --output text)
+
+# 7.5 vpc-endpoint-sg (M2 대비)
+VPCE_SG=$(aws ec2 create-security-group --vpc-id $VPC_ID --group-name vpc-endpoint-sg --description "VPC Interface Endpoints — app-sg only" --region ap-northeast-2 --query 'GroupId' --output text)
+aws ec2 authorize-security-group-ingress --group-id $VPCE_SG --protocol tcp --port 443 --source-group $APP_SG --region ap-northeast-2
+aws ec2 revoke-security-group-egress --group-id $VPCE_SG --protocol -1 --port all --cidr 0.0.0.0/0 --region ap-northeast-2
+```
+
+> **순환 참조 회피**: alb-sg는 어떤 SG도 참조 안 함 (인터넷에서 직접 진입). app-sg가 alb-sg 참조, db-sg가 app-sg 참조 → 단방향 체인. 순서 어기면 ts009-3 발생.
+
+---
+
+## 8. 검증 — 6 subnet + 5 SG ID 출력 (후속 Story placeholder 치환용)
+
+```bash
+echo "=== VPC ID ==="
+echo "VPC_ID=$VPC_ID"
+
+echo "=== Subnet IDs (Story-047 service-prod.json 치환용) ==="
+echo "PUB_2A=$PUB_2A"
+echo "PUB_2C=$PUB_2C"
+echo "APP_2A=$APP_2A    # <APP_SUBNET_2A> 치환"
+echo "APP_2C=$APP_2C    # <APP_SUBNET_2C> 치환"
+echo "DATA_2A=$DATA_2A  # 후속 Story (#14 RDS) 치환용"
+echo "DATA_2C=$DATA_2C"
+
+echo "=== Security Group IDs ==="
+echo "ALB_SG=$ALB_SG       # 후속 Story (#13 ALB) 치환용"
+echo "APP_SG=$APP_SG       # <APP_SG> 치환"
+echo "DB_SG=$DB_SG         # 후속 Story (#14 RDS) 치환용"
+echo "BASTION_SG=$BASTION_SG"
+echo "VPCE_SG=$VPCE_SG     # M2 VPC Endpoint 치환용"
+```
+
+각 ID를 안전한 곳(예: 1Password vault 또는 로컬 `infra/vpc/runtime-ids.local.txt`, **gitignore 필수**)에 저장. 후속 Story에서 placeholder 치환 시 사용.
+
+라우팅 검증:
+```bash
+aws ec2 describe-route-tables --route-table-ids $PUB_RT $PRIV_RT --region ap-northeast-2 \
+  | jq '.RouteTables[] | {Name: (.Tags[]|select(.Key=="Name").Value), Routes: .Routes[]}'
+# public-rt에 0.0.0.0/0 → IGW, private-rt에 0.0.0.0/0 → NAT 확인
+```
+
+NAT 상태:
+```bash
+aws ec2 describe-nat-gateways --nat-gateway-ids $NAT_ID --region ap-northeast-2 | jq '.NatGateways[].State'
+# 기대: "available"
+```
+
+---
+
+## 9. 트러블슈팅
+
+### ts009-1: NAT Gateway 생성 시 EIP 한도 초과 (`AddressLimitExceeded`)
+
+**원인**: AWS 계정 기본 EIP 한도 5개. 다른 리전·서비스에서 이미 사용 중일 수 있음.
+
+**해결**:
+1. 기존 EIP 사용 현황 확인:
+   ```bash
+   aws ec2 describe-addresses --region ap-northeast-2 | jq '.Addresses[] | {AllocationId, AssociationId, Domain}'
+   ```
+2. 사용 안 하는 EIP가 있으면 release (`aws ec2 release-address --allocation-id eipalloc-xxxx`)
+3. 또는 AWS Support → Service Quotas → "EC2-VPC Elastic IPs" 한도 증설 요청 (1-2일 소요)
+
+### ts009-2: private subnet에서 outbound 트래픽 실패 (`Connection timed out`)
+
+**원인 가능성**:
+- private-rt에 `0.0.0.0/0 → NAT` 라우트 누락
+- NAT Gateway가 PENDING 상태 (생성 직후 1-2분)
+- private subnet이 private-rt에 연결 안 됨 (default rt 사용 중)
+
+**해결**:
+1. private-rt 라우트 확인:
+   ```bash
+   aws ec2 describe-route-tables --route-table-ids $PRIV_RT --region ap-northeast-2 | jq '.RouteTables[].Routes'
+   ```
+2. NAT 상태 확인 (§8)
+3. subnet → route table 연결 확인:
+   ```bash
+   aws ec2 describe-route-tables --filters Name=association.subnet-id,Values=$APP_2A --region ap-northeast-2 | jq '.RouteTables[].Tags'
+   ```
+
+### ts009-3: SG 생성 시 순환 참조 (`InvalidGroup.NotFound`)
+
+**원인**: app-sg 생성 시 alb-sg가 아직 미생성. 또는 db-sg 생성 시 app-sg가 미생성.
+
+**해결**: §7 creationOrder 엄수 — alb-sg → app-sg → db-sg → bastion-sg → vpc-endpoint-sg 순서. 이미 잘못 생성했으면 SG 삭제 후 순서대로 재생성.
+
+### ts009-4: IGW를 VPC에 attach 안 함 → public subnet 인터넷 통신 실패
+
+**원인**: `create-internet-gateway`만 실행하고 `attach-internet-gateway` 누락. IGW가 어디에도 연결 안 된 상태.
+
+**해결**:
+```bash
+aws ec2 describe-internet-gateways --internet-gateway-ids $IGW_ID --region ap-northeast-2 \
+  | jq '.InternetGateways[].Attachments'
+# 빈 배열이면 attach 누락
+aws ec2 attach-internet-gateway --vpc-id $VPC_ID --internet-gateway-id $IGW_ID --region ap-northeast-2
+```
+
+### ts009-5: subnet AZ 오타로 인한 다중 AZ 분산 실패
+
+**원인**: subnet 생성 시 `--availability-zone`을 `ap-northeast-2a`/`2c`가 아닌 다른 값(`2b`, `2d`)으로 입력. ap-northeast-2는 2a/2c/2d 사용 가능하지만 본 설계는 2a/2c만.
+
+**해결**: 잘못 만든 subnet 삭제 후 재생성. ECS Service 생성 시 subnet 2개가 같은 AZ에 몰리면 Multi-AZ 분산 실패.
+
+### ts009-6: RDS 호스트명 미해석 (`Unknown host`) — DNS hostname OFF 인한
+
+**원인**: §2 단계의 `modify-vpc-attribute --enable-dns-hostnames` 누락. private VPC 안에서 RDS의 `*.rds.amazonaws.com` 도메인 해석 불가.
+
+**해결**:
+```bash
+aws ec2 describe-vpc-attribute --vpc-id $VPC_ID --attribute enableDnsHostnames --region ap-northeast-2
+# Value=false면 enable:
+aws ec2 modify-vpc-attribute --vpc-id $VPC_ID --enable-dns-hostnames --region ap-northeast-2
+```
+
+---
+
+## 10. 후속 (별도 Story)
+
+- **Story-TBD(ALB)**: `<ALB_SG>` + public subnet ID 2개 사용. milestone item #13
+- **Story-TBD(RDS)**: `<DB_SG>` + data subnet ID 2개 사용. milestone item #14
+- **Story-TBD(ECS Service 치환)**: Story-047 `service-prod.json`/`service-staging.json`의 `<APP_SUBNET_2A>`/`<APP_SUBNET_2C>`/`<APP_SG>` 치환
+- **Story-TBD(Multi-AZ NAT)**: public-2c에 NAT 2번째 생성 + `private-rt` 분리 (M2)
+- **Story-TBD(VPC Endpoint)**: s3·ecr·secretsmanager·logs 4종 Interface Endpoint + `vpc-endpoint-sg` 활용 (M2 비용 검토)
+- **Story-TBD(VPC Flow Logs)**: 네트워크 트래픽 로깅. CloudWatch Logs 또는 S3 송신
+- **Story-TBD(Terraform IaC)**: 본 `vpc-spec.json` + `security-groups.json`을 Terraform 모듈 입력으로 변환. M2 Product 7 Epic 2
+- **Story-TBD(Bastion EC2)**: 운영 진입 도구. SSM Session Manager 채택 — bastion-sg 활용
+
+---
+
+## 관련
+
+- [vpc-topology.md](../../architecture/vpc-topology.md) — 다이어그램 + 표 시각화
+- [ADR015](../../adr/ADR015-vpc-3-layer-network-design.md) — 설계 결정 배경
+- `infra/vpc/vpc-spec.json` · `security-groups.json` — 단일 진실 소스 JSON
+- [ts008](ts008-ecs-cluster-setup.md) — 본 VPC 자원을 사용하는 ECS Cluster 셋업
+- Story-048 — milestone 0.0.1v item #12

--- a/infra/vpc/security-groups.json
+++ b/infra/vpc/security-groups.json
@@ -2,6 +2,7 @@
   "vpc": "thirdtool-vpc",
   "creationOrder": ["alb-sg", "app-sg", "db-sg", "bastion-sg", "vpc-endpoint-sg"],
   "creationOrderRationale": "SG 간 sourceSg 참조이므로 참조 대상이 먼저 존재해야 함 — alb-sg → app-sg(refs alb-sg) → db-sg(refs app-sg) → bastion-sg → vpc-endpoint-sg(refs app-sg)",
+  "egressNote": "AWS 기본 동작은 SG 생성 시 0.0.0.0/0 all egress가 자동 부여된다. 본 spec에서 egress=[] 빈 배열인 SG(db-sg, vpc-endpoint-sg)는 ts009 §7.3/§7.5의 revoke-security-group-egress 명령으로 default rule을 명시 제거해야 spec과 일치 (drift 차단). Terraform 이행 시 자동 처리.",
   "securityGroups": [
     {
       "name": "alb-sg",

--- a/infra/vpc/security-groups.json
+++ b/infra/vpc/security-groups.json
@@ -1,0 +1,52 @@
+{
+  "vpc": "thirdtool-vpc",
+  "creationOrder": ["alb-sg", "app-sg", "db-sg", "bastion-sg", "vpc-endpoint-sg"],
+  "creationOrderRationale": "SG 간 sourceSg 참조이므로 참조 대상이 먼저 존재해야 함 — alb-sg → app-sg(refs alb-sg) → db-sg(refs app-sg) → bastion-sg → vpc-endpoint-sg(refs app-sg)",
+  "securityGroups": [
+    {
+      "name": "alb-sg",
+      "description": "ALB internet-facing — HTTP/HTTPS from anywhere",
+      "ingress": [
+        { "protocol": "tcp", "fromPort": 80,  "toPort": 80,  "source": "0.0.0.0/0",     "description": "HTTP from internet (will redirect to 443)" },
+        { "protocol": "tcp", "fromPort": 443, "toPort": 443, "source": "0.0.0.0/0",     "description": "HTTPS from internet" }
+      ],
+      "egress": [
+        { "protocol": "-1",  "fromPort": 0,   "toPort": 0,   "destination": "0.0.0.0/0", "description": "all outbound (ALB → app-sg targets)" }
+      ]
+    },
+    {
+      "name": "app-sg",
+      "description": "ECS Task in app subnet — accepts only from alb-sg on container port",
+      "ingress": [
+        { "protocol": "tcp", "fromPort": 8080, "toPort": 8080, "sourceSecurityGroup": "alb-sg", "description": "Spring Boot container port from ALB only" }
+      ],
+      "egress": [
+        { "protocol": "-1",  "fromPort": 0,    "toPort": 0,    "destination": "0.0.0.0/0",      "description": "all outbound (ECR pull · Secrets Manager · CloudWatch Logs · external API via NAT)" }
+      ]
+    },
+    {
+      "name": "db-sg",
+      "description": "RDS MySQL — accepts only from app-sg on 3306. No egress.",
+      "ingress": [
+        { "protocol": "tcp", "fromPort": 3306, "toPort": 3306, "sourceSecurityGroup": "app-sg", "description": "MySQL from ECS Task only" }
+      ],
+      "egress": []
+    },
+    {
+      "name": "bastion-sg",
+      "description": "Bastion via SSM Session Manager — no SSH inbound (SSM uses outbound only)",
+      "ingress": [],
+      "egress": [
+        { "protocol": "-1",  "fromPort": 0,    "toPort": 0,    "destination": "0.0.0.0/0",      "description": "all outbound (SSM agent → ssm/ssmmessages/ec2messages endpoints)" }
+      ]
+    },
+    {
+      "name": "vpc-endpoint-sg",
+      "description": "VPC Interface Endpoints (M2) — accepts HTTPS from app-sg only",
+      "ingress": [
+        { "protocol": "tcp", "fromPort": 443,  "toPort": 443,  "sourceSecurityGroup": "app-sg", "description": "HTTPS from ECS Task for endpoint resolution" }
+      ],
+      "egress": []
+    }
+  ]
+}

--- a/infra/vpc/vpc-spec.json
+++ b/infra/vpc/vpc-spec.json
@@ -1,0 +1,56 @@
+{
+  "region": "ap-northeast-2",
+  "vpc": {
+    "name": "thirdtool-vpc",
+    "cidr": "10.0.0.0/16",
+    "enableDnsSupport": true,
+    "enableDnsHostnames": true,
+    "instanceTenancy": "default"
+  },
+  "availabilityZones": ["ap-northeast-2a", "ap-northeast-2c"],
+  "subnets": [
+    { "name": "public-2a", "cidr": "10.0.0.0/24",  "az": "ap-northeast-2a", "layer": "public", "mapPublicIpOnLaunch": true,  "purpose": "ALB + NAT Gateway" },
+    { "name": "public-2c", "cidr": "10.0.1.0/24",  "az": "ap-northeast-2c", "layer": "public", "mapPublicIpOnLaunch": true,  "purpose": "ALB (multi-AZ target)" },
+    { "name": "app-2a",    "cidr": "10.0.10.0/24", "az": "ap-northeast-2a", "layer": "app",    "mapPublicIpOnLaunch": false, "purpose": "ECS Fargate Task" },
+    { "name": "app-2c",    "cidr": "10.0.11.0/24", "az": "ap-northeast-2c", "layer": "app",    "mapPublicIpOnLaunch": false, "purpose": "ECS Fargate Task" },
+    { "name": "data-2a",   "cidr": "10.0.20.0/24", "az": "ap-northeast-2a", "layer": "data",   "mapPublicIpOnLaunch": false, "purpose": "RDS MySQL primary" },
+    { "name": "data-2c",   "cidr": "10.0.21.0/24", "az": "ap-northeast-2c", "layer": "data",   "mapPublicIpOnLaunch": false, "purpose": "RDS MySQL standby (M2 multi-AZ)" }
+  ],
+  "internetGateway": {
+    "name": "thirdtool-igw",
+    "attachToVpc": "thirdtool-vpc"
+  },
+  "natGateway": {
+    "name": "thirdtool-nat",
+    "subnet": "public-2a",
+    "connectivityType": "public",
+    "elasticIp": "auto-allocate",
+    "comment": "single-AZ — 2a 장애 시 private 트래픽 전체 차단. M2에서 multi-AZ 확장 (public-2c에 NAT 추가 + private-rt 분리)"
+  },
+  "routeTables": [
+    {
+      "name": "public-rt",
+      "associatedSubnets": ["public-2a", "public-2c"],
+      "routes": [
+        { "destinationCidrBlock": "0.0.0.0/0", "gatewayId": "thirdtool-igw" }
+      ]
+    },
+    {
+      "name": "private-rt",
+      "associatedSubnets": ["app-2a", "app-2c", "data-2a", "data-2c"],
+      "routes": [
+        { "destinationCidrBlock": "0.0.0.0/0", "natGatewayId": "thirdtool-nat" }
+      ]
+    }
+  ],
+  "tags": {
+    "default": {
+      "Project": "ThirdTool",
+      "Environment": "shared",
+      "ManagedBy": "Story-048"
+    },
+    "perResource": {
+      "subnet": { "Layer": "{public|app|data}" }
+    }
+  }
+}


### PR DESCRIPTION
## 개요

ap-northeast-2 region에 `10.0.0.0/16` VPC와 2 AZ × 3-layer subnet(public/app/data) + IGW + NAT Gateway + Route Table 2 + Security Group 5종의 단일 진실 소스 spec JSON과 토폴로지 다이어그램·1회성 셋업 runbook·결정 기록을 코드베이스에 추가한다. milestone 0.0.1v item #12 "6 1-1 VPC" 코드 단 충족 — 가장 큰 의존 unblocker(#13 ALB·#14 RDS·#11 ECS Service의 subnet/SG placeholder)를 해소한다.

## 왜 / 설계 결정

- **3-layer subnet 분리 (ADR015)**: public/app/data layer 명확 경계 → RDS는 외부·ALB 어디서도 직접 접근 불가, ECS Task는 ALB 외 inbound 차단. 침해 시 폭발 반경 한정
- **SG 참조 체인 단방향**: alb-sg → app-sg → db-sg — 데이터 흐름과 일치, 순환 참조 차단. 참조 SG는 `creationOrder`로 명시
- **단일 NAT (public-2a)**: M1 트래픽 0명 — 가용성 요구 낮아 NAT 시간 비용 절반 절감. trade-off: 2a 장애 시 private 트래픽 차단 (수용, M2 multi-AZ 확장 명시)
- **VPC CIDR 10.0.0.0/16 + /24 6 subnet**: 65K IP 여유 + 향후 신규 layer(ElastiCache 30/OpenSearch 40 등) 10번 단위 분리 패턴 reserve. ADR015 §결정 표에 명시
- **SSM Session Manager 채택**: Bastion EC2 미생성, SSH 키 폐기. `bastion-sg`만 정의
- **drift 차단**: `security-groups.json`의 `egressNote`에 AWS 기본 all-egress vs spec `egress=[]` 불일치 명시 + ts009 §7.3/§7.5 revoke 단계 책임 표기

## 작업 내용

- **feat(infra)**: `infra/vpc/vpc-spec.json` (VPC + 6 subnet + IGW + NAT + 2 RT + 태깅) + `infra/vpc/security-groups.json` (5 SG + creationOrder + egressNote)
- **docs(architecture)**: `docs/architecture/vpc-topology.md` — mermaid 다이어그램 + subnet/라우팅/SG 표 + 데이터 흐름 3종 + M2 확장 후보 (DoD 강제 산출물)
- **docs(operations)**: `docs/operations/troubleshooting/ts009-vpc-setup.md` — 10 섹션 + 트러블슈팅 7건 (ts009-1~7 — CIDR peering 충돌 포함)
- **docs(adr)**: `docs/adr/ADR015-vpc-3-layer-network-design.md` — 대안 7종 비교 + follow-up 8건 + AZ 선택 객관 근거
- **fix(infra)**: Reviewer 5관점 지적 보강 — Critical 3건(milestone 각주·cost NAT 정정·SG egress drift) + Major 4건(milestone 표기·multi-AZ NAT 상충·CIDR 예약 의도·AZ 근거) + Minor 2건(ts009-7·PACKAGE.md infra 섹션)

## 변경 유형

- [x] feat  - [x] fix  - [ ] refactor  - [x] docs  - [ ] test  - [ ] chore

## 테스트

- `jq . infra/vpc/*.json` → 2건 OK
- mermaid 다이어그램 GitHub markdown preview 정상 렌더링
- 자바 코드 0줄 변경 — 단위/슬라이스 테스트 추가 의무 없음 (conventions §4.8 트리거 적용 불가)
- **end-to-end 검증은 사용자 영역** — ts009 §1-8 1회성 셋업 (VPC + 6 subnet + IGW + NAT + 2 RT + 5 SG) 후 ID 6+5건 발행. Story-047 `service-prod.json`의 `<APP_SUBNET_2A>`/`<APP_SUBNET_2C>`/`<APP_SG>` 치환 가능 상태로 진입

## 체크리스트

- [x] 빌드 / 테스트 통과 (자바 무변경)
- [x] 모든 응답 `ApiResponse<T>` 래퍼 — N/A (API 변경 없음)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — ADR015 신규 + index 갱신 + PACKAGE.md `infra/` 섹션 신설 (iam/ecs/vpc + ts0NN/ADR0NN cross-link)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 — N/A
- [x] BC 간 의존 방향 위반 없음 — N/A
- [x] 대상 브랜치 = `develop` 확인

## 머지 영향 (안전성)

- 본 PR은 `.github/workflows/*.yml` 변경 없음 → **기존 EC2 SSH 배포 흐름 영향 0건**
- Java 코드 0줄 변경 → 빌드·테스트·기존 API 동작 영향 0건
- 실제 VPC는 AWS 콘솔에서 사용자가 ts009 따라 1회 셋업 후에만 존재 → 머지 직후 AWS 측 변화 없음

## 비용 영향 참고 (로컬 cost.md 갱신)

- NAT Gateway 항목 $1.10 → $1.44/일 (ts009 §1 명시 $0.06/h × 24h 반영)
- 본주 총 추정 $5.77 → $6.11/일, 6일 누적 $34.6 → $36.66
- ts009 §1에 "셋업 후 즉시 시간 과금 시작" 명시 — 운영 종료 시 NAT + EIP release 절차 §13(local handoff doc)에 명시

## 후속 Story (별도 PR — ts009 §10 + ADR015 follow-up)

- Story-TBD(ALB): `<ALB_SG>` + public subnet 2개 사용 (milestone item #13)
- Story-TBD(RDS): `<DB_SG>` + data subnet 2개 사용 (milestone item #14)
- Story-TBD(ECS placeholder 치환): Story-047 `service-{prod,staging}.json`의 `<APP_SUBNET_*>`/`<APP_SG>` 치환
- Story-TBD(Multi-AZ NAT, VPC Endpoint, Flow Logs): M2 검토
- Story-TBD(Terraform IaC): M2 Product 7 Epic 2

## 관련 이슈

- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-infra-network.md` (Epic 1 Story 1-1 코드 단 충족)
- Milestone: `workflow/task/milestones/version/0.0.1v/milestone.md` item #12
- Story: Story-048
- ADR: ADR015 (선행 결정: ADR013 OIDC, ADR014 ECS Task IAM)
- Runbook: ts009 (선행 의존: ts007 OIDC + ts008 ECS Cluster)
- AWS handoff 통합: `workflow/task/pes/handoff/aws-setup-0.0.1v.md` Stage 2 (gitignored 로컬 트래킹)