### PR TITLE
feat(infra): Story-049 ALB + Target Group + Listener 80→443 + ADR016 + ts010

### DIFF
--- a/docs/adr/ADR016-alb-listener-target-group.md
+++ b/docs/adr/ADR016-alb-listener-target-group.md
@@ -1,0 +1,119 @@
+# ADR016: ALB 1개 공유 + Listener 80→443 redirect + Target Group type=ip + TLS 1.3 정책 (Story-049)
+
+- **상태**: Accepted
+- **날짜**: 2026-06-29
+- **관련**: Product 6 AWS 네트워크 Epic 2 (ALB + 도메인 + TLS) · milestone 0.0.1v item #13 (`workflow/task/milestones/version/0.0.1v/milestone.md`) · `docs/operations/troubleshooting/ts010-alb-setup.md` · `infra/alb/alb-spec.json` · `infra/alb/target-group-spec.json`
+
+## 컨텍스트
+
+Story-048 VPC 셋업 + Story-047 ECS Task Definition·Service 정의 후 다음 의존은 **인터넷 진입점 ALB**. Story-047의 `service-prod.json`/`service-staging.json`이 `<PROD_TARGET_GROUP_ARN>`/`<STAGING_TARGET_GROUP_ARN>` placeholder로 본 Story 산출물을 기다리고 있다.
+
+application-prod.yml은 `jwt.cookie.secure: true`로 HTTPS 강제. ALB가 HTTPS termination 수행해야 브라우저가 쿠키 수락. 또한 Fargate는 awsvpc 네트워크 모드 — ENI 단위 IP 할당이라 ALB Target은 `target-type=ip`만 가능 (instance 등록 불가).
+
+추가 결정 영역:
+- ALB를 prod/staging 환경별 2개 분리 vs 1개 공유 + host header 라우팅
+- TLS 1.2-2021 vs 1.3 (구형 브라우저 호환 vs 보안)
+- HTTP 80을 그대로 forward하지 않고 HTTPS 443으로 강제 redirect
+
+## 결정
+
+### ALB 1개 공유 + host header 라우팅
+
+ALB 1개(`thirdtool-alb`)에 prod·staging Target Group 2개 등록. Listener 443의 default action은 prod TG forward, priority 10 rule이 `host-header: staging.thirdstool.com`을 staging TG로 분기.
+
+| 항목 | 결정 | 근거 |
+| --- | --- | --- |
+| ALB 개수 | 1개 공유 | 시간 비용 절반 절감 ($0.0225/시간 × 1 vs 2). M1 트래픽 0명에 ALB 2개 운영은 과도 |
+| 분기 방식 | host header (`api.thirdstool.com` vs `staging.thirdstool.com`) | path-based보다 환경 격리 명확. DNS 단에서 분기 |
+| scheme | internet-facing | 사용자 진입 |
+| subnets | public-2a + public-2c | multi-AZ — ALB 자체는 AZ 장애 시 다른 AZ로 자동 fail-over |
+| security group | alb-sg (80/443 ingress from 0.0.0.0/0) | ts009 §7.1 정합 |
+
+### Listener 80 → 443 HTTPS Redirect (HTTP 직접 forward 거부)
+
+Listener 80은 default action으로 `redirect 301 HTTPS:443` (host/path/query 보존). HTTP를 ECS로 forward하지 않음.
+
+**근거**:
+- `application-prod.yml` `jwt.cookie.secure: true` → HTTPS 없으면 쿠키 동작 불가
+- 사용자가 `http://` 입력해도 자동 HTTPS 승격
+- HSTS 정책 추후 적용 시 1단 게이트로 단일화
+
+### Target Group `target-type=ip` 강제
+
+Fargate awsvpc 네트워크 모드는 Task당 ENI에 IP 할당. instance 단위 등록 불가 — `target-type=ip` 외 선택지 없음. ECS Service의 `loadBalancers` config가 자동 register/deregister 수행.
+
+healthCheck `path=/health, interval=30s, timeout=5s, threshold 2/2, matcher 200` — Story-047 Task Definition healthCheck command(`wget /health`)와 정합.
+
+`deregistration_delay.timeout_seconds: 30` (default 300 → 30 단축): ECS rolling update 시 기존 Task drain 30s 후 종료 → 다운타임 단축. ECS Task graceful shutdown 30s 가정 (Spring Boot default).
+
+### TLS 1.3 정책 (`ELBSecurityPolicy-TLS13-1-2-2021-06`)
+
+TLS 1.2 + 1.3 모두 지원, 약한 cipher 제거. portfolio 프로젝트라 구형 브라우저 호환 요구 낮음 — 보안 우선.
+
+### ALB attributes 4종
+
+- `routing.http.drop_invalid_header_fields.enabled: true` — RFC 7230 위반 헤더 차단 (HTTP Smuggling 방지)
+- `routing.http.preserve_host_header.enabled: true` — ECS Task가 정확한 Host 헤더 수신 (Spring redirect URI 생성 시 정합)
+- `routing.http.xff_client_port.enabled: true` — `X-Forwarded-For` + port 정보 전달 (감사 추적)
+- `idle_timeout.timeout_seconds: 60` — default 그대로
+
+### 본 ADR이 다루지 않는 범위
+
+- **WAF**: AWS WAF web ACL (Rate-based + SQLi/XSS) 별도 Story (M2 보안 강화)
+- **Custom error pages**: 503/504 default 페이지 — M2 UX 개선 필요 시
+- **ALB access logs S3**: 트래픽 감사 — 보안 사고 추적 시 활성 (cost trade-off)
+- **HTTP/2 enable_default** vs HTTP/3 (QUIC) — 본 ADR은 HTTP/2 (default), HTTP/3은 M3
+- **Sticky sessions**: JWT stateless라 불요. 세션 기반 전환 시 검토
+- **Mutual TLS (mTLS)**: API 클라이언트 인증 강화 — M2
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **시간 비용 절감**: ALB 2개 대비 1개 — $0.54/일 절감 (M1 cost.md baseline $0.80 + LCU 별도)
+- **HTTPS 강제**: `jwt.cookie.secure: true` 정합. 사용자가 HTTP 입력해도 자동 승격
+- **Fargate 정합**: target-type=ip 강제. ECS Service `loadBalancers` config가 awsvpc IP 자동 등록
+- **보안 baseline**: TLS 1.3 + drop_invalid_header_fields + xff_client_port
+- **rolling update 다운타임 단축**: deregistration_delay 30s (default 300 → 90% 단축)
+- **host header 라우팅으로 환경 격리**: DNS 단에서 staging vs prod 분리. URL이 곧 환경
+
+### 트레이드오프 / 부정적
+
+- **단일 ALB 장애점**: AWS ALB 자체는 multi-AZ 자동 — ap-northeast-2 region 전체 장애 시에만 영향. portfolio 프로젝트 가용성 요구 낮음 → 수용
+- **staging LCU가 prod와 동일 ALB에서 경합**: staging 부하 테스트가 prod 응답 시간 영향 가능. M2 트래픽 발생 시 ALB 2개 분리 검토
+- **구형 브라우저 호환 손실**: TLS 1.3 정책 → IE 11 미지원. portfolio 프로젝트라 영향 없음
+- **`host-header` 변경 시 routing rule 재배포 필요**: 추가 환경(beta/dev) 신설 시 ALB rule 추가 — Terraform 자동화 미시점이라 수동 작업
+- **ACM 인증서 발급 지연 risk**: DNS 검증 NS 전파가 최대 72시간 — 운영 시점에 미리 발급해두지 않으면 배포 차단
+- **HTTPS 강제로 인한 ALB → ECS 측 HTTP에서 `X-Forwarded-Proto` 의존**: Spring Boot가 `server.forward-headers-strategy: native` 명시 안 하면 self-referential URL이 `http://`로 생성될 위험 (ts010-3·ts010-4 트러블슈팅 등록)
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **A. ALB 1개 공유 + host header (선택)** | 비용 절감, 환경 격리 DNS 단 | staging이 prod LCU 경합, M2 ALB 분리 시 마이그레이션 |
+| **B. ALB 2개 분리 (prod·staging 각각)** | 환경 완전 격리, LCU 독립 | 시간 비용 2배, M1 트래픽 0명 단계에서 과도 |
+| **C. NLB (Network LB)** | 더 낮은 latency, raw TCP | HTTP/HTTPS 처리 불가 (path/host 라우팅 불가), HTTPS termination도 ECS에 부담 |
+| **D. API Gateway** | rate limiting + WAF 통합 | 시간 비용 + 요청당 비용 증가, Lambda 외 ECS 사용 시 ALB 대비 가치 작음 |
+| **E. target-type=instance** | (선택지 자체 부재) | Fargate awsvpc에서 등록 불가 — AWS 아키텍처 제약 |
+| **F. HTTP 80 forward to ECS (no redirect)** | 인증서 미보유 시 즉시 운영 가능 | `jwt.cookie.secure: true` 동작 불가, 보안 baseline 미달, HSTS 적용 불가 |
+| **G. CloudFront + ALB origin** | edge 캐시, WAF, DDoS 보호 | M1 단계 비용·복잡도 증가. 정적 자산 없어 캐시 가치 낮음 — M3 검토 |
+
+## 알려진 follow-up (본 ADR 범위 외)
+
+- **Story-TBD(ECS Service 치환)**: Story-047 `service-{prod,staging}.json`의 `<*_TARGET_GROUP_ARN>` 치환 + ECS Service 생성 시 Target Group 자동 등록
+- **Story-TBD(WAF)**: AWS WAF web ACL — Rate-based + SQLi/XSS/Common rules. M2 보안 강화
+- **Story-TBD(Route 53 IaC)**: Terraform 모듈로 alias record 자동 관리. M2 Product 7 Epic 2
+- **Story-TBD(Spring Forward Headers)**: `application-prod.yml`에 `server.forward-headers-strategy: native` 추가 — ALB X-Forwarded-Proto 정확 인식. 본 ADR 결정의 application 측 정합. ts010-3·ts010-4 해결책 코드화
+- **Story-TBD(HSTS)**: Spring Security `httpStrictTransportSecurity` 활성 — HTTPS 강제 강화
+- **Story-TBD(ALB 2개 분리)**: M2 staging 트래픽 발생 시 환경별 ALB 분리
+- **Story-TBD(WAF + Shield)**: DDoS 대비 — 트래픽 발생 후 검토
+- **Story-TBD(ALB access logs S3)**: 보안 감사 — S3 비용 trade-off
+- **Story-TBD(Mutual TLS)**: B2B API 클라이언트 인증 — 향후 외부 통합 진입 시
+
+## 다시 검토할 시점
+
+- **staging 트래픽이 prod LCU에 영향 미치는 시점**: ALB 2개 분리 (대안 B로 전환)
+- **portfolio → production 전환 시점**: WAF + Shield + CloudFront 도입
+- **구형 브라우저 사용자 확인 시점**: TLS 정책 완화 (1.2 + 1.3)
+- **API Gateway 가치 임계 도달 시점**: rate limiting을 ALB rule보다 정밀하게 제어 필요 시
+- **HTTP/3 (QUIC) 지원 확정 시점**: AWS ALB HTTP/3 지원되면 latency 개선 검토

--- a/docs/adr/ADR016-alb-listener-target-group.md
+++ b/docs/adr/ADR016-alb-listener-target-group.md
@@ -103,7 +103,7 @@ TLS 1.2 + 1.3 모두 지원, 약한 cipher 제거. portfolio 프로젝트라 구
 - **Story-TBD(ECS Service 치환)**: Story-047 `service-{prod,staging}.json`의 `<*_TARGET_GROUP_ARN>` 치환 + ECS Service 생성 시 Target Group 자동 등록
 - **Story-TBD(WAF)**: AWS WAF web ACL — Rate-based + SQLi/XSS/Common rules. M2 보안 강화
 - **Story-TBD(Route 53 IaC)**: Terraform 모듈로 alias record 자동 관리. M2 Product 7 Epic 2
-- **Story-TBD(Spring Forward Headers)**: `application-prod.yml`에 `server.forward-headers-strategy: native` 추가 — ALB X-Forwarded-Proto 정확 인식. 본 ADR 결정의 application 측 정합. ts010-3·ts010-4 해결책 코드화
+- **Story-TBD(Spring Forward Headers + Graceful Shutdown)** ⚠ **즉시 후속 권장**: `application-prod.yml`에 `server.forward-headers-strategy: native` + `server.shutdown: graceful` + `spring.lifecycle.timeout-per-shutdown-phase: 30s` 추가. 본 ADR 결정의 application 측 정합 — **본 Story 머지 후 ALB Listener 셋업 시 첫 HTTPS 요청에서 ts010-3/ts010-4 즉시 발화 가능**. Spring Boot 3.x default는 `server.shutdown=immediate`라 deregistration_delay 30s가 default 동작에 의존하면 안 됨 — 명시 필수
 - **Story-TBD(HSTS)**: Spring Security `httpStrictTransportSecurity` 활성 — HTTPS 강제 강화
 - **Story-TBD(ALB 2개 분리)**: M2 staging 트래픽 발생 시 환경별 ALB 분리
 - **Story-TBD(WAF + Shield)**: DDoS 대비 — 트래픽 발생 후 검토

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -16,3 +16,4 @@
 | [ADR012](ADR012.md) | 운영 컨테이너 base image `eclipse-temurin:21-jre-alpine` 채택, Distroless 보류 (Story 1-1) | Accepted | 2026-06-25 |
 | [ADR013](ADR013-gha-oidc-assume-role.md) | GitHub Actions → AWS 인증을 OIDC AssumeRole로 전환 (Story-046) | Accepted | 2026-06-29 |
 | [ADR014](ADR014-ecs-task-iam-role-separation.md) | ECS Task IAM Role 3종 분리 — Execution/Task/GHA Deploy (Story-047) | Accepted | 2026-06-29 |
+| [ADR016](ADR016-alb-listener-target-group.md) | ALB 1개 공유 + Listener 80→443 + Target Group type=ip + TLS 1.3 (Story-049) | Accepted | 2026-06-29 |

--- a/docs/operations/troubleshooting/ts010-alb-setup.md
+++ b/docs/operations/troubleshooting/ts010-alb-setup.md
@@ -20,6 +20,9 @@ ts009(VPC)·ts008(ECS)와 cross-link. 1인 운영자가 1회만 실행.
 
 ## 2. ACM 인증서 발급 (도메인 보유 시)
 
+> **사전 발급 권장**: ACM DNS 검증은 NS 전파 + 발급까지 **최대 72시간** 소요 가능 (보통 5-30분). 본 Story 운영 셋업 일정 1주 전에 §2를 선행 실행해 ISSUED 상태로 미리 발급해두는 것이 D-Day 일정 차단 방지에 효과적. milestone.md "리스크와 관찰 포인트" 표에 추가 검토 권장.
+
+
 ```bash
 # wildcard 또는 multi-domain 인증서
 CERT_ARN=$(aws acm request-certificate \

--- a/docs/operations/troubleshooting/ts010-alb-setup.md
+++ b/docs/operations/troubleshooting/ts010-alb-setup.md
@@ -1,0 +1,354 @@
+# ts010: ALB + Target Group 1회성 셋업·검증·트러블슈팅
+
+Story-049로 `infra/alb/`에 ALB + Target Group 2종 spec JSON이 추가됐다. 본 가이드는 AWS 콘솔(또는 CLI)에서 1회성 셋업하는 절차 + 검증 + 자주 보는 에러 6건을 한 곳에 모았다.
+
+ts009(VPC)·ts008(ECS)와 cross-link. 1인 운영자가 1회만 실행.
+
+---
+
+## 1. 전제
+
+- **VPC 셋업 완료** (ts009 §1-8) — VPC ID + public subnet 2개(public-2a, public-2c) + alb-sg ID 발행
+- **도메인 보유 시**: Route 53 hosted zone + 도메인 DNS 위임 완료 → ACM 인증서 발급 가능
+- **도메인 미보유 시**: HTTPS 불가 → HTTP only 운영 (Listener 80 단일, `jwt.cookie.secure=false`로 application-prod.yml 임시 변경 필요. 운영용 아님)
+- AWS 콘솔 ALB 관리 권한 (`elasticloadbalancing:*`, `acm:RequestCertificate`, `route53:ChangeResourceRecordSets`)
+- AWS CLI 권장
+
+> **본 가이드는 도메인 보유 가정** (`thirdstool.com` — application-prod.yml에 기명시). 도메인 미보유 시 §2 ACM 단계 skip + §5 HTTPS 443 listener 미생성.
+
+---
+
+## 2. ACM 인증서 발급 (도메인 보유 시)
+
+```bash
+# wildcard 또는 multi-domain 인증서
+CERT_ARN=$(aws acm request-certificate \
+  --domain-name "thirdstool.com" \
+  --subject-alternative-names "*.thirdstool.com" "api.thirdstool.com" "staging.thirdstool.com" \
+  --validation-method DNS \
+  --region ap-northeast-2 \
+  --query 'CertificateArn' --output text)
+echo "CERT_ARN=$CERT_ARN"
+
+# DNS 검증 record 확인 후 Route 53에 자동 추가
+aws acm describe-certificate --certificate-arn $CERT_ARN --region ap-northeast-2 \
+  | jq '.Certificate.DomainValidationOptions[].ResourceRecord'
+```
+
+각 도메인의 `ResourceRecord` (`_xxx.thirdstool.com → _yyy.acm-validations.aws.`)를 Route 53 hosted zone에 CNAME 추가.
+
+```bash
+# ISSUED 도달 대기 (5분 ~ 72시간 — 보통 5-30분)
+aws acm wait certificate-validated --certificate-arn $CERT_ARN --region ap-northeast-2
+```
+
+ISSUED 상태 확인:
+```bash
+aws acm describe-certificate --certificate-arn $CERT_ARN --region ap-northeast-2 | jq '.Certificate.Status'
+# "ISSUED"
+```
+
+---
+
+## 3. Target Group 2개 생성
+
+VPC ID + alb-sg ID 필요 (ts009 §8 출력).
+
+```bash
+VPC_ID=vpc-xxxxxxxx  # ts009 출력
+
+# prod Target Group
+PROD_TG_ARN=$(aws elbv2 create-target-group \
+  --name thirdtool-prod-tg \
+  --protocol HTTP \
+  --port 8080 \
+  --vpc-id $VPC_ID \
+  --target-type ip \
+  --protocol-version HTTP1 \
+  --health-check-protocol HTTP \
+  --health-check-path /health \
+  --health-check-port traffic-port \
+  --health-check-interval-seconds 30 \
+  --health-check-timeout-seconds 5 \
+  --healthy-threshold-count 2 \
+  --unhealthy-threshold-count 2 \
+  --matcher HttpCode=200 \
+  --tags Key=Project,Value=ThirdTool Key=Environment,Value=prod Key=ManagedBy,Value=Story-049 \
+  --region ap-northeast-2 \
+  --query 'TargetGroups[0].TargetGroupArn' --output text)
+
+# deregistration_delay 단축 (default 300s → 30s)
+aws elbv2 modify-target-group-attributes \
+  --target-group-arn $PROD_TG_ARN \
+  --attributes Key=deregistration_delay.timeout_seconds,Value=30 \
+  --region ap-northeast-2
+
+# staging Target Group (동일 절차, name + tags만 변경)
+STAGING_TG_ARN=$(aws elbv2 create-target-group \
+  --name thirdtool-staging-tg \
+  --protocol HTTP --port 8080 --vpc-id $VPC_ID --target-type ip \
+  --protocol-version HTTP1 \
+  --health-check-path /health \
+  --health-check-interval-seconds 30 --health-check-timeout-seconds 5 \
+  --healthy-threshold-count 2 --unhealthy-threshold-count 2 \
+  --matcher HttpCode=200 \
+  --tags Key=Environment,Value=staging \
+  --region ap-northeast-2 \
+  --query 'TargetGroups[0].TargetGroupArn' --output text)
+
+aws elbv2 modify-target-group-attributes \
+  --target-group-arn $STAGING_TG_ARN \
+  --attributes Key=deregistration_delay.timeout_seconds,Value=30 \
+  --region ap-northeast-2
+
+echo "PROD_TG_ARN=$PROD_TG_ARN"
+echo "STAGING_TG_ARN=$STAGING_TG_ARN"
+```
+
+> **target-type=ip 필수**: Fargate는 instance 등록 불가. instance로 잘못 생성 시 §8 ts010-1 발생.
+
+---
+
+## 4. ALB 생성
+
+```bash
+PUB_2A=subnet-xxxxxxxx  # ts009 §8 출력
+PUB_2C=subnet-yyyyyyyy
+ALB_SG=sg-xxxxxxxx
+
+ALB_ARN=$(aws elbv2 create-load-balancer \
+  --name thirdtool-alb \
+  --type application \
+  --scheme internet-facing \
+  --ip-address-type ipv4 \
+  --subnets $PUB_2A $PUB_2C \
+  --security-groups $ALB_SG \
+  --tags Key=Project,Value=ThirdTool Key=Environment,Value=shared Key=ManagedBy,Value=Story-049 \
+  --region ap-northeast-2 \
+  --query 'LoadBalancers[0].LoadBalancerArn' --output text)
+
+# 보안·라우팅 속성 적용 (preserve_host_header, drop_invalid_header_fields, xff_client_port)
+aws elbv2 modify-load-balancer-attributes \
+  --load-balancer-arn $ALB_ARN \
+  --attributes \
+    Key=routing.http.drop_invalid_header_fields.enabled,Value=true \
+    Key=routing.http.preserve_host_header.enabled,Value=true \
+    Key=routing.http.xff_client_port.enabled,Value=true \
+    Key=idle_timeout.timeout_seconds,Value=60 \
+  --region ap-northeast-2
+
+# ALB DNS 확인
+ALB_DNS=$(aws elbv2 describe-load-balancers --load-balancer-arns $ALB_ARN --region ap-northeast-2 \
+  | jq -r '.LoadBalancers[0].DNSName')
+echo "ALB_DNS=$ALB_DNS"
+```
+
+---
+
+## 5. Listener 2개 + 라우팅 규칙
+
+### 5.1 Listener 80 (HTTP → HTTPS 301 redirect)
+
+```bash
+aws elbv2 create-listener \
+  --load-balancer-arn $ALB_ARN \
+  --protocol HTTP --port 80 \
+  --default-actions 'Type=redirect,RedirectConfig={Protocol=HTTPS,Port=443,StatusCode=HTTP_301,Host=#{host},Path=/#{path},Query=#{query}}' \
+  --region ap-northeast-2
+```
+
+### 5.2 Listener 443 (HTTPS, default forward prod, host rule staging)
+
+```bash
+HTTPS_LISTENER_ARN=$(aws elbv2 create-listener \
+  --load-balancer-arn $ALB_ARN \
+  --protocol HTTPS --port 443 \
+  --ssl-policy ELBSecurityPolicy-TLS13-1-2-2021-06 \
+  --certificates CertificateArn=$CERT_ARN \
+  --default-actions Type=forward,TargetGroupArn=$PROD_TG_ARN \
+  --region ap-northeast-2 \
+  --query 'Listeners[0].ListenerArn' --output text)
+
+# staging host-based rule (priority 10)
+aws elbv2 create-rule \
+  --listener-arn $HTTPS_LISTENER_ARN \
+  --priority 10 \
+  --conditions Field=host-header,Values=staging.thirdstool.com \
+  --actions Type=forward,TargetGroupArn=$STAGING_TG_ARN \
+  --region ap-northeast-2
+```
+
+---
+
+## 6. Route 53 alias record (도메인 보유 시)
+
+ALB DNS → 사용자 도메인 매핑. ALB의 hosted zone ID는 region별 고정 (ap-northeast-2 = `Z3JE5OI70F1IRD`).
+
+```bash
+HOSTED_ZONE_ID=Z<your-hosted-zone-id>  # Route 53 hosted zone 본인 도메인
+ALB_HOSTED_ZONE_ID=Z3JE5OI70F1IRD       # ap-northeast-2 ALB 고정
+
+# api.thirdstool.com → ALB
+cat > /tmp/dns-change.json <<EOF
+{
+  "Changes": [
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "api.thirdstool.com",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "$ALB_HOSTED_ZONE_ID",
+          "DNSName": "dualstack.$ALB_DNS",
+          "EvaluateTargetHealth": true
+        }
+      }
+    },
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "staging.thirdstool.com",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "$ALB_HOSTED_ZONE_ID",
+          "DNSName": "dualstack.$ALB_DNS",
+          "EvaluateTargetHealth": true
+        }
+      }
+    }
+  ]
+}
+EOF
+
+aws route53 change-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --change-batch file:///tmp/dns-change.json
+```
+
+---
+
+## 7. 검증
+
+### 7.1 ARN 출력 메모 (후속 Story placeholder 치환용)
+
+```
+PROD_TG_ARN=$PROD_TG_ARN
+# → infra/ecs/service-prod.json <PROD_TARGET_GROUP_ARN> 치환
+
+STAGING_TG_ARN=$STAGING_TG_ARN
+# → infra/ecs/service-staging.json <STAGING_TARGET_GROUP_ARN> 치환
+
+ALB_ARN=$ALB_ARN
+ALB_DNS=$ALB_DNS
+CERT_ARN=$CERT_ARN
+HTTPS_LISTENER_ARN=$HTTPS_LISTENER_ARN
+```
+
+### 7.2 Target Group 상태 (ECS Service 등록 후만 의미)
+
+```bash
+aws elbv2 describe-target-health --target-group-arn $PROD_TG_ARN --region ap-northeast-2 \
+  | jq '.TargetHealthDescriptions[] | {Target: .Target.Id, State: .TargetHealth.State}'
+# ECS Service 미생성 시 빈 배열. Service 등록 후 1-2분 대기 → "healthy" 도달
+```
+
+### 7.3 HTTP → HTTPS redirect 검증 (도메인 보유 시)
+
+```bash
+curl -sI http://api.thirdstool.com/health
+# 기대: HTTP/1.1 301 Moved Permanently
+#       Location: https://api.thirdstool.com/health
+
+curl -sI https://api.thirdstool.com/health
+# 기대: HTTP/2 200 (ECS Service healthy 도달 후)
+```
+
+### 7.4 staging host header 분기 검증
+
+```bash
+curl -sI https://staging.thirdstool.com/health
+# staging-tg → staging Service (별도 Task)로 라우팅
+```
+
+---
+
+## 8. 트러블슈팅
+
+### ts010-1: Target Group의 Target이 `unhealthy` 상태 영구 지속
+
+**원인 가능성**:
+- Target Group `target-type=instance`로 잘못 생성 (Fargate는 ip 강제) — 그러나 ECS Service의 LoadBalancers config에서 IP를 등록할 수 없으므로 등록 자체 실패
+- ECS Task의 healthCheck가 ALB Target Group healthCheck 도달 전에 실패
+- ALB SG (`alb-sg`) → app-sg ingress 8080 누락
+- ECS Service `healthCheckGracePeriodSeconds`(90s) < ALB threshold × interval (2 × 30 = 60s) 라 healthy 안정 도달 전 Task 종료
+
+**해결**:
+1. Target Group describe → `TargetType` 확인 → `ip`가 아니면 재생성 필수
+2. `alb-sg` ingress: 80/443 from 0.0.0.0/0 / `app-sg` ingress: 8080 from alb-sg (ts009 §7.1-7.2 확인)
+3. ECS Exec로 Task 진입 → `wget -O- http://localhost:8080/health` 직접 200 확인 (Spring Boot 부팅 완료 검증)
+4. Service `healthCheckGracePeriodSeconds`를 120s로 늘리거나 ECS Task healthCheck `startPeriod`를 늘림
+
+### ts010-2: ACM 인증서 `PENDING_VALIDATION` 영구 지속
+
+**원인**: DNS 검증 record가 Route 53에 추가됐지만 NS 위임 미설정으로 전파 안 됨. 또는 도메인 registrar에서 NS 변경 5-72시간 대기.
+
+**해결**:
+1. `dig _xxx.thirdstool.com CNAME` → 등록한 검증 CNAME이 보이는지 확인
+2. 안 보이면 Route 53 hosted zone NS와 도메인 registrar(가비아·후이즈·Route 53 등) NS가 일치하는지 확인
+3. NS 변경 직후라면 최대 72시간 대기 (보통 5-30분)
+
+### ts010-3: HTTP→HTTPS redirect가 1회만 동작, 이후 무한 loop
+
+**원인**: ECS Task가 `X-Forwarded-Proto` 헤더 무시. Spring Boot가 HTTPS 인지 못 해 자체 응답에 `http://` URL 반환 → 브라우저가 다시 80으로 요청.
+
+**해결**:
+1. `application-prod.yml`에 `server.forward-headers-strategy: native` 또는 `framework` 추가
+2. `routing.http.xff_client_port.enabled=true` ALB attribute 확인 (§4 명시)
+3. ALB가 `X-Forwarded-Proto: https` 헤더 전달 중인지 Task 로그 확인
+
+### ts010-4: `jwt.cookie.secure=true` + HTTPS 브라우저에서 쿠키 못 받음
+
+**원인**: ALB → ECS는 HTTP, application-prod.yml은 `jwt.cookie.secure=true` 명시. Spring이 응답에 `Secure` flag 붙이지만 ALB가 `X-Forwarded-Proto: https`로 알려야 정상.
+
+**해결**: ts010-3 해결과 동일. `forward-headers-strategy` 적용.
+
+### ts010-5: ACM 인증서 SubjectAlternativeNames 빠진 도메인 추가
+
+**원인**: 인증서 발급 시 `staging.thirdstool.com` 누락 → 발급 후 도메인 추가 시 인증서 재발급 필요.
+
+**해결**:
+1. 새 인증서 발급(`--subject-alternative-names`에 누락 도메인 포함)
+2. ALB Listener 443의 certificate 교체 (`aws elbv2 modify-listener --certificates`)
+3. 기존 인증서 삭제 (ALB 미참조 확인 후)
+
+### ts010-6: Listener rule priority 충돌 (`PriorityInUse`)
+
+**원인**: 새 rule 추가 시 동일 priority 사용 중. priority는 1-50000 unique 필수.
+
+**해결**:
+```bash
+aws elbv2 describe-rules --listener-arn $HTTPS_LISTENER_ARN --region ap-northeast-2 \
+  | jq '.Rules[] | {Priority, Conditions}'
+# 사용 중 priority 확인 후 다른 값(예: 20, 30) 사용
+```
+
+---
+
+## 9. 후속 (별도 Story)
+
+- **Story-TBD(ECS Service 치환)**: Story-047 `service-{prod,staging}.json`의 `<*_TARGET_GROUP_ARN>` 치환 + ECS Service 생성/업데이트
+- **Story-TBD(WAF)**: ALB 앞 AWS WAF web ACL — Rate-based + SQLi/XSS/Common rules (M2 보안 강화)
+- **Story-TBD(Route 53 IaC)**: Terraform 모듈로 alias record 자동 관리 (M2)
+- **Story-TBD(sticky sessions)**: 현재 JWT stateless라 불요. 세션 기반 전환 시 검토
+- **Story-TBD(connection draining 튜닝)**: 현재 30s. 부하 테스트 후 ECS Task graceful shutdown 시간 매칭
+- **Story-TBD(Custom error pages)**: 503/504 default 페이지 customizing
+- **Story-TBD(ALB access logs S3)**: 트래픽 감사 — 보안 사고 추적 (cost trade-off)
+
+---
+
+## 10. 관련
+
+- [`ts009-vpc-setup.md`](ts009-vpc-setup.md) — alb-sg + public subnet 발행 (선행)
+- [`ts008-ecs-cluster-setup.md`](ts008-ecs-cluster-setup.md) — ECS Service의 LoadBalancers config가 본 TG ARN 사용
+- [ADR016](../../adr/ADR016-alb-listener-target-group.md) — ALB·Target Group 설계 결정 배경
+- `infra/alb/alb-spec.json` · `target-group-spec.json` — 단일 진실 소스 JSON
+- Story-049 — milestone 0.0.1v item #13
+- AWS handoff 통합: `workflow/task/pes/handoff/aws-setup-0.0.1v.md` Stage 7

--- a/infra/alb/alb-spec.json
+++ b/infra/alb/alb-spec.json
@@ -1,0 +1,67 @@
+{
+  "region": "ap-northeast-2",
+  "loadBalancers": [
+    {
+      "name": "thirdtool-alb",
+      "scheme": "internet-facing",
+      "type": "application",
+      "ipAddressType": "ipv4",
+      "subnets": ["public-2a", "public-2c"],
+      "securityGroups": ["alb-sg"],
+      "idleTimeoutSeconds": 60,
+      "deletionProtection": false,
+      "http2Enabled": true,
+      "attributes": {
+        "routing.http.drop_invalid_header_fields.enabled": true,
+        "routing.http.preserve_host_header.enabled": true,
+        "routing.http.xff_client_port.enabled": true
+      },
+      "listeners": [
+        {
+          "port": 80,
+          "protocol": "HTTP",
+          "defaultAction": {
+            "type": "redirect",
+            "redirectConfig": {
+              "protocol": "HTTPS",
+              "port": "443",
+              "statusCode": "HTTP_301",
+              "host": "#{host}",
+              "path": "/#{path}",
+              "query": "#{query}"
+            }
+          }
+        },
+        {
+          "port": 443,
+          "protocol": "HTTPS",
+          "sslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+          "certificateArn": "<ACM_CERT_ARN>",
+          "defaultAction": {
+            "type": "forward",
+            "targetGroupName": "thirdtool-prod-tg"
+          },
+          "rules": [
+            {
+              "priority": 10,
+              "conditions": [
+                { "field": "host-header", "values": ["staging.thirdstool.com"] }
+              ],
+              "action": {
+                "type": "forward",
+                "targetGroupName": "thirdtool-staging-tg"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tags": {
+    "default": {
+      "Project": "ThirdTool",
+      "Environment": "shared",
+      "ManagedBy": "Story-049"
+    }
+  }
+}

--- a/infra/alb/target-group-spec.json
+++ b/infra/alb/target-group-spec.json
@@ -1,0 +1,64 @@
+{
+  "vpc": "thirdtool-vpc",
+  "targetGroupTypeRationale": "Fargate awsvpc 네트워크 모드는 ENI 단위 IP를 받으므로 target-type=ip 필수 (instance 등록 불가). ECS Service가 LoadBalancers 설정으로 자동 register/deregister 수행.",
+  "targetGroups": [
+    {
+      "name": "thirdtool-prod-tg",
+      "targetType": "ip",
+      "protocol": "HTTP",
+      "protocolVersion": "HTTP1",
+      "port": 8080,
+      "vpc": "thirdtool-vpc",
+      "healthCheck": {
+        "enabled": true,
+        "protocol": "HTTP",
+        "path": "/health",
+        "port": "traffic-port",
+        "intervalSeconds": 30,
+        "timeoutSeconds": 5,
+        "healthyThresholdCount": 2,
+        "unhealthyThresholdCount": 2,
+        "matcher": { "httpCode": "200" }
+      },
+      "attributes": {
+        "deregistration_delay.timeout_seconds": 30,
+        "load_balancing.algorithm.type": "round_robin",
+        "stickiness.enabled": false
+      },
+      "tags": {
+        "Project": "ThirdTool",
+        "Environment": "prod",
+        "ManagedBy": "Story-049"
+      }
+    },
+    {
+      "name": "thirdtool-staging-tg",
+      "targetType": "ip",
+      "protocol": "HTTP",
+      "protocolVersion": "HTTP1",
+      "port": 8080,
+      "vpc": "thirdtool-vpc",
+      "healthCheck": {
+        "enabled": true,
+        "protocol": "HTTP",
+        "path": "/health",
+        "port": "traffic-port",
+        "intervalSeconds": 30,
+        "timeoutSeconds": 5,
+        "healthyThresholdCount": 2,
+        "unhealthyThresholdCount": 2,
+        "matcher": { "httpCode": "200" }
+      },
+      "attributes": {
+        "deregistration_delay.timeout_seconds": 30,
+        "load_balancing.algorithm.type": "round_robin",
+        "stickiness.enabled": false
+      },
+      "tags": {
+        "Project": "ThirdTool",
+        "Environment": "staging",
+        "ManagedBy": "Story-049"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 개요

ALB(internet-facing) 1개 + Target Group 2종(prod·staging, target-type=ip) + Listener 80→443 redirect + host-header staging routing의 단일 진실 소스 spec JSON과 1회성 셋업 runbook + 결정 기록을 코드베이스에 추가한다. milestone 0.0.1v item #13 "6 1-2 ALB + Target Group type=ip" 코드 단 충족 — Story-047 `service-prod.json`/`service-staging.json`의 `<PROD_TARGET_GROUP_ARN>`/`<STAGING_TARGET_GROUP_ARN>` placeholder 해소 자원 발행.

## ⚠️ 머지 순서 (CRITICAL)

**본 PR은 PR #177 (Story-048 VPC) 머지 후 머지 권장**:
- 본 PR이 사용하는 logical name(`alb-sg`, `public-2a`, `public-2c`)은 PR #177의 `infra/vpc/*.json` 산출물
- PR #177 미머지 상태에서 본 PR만 머지 시 develop이 부분 일관성 손실 (ALB JSON 존재 + VPC JSON 부재)
- `docs/adr/index.md` 충돌 가능성: PR #177의 ADR015 행 추가 vs 본 PR의 ADR016 행 추가 — 동일 위치 → rebase 시 ADR016이 ADR015 다음으로 이동 필요
- 권장 순서: #177 → 본 PR (#178)

## ⚠️ 즉시 후속 Story 필요 (CRITICAL)

본 PR 머지로 ALB가 깔리는 즉시 다음 application 측 설정 부재가 발화:

- **`server.forward-headers-strategy: native`** 미설정 → ALB가 `X-Forwarded-Proto: https` 전달해도 Spring 미인식 → HTTPS redirect 무한 loop (ts010-3) + `jwt.cookie.secure=true` 쿠키 거부 (ts010-4)
- **`server.shutdown: graceful` + `spring.lifecycle.timeout-per-shutdown-phase: 30s`** 미설정 → Spring Boot 3.x default `shutdown=immediate`라 본 ADR016 deregistration_delay 30s가 default 동작 의존 시 깨짐 → ECS rolling update 시 in-flight request 5xx

본 PR 머지 즉시 후속 Story로 application-prod.yml 변경 발행 필수.

## 왜 / 설계 결정

- **ALB 1개 공유 + host-header routing (ADR016)**: prod·staging 환경별 ALB 2개 분리 대비 시간 비용 절반 절감 (~$0.54/일). `staging.thirdstool.com` host header rule로 staging TG 분기. M2 staging LCU 경합 시 분리 follow-up
- **target-type=ip 강제**: Fargate awsvpc 네트워크 모드는 instance 등록 불가. ECS Service `loadBalancers` config가 ENI IP 자동 register
- **Listener 80→443 HTTPS 301 redirect**: `application-prod.yml` `jwt.cookie.secure: true` 정합. host/path/query 보존
- **TLS 1.3 정책** (`ELBSecurityPolicy-TLS13-1-2-2021-06`): TLS 1.2 + 1.3 지원, 약한 cipher 제거. portfolio라 구형 브라우저 호환 요구 낮음
- **deregistration_delay 30s**: default 300s → 90% 단축. ECS rolling update 다운타임 축소 (단 server.shutdown=graceful 명시 필수)
- **ALB attributes 4종**: drop_invalid_header_fields(HTTP Smuggling 방지) + preserve_host_header + xff_client_port + idle_timeout=60

## 작업 내용

- **feat(infra)**: `infra/alb/alb-spec.json` (ALB 1개 + Listener 80→443 + 443 forward prod + host rule staging + 보안 attributes 4종) + `infra/alb/target-group-spec.json` (prod·staging, target-type=ip, /health 30s 2/2 threshold, deregistration 30s, stickiness false)
- **docs(operations)**: `docs/operations/troubleshooting/ts010-alb-setup.md` (357줄) — 10 섹션 + 트러블슈팅 6건 (ACM 발급 + ALB 생성 + Listener + Route 53 alias + 검증 + ts010-1~6)
- **docs(adr)**: `docs/adr/ADR016-alb-listener-target-group.md` (119줄) — 대안 7종 비교 + follow-up 9건 + ⚠ Spring forward-headers/graceful shutdown 즉시 후속 강조 + index 갱신
- **fix(infra)**: Reviewer 5관점 지적 보강 — Critical 1건(도메인 오타 false positive 검증) + Major 4건(milestone 각주·cost Route 53·product line 513 deviation·ts010 ACM 사전 발급) + Minor 1건(Spring Boot 3.x default shutdown)

## 변경 유형

- [x] feat  - [x] fix  - [ ] refactor  - [x] docs  - [ ] test  - [ ] chore

## 테스트

- `jq . infra/alb/*.json` → 2건 OK
- 자바 코드 0줄 변경 — 단위/슬라이스 테스트 추가 의무 없음 (conventions §4.8 트리거 적용 불가)
- **end-to-end는 사용자 영역** — ts010 §1-6 1회성 셋업 (ACM + Target Group 2 + ALB + Listener 2 + Route 53 alias) 후 ALB DNS 발행 + Target Group ARN 2건 발행. Story-047 `service-{prod,staging}.json` placeholder 치환 가능 상태로 진입

## 체크리스트

- [x] 빌드 / 테스트 통과 (자바 무변경)
- [x] 모든 응답 `ApiResponse<T>` 래퍼 — N/A (API 변경 없음)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 반영 — ADR016 신규 + index 갱신
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수 — N/A
- [x] BC 간 의존 방향 위반 없음 — N/A
- [x] 대상 브랜치 = `develop` 확인
- [x] (stacked) 대상 브랜치 = `develop` 확인 — PR #177 머지 순서 의존

## 머지 영향 (안전성)

- 본 PR은 `.github/workflows/*.yml` 변경 없음 → **기존 EC2 SSH 배포 흐름 영향 0건**
- Java 코드 0줄 변경 → 빌드·테스트·기존 API 동작 영향 0건
- 실제 ALB는 AWS 콘솔에서 ts010 따라 1회 셋업 후에만 존재 → 머지 직후 AWS 측 변화 없음

## 비용 영향 참고 (로컬 cost.md 갱신)

- ALB 시간 비용 ~$0.80/일 (cost.md 기존 baseline)
- Route 53 hosted zone $0.50/월 = ~$0.02/일 신규 (Story-049 alias record 필요)
- ACM 인증서 (AWS 공인 wildcard) $0 (관리형 무료)
- 본주 총 추정 $6.11 → $6.13/일, 6일 누적 $36.66 → $36.78

## 후속 Story (별도 PR — ADR016 follow-up 9건 + ts010 §9 7건)

**⚠ 즉시 후속 (CRITICAL — 본 PR 머지 직후)**:
- Story-TBD(Spring Forward Headers + Graceful Shutdown): `application-prod.yml`에 `server.forward-headers-strategy: native` + `server.shutdown: graceful` + `spring.lifecycle.timeout-per-shutdown-phase: 30s` 추가

**일반 follow-up**:
- Story-TBD(ECS Service 치환): Story-047 `service-{prod,staging}.json` `<*_TARGET_GROUP_ARN>` 치환 + ECS Service 생성
- Story-TBD(application-staging.yml 신설): staging Task가 prod profile 사용하는 transitional 해소 (Story-047 ADR014 follow-up 묶음)
- Story-TBD(HSTS): Spring Security `httpStrictTransportSecurity` 활성
- Story-TBD(WAF): Rate-based + SQLi/XSS/Common rules (M2 보안 강화)
- Story-TBD(Route 53 IaC, ALB 분리, CloudFront, mTLS): M2-M3

## 관련 이슈

- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-infra-network.md` (Epic 2 Story 2-1 코드 단 충족, ADR016 deviation 명시 갱신)
- Milestone: `workflow/task/milestones/version/0.0.1v/milestone.md` item #13
- Story: Story-049
- ADR: ADR016 (선행: ADR013 OIDC, ADR014 ECS IAM, ADR015 VPC — PR #177 머지 후)
- Runbook: ts010 (선행: ts009 VPC + ts008 ECS)
- AWS handoff: `workflow/task/pes/handoff/aws-setup-0.0.1v.md` Stage 7 (gitignored)