### PR TITLE
feat(infra): Secrets Manager 5종 비밀 spec + ts012 + ADR019 [Story-052]

### DIFF
--- a/docs/adr/ADR019-secrets-manager-naming-and-task-role-scope.md
+++ b/docs/adr/ADR019-secrets-manager-naming-and-task-role-scope.md
@@ -1,0 +1,146 @@
+# ADR019: Secrets Manager 5종 비밀 명명 + env-prefix 격리 + Task Role Resource scope (Story-052)
+
+- **상태**: Accepted
+- **날짜**: 2026-06-30
+- **관련**: Product 7 Secrets·Terraform Epic 1 (`workflow/task/pes/workspectrum/sdd/in-progress/product-infra-ops.md`) · milestone 0.0.1v item #15 (`workflow/task/milestones/version/0.0.1v/milestone.md`) · `docs/operations/troubleshooting/ts012-secrets-manager-setup.md` · `infra/secrets/` · `infra/iam/ecs-task-role-permissions-policy.json` · `infra/ecs/task-definition-prod.json` · ADR014(IAM Role 분리) · ADR018(RDS) · 후속 Story-053 (Spring Cloud AWS bootstrap)
+
+## 컨텍스트
+
+Story-046(GHA OIDC) + Story-047(ECS Task Def secrets ARN placeholder) + Story-051(RDS) 후 다음 의존 단계는 **실제 비밀의 영속 저장소** — AWS Secrets Manager. 본 Story가 만들어지면:
+
+- task-definition-prod.json의 `<SUFFIX>` placeholder 해소 (ts012 출력 메모로 채움)
+- GitHub Actions Secrets에 보관되던 `DB_PASSWORD`, `JWT_SECRET_KEY`, `KAKAO_CLIENT_SECRET`, `NAVER_CLIENT_SECRET` 5건 폐기 (GitHub Secrets 의존 0건 달성)
+- 후속 Story-053이 Spring Cloud AWS Secrets Manager bootstrap으로 application-prod.yml placeholder를 자동 치환할 진입점
+- AI Epic 3 (Story-058+) 진입 시 Gemini API key 사전 자리 마련
+
+추가 결정 영역:
+- **시크릿 분할 단위**: 모든 비밀 1개 시크릿에 통합 vs 도메인별 분할 vs 5종 분할 vs JSON multi-key 활용
+- **환경 분리 방식**: 시크릿 이름 prefix(`thirdtool/{env}/...`) vs Tag 기반 ABAC vs Role 분리(env마다 별도 Role)
+- **회전 정책**: M1 활성 vs M2 활성 vs 비활성
+- **AWS IAM User access key (S3Config용)**: Secrets Manager에 저장 유지 vs DefaultCredentialsProvider 전환 후 폐기
+- **암호화 키**: AWS managed `aws/secretsmanager` vs Customer Managed KMS Key (CMK)
+
+## 결정
+
+### 5종 비밀 분할 + JSON multi-key
+
+| 시크릿 | 키 | 값 출처 |
+| --- | --- | --- |
+| `thirdtool/{env}/db-credential` | HOST, PORT, NAME, USERNAME, PASSWORD | RDS endpoint (ts011) + 운영자 결정 |
+| `thirdtool/{env}/jwt-secret` | SECRET_KEY | `openssl rand -base64 48` (384 bit ≥ HS512 최소 256 bit) |
+| `thirdtool/{env}/oauth-kakao` | CLIENT_ID, CLIENT_SECRET | 카카오 developers 콘솔 |
+| `thirdtool/{env}/oauth-naver` | CLIENT_ID, CLIENT_SECRET | 네이버 developers 콘솔 |
+| `thirdtool/{env}/gemini-api-key` | API_KEY | Google AI Studio (M1은 placeholder 등록만) |
+
+- **단일 통합 시크릿 거부**: 키 회전 단위가 비밀별로 다름(JWT 회전 vs OAuth 회전 vs DB 회전). 단일 통합은 한 키 회전이 다른 비밀 cache invalidation을 트리거 → 부팅 jitter.
+- **kakao+naver 통합 거부**: 향후 oauth provider 추가(애플/구글) 시 시크릿 분리 패턴 강제. 통합 시 키 충돌(`KAKAO_CLIENT_ID` vs `GOOGLE_CLIENT_ID`) 회피용 prefix 강제 → JSON 키가 길어짐.
+- **5종 분할 채택**: 회전 단위 + 발급 출처가 모두 비밀별로 다름. JSON multi-key는 동일 출처의 key/secret pair는 함께 두어 운영 일관성 유지.
+
+### env-prefix 격리 (`thirdtool/{env}/...`)
+
+- 격리 방식: 비밀 이름 prefix (`thirdtool/dev/...` · `thirdtool/staging/...` · `thirdtool/prod/...`).
+- Task Role IAM 정책의 `Resource` 배열에 env별 prefix를 ARN 와일드카드로 명시.
+- **dev/prod 통합 운영 (M1)**: 단일 Task Role이 두 env 모두 접근(`dev/*` + `prod/*`). M1 합격선은 dev only지만 prod 진입 시 즉시 사용 가능하도록 미리 등록. env별 Role 분리는 환경 분리 Epic에서.
+- staging은 별도 Role(`staging-task-role` — 본 ADR 범위 외) — env 격리 보장.
+
+**Tag 기반 ABAC 거부**: IAM Condition `aws:ResourceTag/Environment` 방식은 시크릿마다 Tag 누락 시 위험. ARN prefix는 시크릿 이름이 자체 검증.
+
+### 회전 정책: 비활성 (M1)
+
+- 자동 회전 disable. 수동 회전이 필요한 경우 새 시크릿 발급 후 Task Def revision 갱신 + Service 재배포.
+- M2 진입 시 RDS Multi-AZ + Secrets Manager Rotation Lambda 동시 검토.
+
+### IAM User access key는 별도 처리 (본 ADR 범위 외)
+
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`는 Secrets Manager에 보관하지 않는다. 대신 ECS Task Role IAM의 S3 권한(`S3BucketReadWriteThirdToolServer` Statement)을 통해 `software.amazon.awssdk:s3:2.30.0`의 `DefaultCredentialsProvider`가 EC2 Container Credentials Provider 경로로 자동 인증. **본 전환은 Story-053(S3Config 코드 변경)에서 수행**. 본 ADR은 5종 비밀에 한정.
+
+### 암호화 키: AWS managed `aws/secretsmanager`
+
+- 사용 시점 KMS 비용 없음(AWS-managed key는 시간당 무료).
+- M2 트래픽 도달 후 audit log 필요성 발생 시 CMK 전환 검토. CMK 전환 시 시크릿 변경 없이 `aws kms re-encrypt` 1회 실행으로 완료.
+
+### Task Role Statement 2개 추가
+
+```json
+{
+  "Sid": "SecretsManagerReadOwnEnvPrefixes",
+  "Effect": "Allow",
+  "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+  "Resource": [
+    "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/dev/db-credential-*",
+    ... (10건 — 5 type × 2 env)
+  ]
+}
+{
+  "Sid": "KMSDecryptForSecretsManager",
+  "Effect": "Allow",
+  "Action": ["kms:Decrypt"],
+  "Resource": "*",
+  "Condition": { "StringEquals": { "kms:ViaService": "secretsmanager.ap-northeast-2.amazonaws.com" } }
+}
+```
+
+- `secretsmanager:DescribeSecret`는 Spring Cloud AWS bootstrap이 시크릿 메타데이터 조회 시 필요(Story-053).
+- `kms:Decrypt` Condition으로 다른 AWS service 경유 decrypt는 차단 — Secrets Manager 호출 컨텍스트로만 한정.
+
+### 본 ADR이 다루지 않는 범위
+
+- **staging Task Role 분리**: 환경 분리 Epic에서 별도 Role + Resource scope 분리
+- **S3Config DefaultCredentialsProvider 전환**: Story-053 (Spring Cloud AWS 측)
+- **CMK 전환**: M2 audit log 필요성 발생 후
+- **회전 Lambda**: M2 RDS Multi-AZ와 동시
+- **VPC Endpoint (Secrets Manager Interface)**: NAT 트래픽 절감용 (Product 7 Epic 2)
+- **Secrets Manager replication (multi-region)**: us-east-1 (CloudFront ACM) 등 별도 region 비밀 필요 시점에 검토
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **5종 비밀 회전 독립성**: JWT 회전이 OAuth 클라이언트에 영향 없음. DB password 회전이 Gemini API key 캐시에 영향 없음.
+- **env-prefix로 cross-env 누수 차단**: prod Task가 실수로 dev 비밀 호출해도 IAM에서 거부. **GitHub Secrets에 5종 비밀 보관 0건** — `git log -p` / `git secrets scan` 검사로 평문 비밀 누설 위험 0.
+- **JSON multi-key로 동일 출처 비밀 그룹화**: OAuth provider 1곳에서 발급한 client_id + client_secret을 단일 시크릿 회전으로 동시 갱신 가능.
+- **Spring Cloud AWS bootstrap (Story-053) 진입 준비**: 본 명명 규칙이 application-prod.yml placeholder와 매핑되어 boot 시점 자동 치환 가능.
+- **AWS managed KMS로 비용 0**: 시크릿당 월 $0.40만 부담 (5종 × $0.40 = $2/월 dev env 단일 기준).
+
+### 트레이드오프 / 부정적
+
+- **시크릿당 월 $0.40 비용 누적**: 5종 × 3 env = 15 secrets × $0.40 = $6/월 (전 환경 등록 시). API call cost는 별도 ($0.05 per 10K calls — Spring Cloud AWS는 부팅 시 1회 + 캐시 → 부담 없음).
+- **수동 회전 운영 부담**: 회전 자동화 부재로 운영자가 회전 주기 직접 관리. 운영자 1인 환경에서 회전 주기 트래킹이 잊혀질 위험. M2 Lambda 도입 시 해소.
+- **ARN suffix(`-AbCd9X`) 관리**: 시크릿마다 다른 suffix를 ts012 출력 메모로 보관 + Task Def 치환. 운영자가 메모 누락 시 Task 부팅 실패. ts012가 절차 명시.
+- **dev/prod 통합 Task Role (M1)**: M1 합격선은 dev only지만 prod 진입 시 즉시 동일 Role 사용 → cross-env 침범 위험. env 분리 Epic에서 Role 분리 필수.
+- **DescribeSecret 권한 추가**: Spring Cloud AWS bootstrap이 사용하지만, M1 단계에서 사용 안 함 (Story-053 머지 전엔 dead permission). 보안 surface 약간 확대지만 list 권한 미부여로 enumeration 차단.
+- **VPC Endpoint 부재 시 NAT 트래픽 발생**: ECS Task가 Secrets Manager 호출 시 NAT Gateway 경유. 부팅 시점 1회만 발생 → 비용 미미 (~$0.001/월/task). M2 Epic 2 (VPC Endpoint) 도입 후 0으로 감소.
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **A. 모든 비밀 단일 시크릿 (`thirdtool/{env}/all`)** | API call 1회, 비용 1/5 | 회전 단위가 다른 비밀 묶임 → 1 비밀 회전이 전체 cache invalidation 트리거. JWT 회전이 DB cache까지 무효화 |
+| **B. 도메인별 분할 (`thirdtool/{env}/auth`, `thirdtool/{env}/data`)** | API call 2-3회 | 회전 단위 차이는 여전. provider 추가 시 통합 시크릿 키 충돌 |
+| **C (선택). 5종 분할 + JSON multi-key** | 회전 독립 + 발급 출처별 그룹화 + provider 추가 유연 | 시크릿 수 증가 → 비용 약간 |
+| **D. Parameter Store (SSM Parameter — SecureString)** | 비용 0 | 회전 자동화 부재, 부팅 시점 1 API call에 1 parameter 강제(여러 keyparameter를 묶을 수 없음 → secret당 N call 필요), Cross-account 공유 미지원 |
+| **E. Tag 기반 ABAC (`Environment=prod` Tag)** | env 추가 시 IAM Resource 갱신 불요 | 시크릿마다 Tag 누락 위험 + IAM Condition 디버깅 복잡. ARN prefix가 자체 검증 |
+| **F. env별 Task Role 완전 분리** | cross-env 격리 강제 | M1은 단일 운영자 단일 env(dev) → 과도. M2 환경 분리 Epic에서 도입 |
+| **G. 자동 회전 즉시 활성** | M1부터 회전 자동화 | Rotation Lambda 코드 작성 + 테스트 필요. M1 트래픽 0 + 운영자 1인 환경에 과도. M2 RDS Multi-AZ와 동시 도입이 효율 |
+| **H. CMK (Customer Managed KMS)** | audit log + 권한 세분화 | KMS 시간당 $1/key 비용 + key rotation 관리. M1 audit 요구 부재. M2 검토 |
+
+## 알려진 follow-up (본 ADR 범위 외)
+
+- **Story-053 (Spring Cloud AWS bootstrap)**: 본 ADR 직후 — `spring-cloud-aws-starter-secrets-manager` 의존 + bootstrap.yml + application-prod.yml placeholder 매핑. 본 ADR §1.2의 비밀 이름 정합 필수
+- **Story-TBD (S3Config DefaultCredentialsProvider 전환)**: `AWS_ACCESS_KEY_ID` 환경변수 의존 제거 + Task Role IAM 직접 사용. Story-053과 합쳐도 OK
+- **Story-TBD (GitHub Secrets 폐기 verify)**: PR-A 머지 + ts012 등록 완료 후 GitHub Actions Secrets 페이지에서 `DB_PASSWORD`/`JWT_SECRET_KEY`/`KAKAO_*`/`NAVER_*` 5건 수동 삭제 + `git secrets scan`으로 평문 누설 검사
+- **Story-TBD (staging Task Role 분리)**: 환경 분리 Epic — staging 전용 Task Role + `Resource: thirdtool/staging/*` 단일 prefix scope
+- **Story-TBD (VPC Endpoint Secrets Manager Interface)**: Product 7 Epic 2 — NAT 트래픽 절감
+- **Story-TBD (Rotation Lambda + RDS Multi-AZ)**: M2 트래픽 도달 시점
+- **Story-TBD (CMK 전환)**: audit log 요구 발생 시
+- **Story-TBD (cross-region replication)**: us-east-1 (CloudFront ACM) 외 region별 비밀 필요 시점
+
+## 다시 검토할 시점
+
+- **GitHub Secrets에 비밀 1건이라도 잔존 발견 시점**: ADR 위반 — 즉시 폐기 + ADR follow-up 진입
+- **시크릿당 월 비용이 $0.40 × 30개 = $12 도달 시점**: env/팀별 통합 시크릿 분할 검토
+- **회전 누락으로 인한 incident 발생 시점**: M2 Rotation Lambda 도입 가속
+- **staging env 진입 시점**: 본 ADR §1.4의 Task Role 분리 + Resource scope 분리 즉시 적용
+- **AI Epic 3 진입 시점 (Gemini 실제 사용)**: `thirdtool/{env}/gemini-api-key`에 placeholder 값을 실제 API key로 갱신 + 비용 모니터링 (Google AI Studio quota)
+- **multi-region (us-east-1 CloudFront ACM) 비밀 필요 시점**: Secrets Manager replication 활성 검토 — 본 ADR §1.6에 추가
+- **Customer Managed KMS audit log 필요 시점**: CMK 전환 (시크릿 변경 없이 re-encrypt 1회)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,3 +20,4 @@
 | [ADR016](ADR016-alb-listener-target-group.md) | ALB 1개 공유 + Listener 80→443 + Target Group type=ip + TLS 1.3 (Story-049) | Accepted | 2026-06-29 |
 | [ADR017](ADR017-spring-forward-headers-graceful-shutdown.md) | Spring `forward-headers-strategy=native` + `server.shutdown=graceful` (Story-050) | Accepted | 2026-06-29 |
 | [ADR018](ADR018-rds-mysql-single-az-prod.md) | RDS MySQL prod single-AZ + db.t4g.micro + utf8mb4 + Asia/Seoul (Story-051) | Accepted | 2026-06-29 |
+| [ADR019](ADR019-secrets-manager-naming-and-task-role-scope.md) | Secrets Manager 5종 비밀 명명 + env-prefix 격리 + Task Role Resource scope (Story-052) | Accepted | 2026-06-30 |

--- a/docs/operations/troubleshooting/ts012-secrets-manager-setup.md
+++ b/docs/operations/troubleshooting/ts012-secrets-manager-setup.md
@@ -1,0 +1,367 @@
+# ts012: AWS Secrets Manager 5종 비밀 등록·검증·트러블슈팅
+
+Story-052로 `infra/secrets/`에 5종 비밀(`db-credential`, `jwt-secret`, `oauth-kakao`, `oauth-naver`, `gemini-api-key`)의 페이로드 구조 + IAM Task Role 권한 patch + ADR019가 추가됐다. 본 가이드는 AWS 콘솔(또는 CLI)에서 1회성 등록 + 검증 + 자주 보는 에러 6건을 한 곳에 모았다.
+
+ts007(GHA OIDC)·ts008(ECS)·ts011(RDS)·ts014(ALB-HTTPS, 후속)와 cross-link. 1인 운영자가 env마다 1회만 실행.
+
+---
+
+## 1. 전제
+
+- **VPC 셋업 완료** (ts009)
+- **ECS Task Role 생성 완료** (ts008 §3 — `arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-role`)
+- **RDS 인스턴스 완료** (ts011 §5 — `db-credential`의 HOST/PORT/NAME 출처)
+- **카카오/네이버 developers 등록 완료** (ts006 §2.1 / §2.2 — OAuth client_id/secret 출처)
+- **Google AI Studio 가입 (선택)** — `gemini-api-key`는 M1 placeholder OK, AI Epic 3 진입 전엔 미사용
+- AWS 콘솔 Secrets Manager 관리 권한 (`secretsmanager:*`, `kms:Decrypt` for `aws/secretsmanager`)
+- **결제**: 시크릿당 월 $0.40 + API call $0.05/10K. 5 secrets × 1 env(dev) × $0.40 = **$2/월 baseline** (prod 전환 시 $4)
+
+> **GitHub Secrets 폐기 안전망**: 본 가이드 완주 + Task Def 부팅 검증 통과(§6) 후에만 GitHub Actions Secrets에서 `DB_PASSWORD`/`JWT_SECRET_KEY`/`KAKAO_CLIENT_SECRET`/`NAVER_CLIENT_SECRET` 4건 삭제. 미리 지우면 dev-cicd.yml 롤백 시점에 부팅 실패.
+
+---
+
+## 2. 사전 값 준비 (운영자 보관소)
+
+§3 실행 전 다음 7건의 값을 안전한 곳(예: `~/thirdtool-aws-ids.txt` gitignore 또는 1Password)에 모은다:
+
+```
+# RDS 출력 (ts011 §5)
+RDS_ENDPOINT=______________.ap-northeast-2.rds.amazonaws.com
+DB_NAME=thirdtool
+DB_USERNAME=admin
+DB_PASSWORD=______________               # ts011 §4에서 결정한 master password
+
+# JWT 신규 생성
+JWT_SECRET_KEY=$(openssl rand -base64 48)   # HS512 충분, 384 bit ≥ 256 bit 최소
+
+# 카카오 developers
+KAKAO_CLIENT_ID=______________            # REST API 키
+KAKAO_CLIENT_SECRET=______________
+
+# 네이버 developers
+NAVER_CLIENT_ID=______________
+NAVER_CLIENT_SECRET=______________
+
+# Google AI Studio (선택 — M1 placeholder OK)
+GEMINI_API_KEY=PLACEHOLDER_FOR_M2          # 실제 발급 전엔 이 값 그대로 등록
+```
+
+---
+
+## 3. 시크릿 5종 등록 — CLI
+
+> 콘솔 절차는 §4. CLI는 자동화·재현성 우선. 본 절차는 `dev` env 기준. `prod`/`staging`은 env 부분만 치환하여 동일 반복.
+
+### 3.1 db-credential
+
+```bash
+ENV=dev
+aws secretsmanager create-secret \
+  --name "thirdtool/${ENV}/db-credential" \
+  --description "ThirdTool ${ENV} — RDS MySQL connection (Story-052)" \
+  --secret-string "$(jq -n \
+    --arg host "$RDS_ENDPOINT" \
+    --arg port "3306" \
+    --arg name "$DB_NAME" \
+    --arg user "$DB_USERNAME" \
+    --arg pass "$DB_PASSWORD" \
+    '{HOST: $host, PORT: $port, NAME: $name, USERNAME: $user, PASSWORD: $pass}')" \
+  --tags Key=Project,Value=ThirdTool Key=ManagedBy,Value=Story-052 Key=Environment,Value="$ENV" \
+  --region ap-northeast-2
+
+# 응답의 ARN 끝 random 6 char suffix 메모 → DB_SUFFIX
+```
+
+### 3.2 jwt-secret
+
+```bash
+aws secretsmanager create-secret \
+  --name "thirdtool/${ENV}/jwt-secret" \
+  --description "ThirdTool ${ENV} — JWT HS512 signing key (Story-052)" \
+  --secret-string "$(jq -n --arg k "$JWT_SECRET_KEY" '{SECRET_KEY: $k}')" \
+  --tags Key=Project,Value=ThirdTool Key=ManagedBy,Value=Story-052 Key=Environment,Value="$ENV" \
+  --region ap-northeast-2
+
+# suffix 메모 → JWT_SUFFIX
+```
+
+### 3.3 oauth-kakao
+
+```bash
+aws secretsmanager create-secret \
+  --name "thirdtool/${ENV}/oauth-kakao" \
+  --description "ThirdTool ${ENV} — Kakao OAuth client (Story-052)" \
+  --secret-string "$(jq -n \
+    --arg id "$KAKAO_CLIENT_ID" \
+    --arg sec "$KAKAO_CLIENT_SECRET" \
+    '{CLIENT_ID: $id, CLIENT_SECRET: $sec}')" \
+  --tags Key=Project,Value=ThirdTool Key=ManagedBy,Value=Story-052 Key=Environment,Value="$ENV" \
+  --region ap-northeast-2
+
+# suffix 메모 → KAKAO_SUFFIX
+```
+
+### 3.4 oauth-naver
+
+```bash
+aws secretsmanager create-secret \
+  --name "thirdtool/${ENV}/oauth-naver" \
+  --description "ThirdTool ${ENV} — Naver OAuth client (Story-052)" \
+  --secret-string "$(jq -n \
+    --arg id "$NAVER_CLIENT_ID" \
+    --arg sec "$NAVER_CLIENT_SECRET" \
+    '{CLIENT_ID: $id, CLIENT_SECRET: $sec}')" \
+  --tags Key=Project,Value=ThirdTool Key=ManagedBy,Value=Story-052 Key=Environment,Value="$ENV" \
+  --region ap-northeast-2
+
+# suffix 메모 → NAVER_SUFFIX
+```
+
+### 3.5 gemini-api-key
+
+```bash
+aws secretsmanager create-secret \
+  --name "thirdtool/${ENV}/gemini-api-key" \
+  --description "ThirdTool ${ENV} — Gemini API key (Story-052, AI Epic 3 진입 전 placeholder)" \
+  --secret-string "$(jq -n --arg k "$GEMINI_API_KEY" '{API_KEY: $k}')" \
+  --tags Key=Project,Value=ThirdTool Key=ManagedBy,Value=Story-052 Key=Environment,Value="$ENV" \
+  --region ap-northeast-2
+
+# suffix 메모 → GEMINI_SUFFIX
+```
+
+---
+
+## 4. 시크릿 5종 등록 — 콘솔 (대안)
+
+CLI 미사용 시 각 시크릿마다 1회씩:
+
+1. **Secrets Manager** → **Store a new secret**
+2. Secret type: **Other type of secret**
+3. Key/value pairs 탭에서 JSON 키별로 입력 (§3.1~3.5 페이로드 구조 참조)
+4. Encryption key: `aws/secretsmanager` (AWS managed, 비용 0) → Next
+5. Secret name: `thirdtool/dev/db-credential` 등 (정확한 이름 — Spring Cloud AWS bootstrap이 이 이름으로 fetch)
+6. Description: 자유 / Tags: Project=ThirdTool, Environment=dev, ManagedBy=Story-052 → Next
+7. Configure rotation: **Disable automatic rotation** (M1은 수동, ADR019 §1.3) → Next
+8. Review → **Store**
+9. 생성된 시크릿 상세 페이지에서 ARN 끝 random suffix(`-AbCd9X`) 메모
+
+---
+
+## 5. 출력 메모 보관
+
+본 가이드 끝에서 다음 5건의 ARN suffix를 보관 (Task Def `<SUFFIX>` 치환에 사용):
+
+```
+SECRETS_SUFFIX_DEV_DB_CREDENTIAL=______________
+SECRETS_SUFFIX_DEV_JWT_SECRET=______________
+SECRETS_SUFFIX_DEV_OAUTH_KAKAO=______________
+SECRETS_SUFFIX_DEV_OAUTH_NAVER=______________
+SECRETS_SUFFIX_DEV_GEMINI_API_KEY=______________
+```
+
+이 값을 `infra/ecs/task-definition-prod.json`의 secrets ARN 끝 `<SUFFIX>` 자리에 치환한다 (실 등록 후 ts008 §6 Task Def register 단계).
+
+---
+
+## 6. 검증
+
+### 6.1 시크릿 5건 존재 확인
+
+```bash
+aws secretsmanager list-secrets \
+  --filters Key=name,Values=thirdtool/dev/ \
+  --region ap-northeast-2 \
+  | jq -r '.SecretList[].Name'
+```
+
+다음 5건이 나와야 한다:
+```
+thirdtool/dev/db-credential
+thirdtool/dev/jwt-secret
+thirdtool/dev/oauth-kakao
+thirdtool/dev/oauth-naver
+thirdtool/dev/gemini-api-key
+```
+
+### 6.2 시크릿 값 1건 fetch 검증
+
+```bash
+aws secretsmanager get-secret-value \
+  --secret-id thirdtool/dev/jwt-secret \
+  --region ap-northeast-2 \
+  | jq -r '.SecretString | fromjson | .SECRET_KEY' | wc -c
+# 65 (base64 48 byte → ~65 char)
+```
+
+### 6.3 Task Role에서 GetSecretValue 권한 검증
+
+ECS Task가 부팅 시점 자신의 Role로 fetch 가능한지 시뮬레이션 — 로컬에서 Task Role을 임시 AssumeRole 후 호출:
+
+```bash
+ROLE_ARN=arn:aws:iam::<AWS_ACCOUNT_ID>:role/ecs-task-role
+CREDS=$(aws sts assume-role --role-arn "$ROLE_ARN" --role-session-name verify-secrets-fetch)
+
+AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r '.Credentials.AccessKeyId') \
+AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r '.Credentials.SecretAccessKey') \
+AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r '.Credentials.SessionToken') \
+aws secretsmanager get-secret-value \
+  --secret-id thirdtool/dev/db-credential \
+  --region ap-northeast-2 \
+  | jq -r '.SecretString | fromjson | .USERNAME'
+# admin (또는 ts011 §4에서 입력한 값)
+```
+
+> 401/AccessDenied 발생 시 ts012-3 참조.
+
+### 6.4 ECS Task 부팅 시 env 주입 확인 (PR-A 머지 + 첫 배포 후)
+
+ECS Task가 실제 부팅된 뒤 Task의 환경변수에 시크릿 값이 주입되었는지:
+
+```bash
+TASK_ID=$(aws ecs list-tasks --cluster thirdtool-cluster-dev --service-name thirdtool-service-dev --query 'taskArns[0]' --output text --region ap-northeast-2)
+
+aws ecs execute-command --cluster thirdtool-cluster-dev \
+  --task "$TASK_ID" --container app --interactive --command "sh -c 'env | grep -E \"DB_HOST|JWT_SECRET\" | head -2'" \
+  --region ap-northeast-2
+```
+
+`DB_HOST=...rds.amazonaws.com` / `JWT_SECRET_KEY=...` 라인이 출력되어야 한다 (실 값은 마스킹 X — execute-command session은 운영자만 접근).
+
+---
+
+## 7. 자주 보는 에러 6건
+
+### ts012-1 — `InvalidRequestException: A secret with this name is already scheduled for deletion`
+
+이전 등록 + 삭제 시도 시 발생. AWS는 시크릿을 7-30일 recovery window로 보관.
+
+**해결**:
+```bash
+# 즉시 영구 삭제
+aws secretsmanager delete-secret --secret-id thirdtool/dev/db-credential \
+  --force-delete-without-recovery --region ap-northeast-2
+# 또는 recovery 취소
+aws secretsmanager restore-secret --secret-id thirdtool/dev/db-credential --region ap-northeast-2
+```
+
+### ts012-2 — `ResourceNotFoundException: Secrets Manager can't find the specified secret`
+
+Task Def에서 시크릿 fetch 실패 — 시크릿 이름이 정확히 일치하지 않음.
+
+**원인**:
+- 시크릿 이름에 추가 prefix/suffix가 붙음 (예: `thirdtool/Dev/...` 대소문자 차이)
+- env 분리 누락 — `thirdtool/db-credential`로 등록되어 prefix 없음
+- ARN suffix가 Task Def `<SUFFIX>` placeholder에 미치환 (등록 후 보관소에 적은 suffix를 잊고 그대로 둠)
+
+**해결**: §6.1으로 정확한 이름 확인 → Task Def revision 갱신.
+
+### ts012-3 — `AccessDeniedException: User: arn:aws:sts::...:assumed-role/ecs-task-role/... is not authorized to perform: secretsmanager:GetSecretValue`
+
+IAM Task Role의 Resource scope가 시크릿 ARN과 매칭 안 됨.
+
+**원인**:
+- `infra/iam/ecs-task-role-permissions-policy.json` 패치 누락 (Story-052 안 머지)
+- Resource ARN에 region 불일치 (`secretsmanager:us-east-1` vs `secretsmanager:ap-northeast-2`)
+- ARN 패턴 `thirdtool/dev/db-credential-*` 와일드카드에 누락된 시크릿 type 존재
+
+**해결**:
+```bash
+# 1) 현재 정책 확인
+aws iam get-role-policy --role-name ecs-task-role --policy-name ecs-task-role-permissions
+# 2) ADR019 정책 재적용
+aws iam put-role-policy --role-name ecs-task-role --policy-name ecs-task-role-permissions \
+  --policy-document file://infra/iam/ecs-task-role-permissions-policy.json
+```
+
+### ts012-4 — KMS `Decrypt` 권한 부족 — `KMSAccessDeniedException`
+
+`aws/secretsmanager` (AWS managed key)는 기본 Decrypt 권한 부여되지만, CMK 전환 후엔 `kms:Decrypt` 별도 부여 필요.
+
+**해결**: ADR019의 `KMSDecryptForSecretsManager` Statement가 활성화되어 있는지 확인. CMK 전환 시 Resource를 specific key ARN으로 좁힘.
+
+### ts012-5 — JSON multi-key fetch에서 키 누락 — Task Def `valueFrom`이 `arn:...:thirdtool/dev/db-credential-SUFFIX:HOST::`인데 응답 빈 문자열
+
+시크릿 페이로드가 JSON이 아니거나 키 이름이 다름 (예: `host` 소문자로 등록).
+
+**해결**:
+```bash
+aws secretsmanager get-secret-value --secret-id thirdtool/dev/db-credential --region ap-northeast-2 \
+  | jq -r '.SecretString | fromjson | keys'
+# ["HOST","NAME","PASSWORD","PORT","USERNAME"] 정확한 키만 출력되어야 함
+```
+
+키가 잘못되었으면 `update-secret`로 페이로드 교체:
+```bash
+aws secretsmanager update-secret --secret-id thirdtool/dev/db-credential \
+  --secret-string "$(jq -n --arg host "$RDS_ENDPOINT" ... '{HOST: $host, ...}')" \
+  --region ap-northeast-2
+```
+
+### ts012-6 — `OperationNotPermittedException: Cannot update secret with a value containing more than 65536 characters`
+
+페이로드 65 KB 초과. 페이로드 분할 또는 S3 객체로 외부화.
+
+**해결**: 본 5종 비밀 페이로드는 모두 < 1 KB이므로 발생 시 페이로드 입력 실수. `jq` 출력 길이 확인 후 재입력.
+
+---
+
+## 8. GitHub Secrets 폐기
+
+§3·§6 완료 + ECS Task 부팅 검증(ts008 §7 — Task RUNNING + Service Healthy) 통과 후, 다음 4건을 GitHub Actions Secrets에서 수동 삭제:
+
+GitHub repo → Settings → Secrets and variables → Actions → Repository secrets:
+
+- `DB_PASSWORD`
+- `JWT_SECRET_KEY`
+- `KAKAO_CLIENT_SECRET`
+- `NAVER_CLIENT_SECRET`
+
+> `DB_HOST`/`KAKAO_CLIENT_ID`/`NAVER_CLIENT_ID`는 비밀 아니므로 GitHub Variables로 이전하거나 Secrets Manager로 통합 가능. M1은 통합 (ADR019 §1.2 — JSON multi-key).
+
+폐기 후 `gh secret list` 출력에서 위 4건이 안 보이는지 확인.
+
+---
+
+## 9. 회전 절차 (M1 수동)
+
+특정 비밀 회전이 필요할 때 (예: JWT key 만료, OAuth client_secret 노출):
+
+```bash
+# 1) 새 값 생성 (예: JWT)
+NEW_JWT=$(openssl rand -base64 48)
+
+# 2) 시크릿 값 갱신 (versionId 자동 발급)
+aws secretsmanager put-secret-value \
+  --secret-id thirdtool/dev/jwt-secret \
+  --secret-string "$(jq -n --arg k "$NEW_JWT" '{SECRET_KEY: $k}')" \
+  --region ap-northeast-2
+
+# 3) ECS Service force-new-deployment — Task가 부팅 시 새 버전 fetch
+aws ecs update-service \
+  --cluster thirdtool-cluster-dev \
+  --service thirdtool-service-dev \
+  --force-new-deployment \
+  --region ap-northeast-2
+```
+
+> Spring Cloud AWS (Story-053)는 부팅 시점 1회만 fetch + 캐시. **회전은 Task 재배포 단위** — 캐시 무효화 자동화는 M2 Rotation Lambda에서.
+
+---
+
+## 10. 출력 요약 (보관소 기재 항목)
+
+본 가이드 완주 후 운영자 보관소에 다음 9건이 누적되어야 한다:
+
+```
+# Stage 5 (Secrets Manager) — Story-052 산출물
+SECRETS_REGION=ap-northeast-2
+SECRETS_SUFFIX_DEV_DB_CREDENTIAL=______________      # ts012 §3.1
+SECRETS_SUFFIX_DEV_JWT_SECRET=______________         # ts012 §3.2
+SECRETS_SUFFIX_DEV_OAUTH_KAKAO=______________        # ts012 §3.3
+SECRETS_SUFFIX_DEV_OAUTH_NAVER=______________        # ts012 §3.4
+SECRETS_SUFFIX_DEV_GEMINI_API_KEY=______________     # ts012 §3.5
+GITHUB_SECRETS_REVOKED_AT=______________             # §8 폐기 시점 (YYYY-MM-DD HH:MM)
+TASK_DEF_REVISION_AFTER_SUFFIX_FILL=______________   # 5 SUFFIX 치환 후 Task Def revision (ts008 §6)
+SECRETS_MONTHLY_BUDGET_INVOICE=______________        # 첫 월 청구 금액 — $2 baseline 검증
+```

--- a/infra/ecs/task-definition-prod.json
+++ b/infra/ecs/task-definition-prod.json
@@ -24,21 +24,20 @@
       ],
       "environment": [
         { "name": "SPRING_PROFILES_ACTIVE", "value": "prod" },
-        { "name": "TZ", "value": "Asia/Seoul" },
-        { "name": "DB_PORT", "value": "3306" }
+        { "name": "TZ", "value": "Asia/Seoul" }
       ],
       "secrets": [
-        { "name": "DB_HOST",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:HOST::" },
-        { "name": "DB_NAME",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:NAME::" },
-        { "name": "DB_USERNAME",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:USERNAME::" },
-        { "name": "DB_PASSWORD",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-<SUFFIX>:PASSWORD::" },
-        { "name": "JWT_SECRET_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/jwt-<SUFFIX>:SECRET_KEY::" },
-        { "name": "KAKAO_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:KAKAO_CLIENT_ID::" },
-        { "name": "KAKAO_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:KAKAO_CLIENT_SECRET::" },
-        { "name": "NAVER_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:NAVER_CLIENT_ID::" },
-        { "name": "NAVER_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-<SUFFIX>:NAVER_CLIENT_SECRET::" },
-        { "name": "AWS_ACCESS_KEY_ID",     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/aws-<SUFFIX>:ACCESS_KEY_ID::" },
-        { "name": "AWS_SECRET_ACCESS_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/aws-<SUFFIX>:SECRET_ACCESS_KEY::" }
+        { "name": "DB_HOST",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-credential-<DB_SUFFIX>:HOST::" },
+        { "name": "DB_PORT",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-credential-<DB_SUFFIX>:PORT::" },
+        { "name": "DB_NAME",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-credential-<DB_SUFFIX>:NAME::" },
+        { "name": "DB_USERNAME",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-credential-<DB_SUFFIX>:USERNAME::" },
+        { "name": "DB_PASSWORD",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-credential-<DB_SUFFIX>:PASSWORD::" },
+        { "name": "JWT_SECRET_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/jwt-secret-<JWT_SUFFIX>:SECRET_KEY::" },
+        { "name": "KAKAO_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-kakao-<KAKAO_SUFFIX>:CLIENT_ID::" },
+        { "name": "KAKAO_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-kakao-<KAKAO_SUFFIX>:CLIENT_SECRET::" },
+        { "name": "NAVER_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-naver-<NAVER_SUFFIX>:CLIENT_ID::" },
+        { "name": "NAVER_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-naver-<NAVER_SUFFIX>:CLIENT_SECRET::" },
+        { "name": "GEMINI_API_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/gemini-api-key-<GEMINI_SUFFIX>:API_KEY::" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/infra/ecs/task-definition-staging.json
+++ b/infra/ecs/task-definition-staging.json
@@ -24,21 +24,20 @@
       ],
       "environment": [
         { "name": "SPRING_PROFILES_ACTIVE", "value": "prod" },
-        { "name": "TZ", "value": "Asia/Seoul" },
-        { "name": "DB_PORT", "value": "3306" }
+        { "name": "TZ", "value": "Asia/Seoul" }
       ],
       "secrets": [
-        { "name": "DB_HOST",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:HOST::" },
-        { "name": "DB_NAME",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:NAME::" },
-        { "name": "DB_USERNAME",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:USERNAME::" },
-        { "name": "DB_PASSWORD",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-<SUFFIX>:PASSWORD::" },
-        { "name": "JWT_SECRET_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/jwt-<SUFFIX>:SECRET_KEY::" },
-        { "name": "KAKAO_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:KAKAO_CLIENT_ID::" },
-        { "name": "KAKAO_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:KAKAO_CLIENT_SECRET::" },
-        { "name": "NAVER_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:NAVER_CLIENT_ID::" },
-        { "name": "NAVER_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-<SUFFIX>:NAVER_CLIENT_SECRET::" },
-        { "name": "AWS_ACCESS_KEY_ID",     "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/aws-<SUFFIX>:ACCESS_KEY_ID::" },
-        { "name": "AWS_SECRET_ACCESS_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/aws-<SUFFIX>:SECRET_ACCESS_KEY::" }
+        { "name": "DB_HOST",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-credential-<DB_SUFFIX>:HOST::" },
+        { "name": "DB_PORT",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-credential-<DB_SUFFIX>:PORT::" },
+        { "name": "DB_NAME",              "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-credential-<DB_SUFFIX>:NAME::" },
+        { "name": "DB_USERNAME",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-credential-<DB_SUFFIX>:USERNAME::" },
+        { "name": "DB_PASSWORD",          "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/db-credential-<DB_SUFFIX>:PASSWORD::" },
+        { "name": "JWT_SECRET_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/jwt-secret-<JWT_SUFFIX>:SECRET_KEY::" },
+        { "name": "KAKAO_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-kakao-<KAKAO_SUFFIX>:CLIENT_ID::" },
+        { "name": "KAKAO_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-kakao-<KAKAO_SUFFIX>:CLIENT_SECRET::" },
+        { "name": "NAVER_CLIENT_ID",      "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-naver-<NAVER_SUFFIX>:CLIENT_ID::" },
+        { "name": "NAVER_CLIENT_SECRET",  "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/oauth-naver-<NAVER_SUFFIX>:CLIENT_SECRET::" },
+        { "name": "GEMINI_API_KEY",       "valueFrom": "arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/staging/gemini-api-key-<GEMINI_SUFFIX>:API_KEY::" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/infra/iam/ecs-task-role-permissions-policy.json
+++ b/infra/iam/ecs-task-role-permissions-policy.json
@@ -25,6 +25,39 @@
         "ssmmessages:OpenDataChannel"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManagerReadOwnEnvPrefixes",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/dev/db-credential-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/dev/jwt-secret-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/dev/oauth-kakao-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/dev/oauth-naver-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/dev/gemini-api-key-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/prod/db-credential-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/prod/jwt-secret-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/prod/oauth-kakao-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/prod/oauth-naver-*",
+        "arn:aws:secretsmanager:ap-northeast-2:*:secret:thirdtool/prod/gemini-api-key-*"
+      ]
+    },
+    {
+      "Sid": "KMSDecryptForSecretsManager",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "secretsmanager.ap-northeast-2.amazonaws.com"
+        }
+      }
     }
   ]
 }

--- a/infra/secrets/README.md
+++ b/infra/secrets/README.md
@@ -1,0 +1,79 @@
+# Secrets Manager — 5종 비밀 spec (Story-052)
+
+> ECS Task가 부팅 시점에 환경변수로 주입받는 5종 비밀의 명명 규칙·페이로드 구조·env 분리 spec.
+> 실제 값(value)은 `infra/`에 commit하지 않는다 — 본 디렉토리의 `*.template.json`은 **구조 예시만** 보여주는 placeholder.
+
+ADR019 참조: `docs/adr/ADR019-secrets-manager-naming-and-task-role-scope.md`
+운영 절차: `docs/operations/troubleshooting/ts012-secrets-manager-setup.md`
+통합 흐름: `workflow/task/pes/handoff/aws-setup-0.0.1v.md` §7 (Stage 5)
+
+---
+
+## 1. 명명 규칙
+
+```
+thirdtool/{env}/{type}
+```
+
+- `{env}`: `dev` · `staging` · `prod` (3종, 환경별 완전 격리)
+- `{type}`: 5종 — `db-credential` · `jwt-secret` · `oauth-kakao` · `oauth-naver` · `gemini-api-key`
+
+총 5 type × 3 env = **15 secrets** (env별 Task Role이 자기 env prefix에만 접근).
+
+> M1 합격선은 `dev` env 5종 등록(milestone item #15 + infra.md). `staging`·`prod`는 환경 분리 Epic 진행 시 동일 패턴으로 확장.
+
+## 2. 5종 비밀 페이로드 구조
+
+| Secret name | 페이로드 형식 | 키 | 값 출처 |
+| --- | --- | --- | --- |
+| `thirdtool/{env}/db-credential` | JSON multi-key | `HOST`, `PORT`, `NAME`, `USERNAME`, `PASSWORD` | RDS endpoint (ts011 §5 출력) + 운영자가 결정한 DB user/password |
+| `thirdtool/{env}/jwt-secret` | JSON 1 key | `SECRET_KEY` | `openssl rand -base64 48` (HS512 충분, 384 bit ≥ 256 bit 최소 요구) |
+| `thirdtool/{env}/oauth-kakao` | JSON 2 keys | `CLIENT_ID`, `CLIENT_SECRET` | 카카오 developers 콘솔 (ts006 §2.1) |
+| `thirdtool/{env}/oauth-naver` | JSON 2 keys | `CLIENT_ID`, `CLIENT_SECRET` | 네이버 developers 콘솔 (ts006 §2.2) |
+| `thirdtool/{env}/gemini-api-key` | JSON 1 key | `API_KEY` | Google AI Studio 발급 (M1은 사용 안 함, AI Epic 3 진입 시 활성) |
+
+**환경별 격리 원칙**: env마다 별도 비밀. dev secret을 prod에서 참조하지 않는다. Task Role이 prefix 단위 권한으로 강제.
+
+## 3. ECS Task Def secrets 참조 패턴
+
+Task Definition의 `containerDefinitions[].secrets`에서 ARN + JSON 키 추출:
+
+```
+arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/db-credential-<SUFFIX>:HOST::
+arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/jwt-secret-<SUFFIX>:SECRET_KEY::
+arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-kakao-<SUFFIX>:CLIENT_ID::
+arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/oauth-naver-<SUFFIX>:CLIENT_SECRET::
+arn:aws:secretsmanager:ap-northeast-2:<AWS_ACCOUNT_ID>:secret:thirdtool/prod/gemini-api-key-<SUFFIX>:API_KEY::
+```
+
+- `<SUFFIX>`: AWS가 시크릿 생성 시 자동 부여하는 random 6 char (`-AbCd9X`). 시크릿마다 다르며, ts012 §4의 출력 메모 블록에 저장 후 Task Def에 치환.
+- 마지막 `::` 2개 colon은 version stage / version id 생략 (AWS Task Def secrets 문법).
+
+## 4. Task Role 권한 범위
+
+각 env의 ECS Task Role은 **자기 env prefix의 비밀만** 읽을 수 있다 (cross-env 차단).
+
+```
+prod Task Role  → "Resource": "arn:aws:secretsmanager:*:*:secret:thirdtool/prod/*"
+staging Task Role → "Resource": "arn:aws:secretsmanager:*:*:secret:thirdtool/staging/*"
+dev Task Role   → "Resource": "arn:aws:secretsmanager:*:*:secret:thirdtool/dev/*"
+```
+
+본 디렉토리의 `infra/iam/ecs-task-role-permissions-policy.json`은 **현 시점 prod·dev 통합 운영(M1)** 기준 — env 분리 Epic 진입 시 env별 Role 분리 + Resource prefix scope 분리.
+
+## 5. 회전 정책 (M1)
+
+- **자동 회전 비활성** — M1 트래픽 0 + 운영자 1인. 수동 회전으로 충분.
+- M2 진입 시 RDS multi-AZ + Secrets Manager rotation Lambda 동시 검토.
+
+## 6. M1 합격 조건 (milestone.md item #15)
+
+- [ ] `thirdtool/dev/db-credential` 등록 (5 keys)
+- [ ] `thirdtool/dev/jwt-secret` 등록 (1 key)
+- [ ] `thirdtool/dev/oauth-kakao` 등록 (2 keys)
+- [ ] `thirdtool/dev/oauth-naver` 등록 (2 keys)
+- [ ] `thirdtool/dev/gemini-api-key` 등록 (1 key) — 값은 placeholder OK (AI Epic 3 진입 전엔 미사용)
+- [ ] Task Role policy에 `secretsmanager:GetSecretValue` + `thirdtool/dev/*` Resource scope 적용
+- [ ] GitHub Secrets에서 `DB_PASSWORD` · `JWT_SECRET_KEY` · `KAKAO_*` · `NAVER_*` 폐기 (대체된 후)
+
+상세 절차: ts012-secrets-manager-setup.md.

--- a/infra/secrets/secret-db-credential.template.json
+++ b/infra/secrets/secret-db-credential.template.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "PLACEHOLDER 구조 예시 — 실제 값은 commit 금지. ts012 §3 절차로 AWS Secrets Manager에 직접 등록. thirdtool/{env}/db-credential 명명",
+  "HOST": "thirdtool-prod-db.cabcdefghijk.ap-northeast-2.rds.amazonaws.com",
+  "PORT": "3306",
+  "NAME": "thirdtool",
+  "USERNAME": "admin",
+  "PASSWORD": "REPLACE_WITH_RDS_MASTER_PASSWORD"
+}

--- a/infra/secrets/secret-gemini-api-key.template.json
+++ b/infra/secrets/secret-gemini-api-key.template.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "PLACEHOLDER 구조 예시 — 실제 값은 commit 금지. ts012 §3-5 절차로 AWS Secrets Manager에 직접 등록. thirdtool/{env}/gemini-api-key 명명. Google AI Studio (https://aistudio.google.com)에서 API key 발급. M1은 미사용 (AI Epic 3 진입 시 활성) — placeholder 'PLACEHOLDER_FOR_M2' 값으로 등록만 해두고 비용 발생 차단.",
+  "API_KEY": "REPLACE_WITH_GEMINI_API_KEY_OR_PLACEHOLDER"
+}

--- a/infra/secrets/secret-jwt-secret.template.json
+++ b/infra/secrets/secret-jwt-secret.template.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "PLACEHOLDER 구조 예시 — 실제 값은 commit 금지. ts012 §3-2 절차로 AWS Secrets Manager에 직접 등록. thirdtool/{env}/jwt-secret 명명. 생성: openssl rand -base64 48 (HS512 충분, 384 bit ≥ 256 bit 최소 요구).",
+  "SECRET_KEY": "REPLACE_WITH_OPENSSL_RAND_BASE64_48_OUTPUT"
+}

--- a/infra/secrets/secret-oauth-kakao.template.json
+++ b/infra/secrets/secret-oauth-kakao.template.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "PLACEHOLDER 구조 예시 — 실제 값은 commit 금지. ts012 §3-3 절차로 AWS Secrets Manager에 직접 등록. thirdtool/{env}/oauth-kakao 명명. 카카오 developers 콘솔(ts006 §2.1)에서 등록한 앱의 REST API 키 + Secret",
+  "CLIENT_ID": "REPLACE_WITH_KAKAO_REST_API_KEY",
+  "CLIENT_SECRET": "REPLACE_WITH_KAKAO_CLIENT_SECRET"
+}

--- a/infra/secrets/secret-oauth-naver.template.json
+++ b/infra/secrets/secret-oauth-naver.template.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "PLACEHOLDER 구조 예시 — 실제 값은 commit 금지. ts012 §3-4 절차로 AWS Secrets Manager에 직접 등록. thirdtool/{env}/oauth-naver 명명. 네이버 developers 콘솔(ts006 §2.2)에서 등록한 앱의 Client ID + Secret",
+  "CLIENT_ID": "REPLACE_WITH_NAVER_CLIENT_ID",
+  "CLIENT_SECRET": "REPLACE_WITH_NAVER_CLIENT_SECRET"
+}


### PR DESCRIPTION
## 개요

milestone 0.0.1v item #15 (Tier 1) — AWS Secrets Manager에 5종 비밀(`db-credential`·`jwt-secret`·`oauth-kakao`·`oauth-naver`·`gemini-api-key`)을 등록하기 위한 spec JSON + 운영 가이드 + ADR + IAM Task Role 권한 patch를 추가. 본 PR 머지 후 사용자가 ts012 절차로 AWS 콘솔/CLI에서 5건 등록 → ECS Task Def `<SUFFIX>` 치환 → Stage 9 진입.

## 왜 / 설계 결정

- **GitHub Secrets 의존 0건** 도달을 위한 단일 진실 소스를 AWS Secrets Manager로 이전 (milestone "비밀 신호")
- **5종 분할** 채택 — 회전 단위가 비밀별로 독립 + provider 추가(애플/구글) 시 통합 시크릿 키 충돌 회피 (ADR019 대안 비교 A/B 거부)
- **env-prefix 격리** (`thirdtool/{env}/...`) — Tag 기반 ABAC 대신 ARN prefix로 자체 검증 (ADR019 대안 비교 E 거부)
- **M1 회전 비활성** — 트래픽 0 + 운영자 1인 → 수동 회전으로 충분. M2 Rotation Lambda는 RDS Multi-AZ와 동시 도입
- **AWS managed `aws/secretsmanager` KMS** — CMK 시간당 비용 회피. M2 audit 요구 발생 시 re-encrypt로 전환

## 작업 내용

- feat(infra/secrets): 5종 비밀 페이로드 템플릿 + README (명명 규칙 + Task Role scope)
- feat(infra/iam): ecs-task-role-permissions-policy.json patch — SecretsManagerReadOwnEnvPrefixes (10 ARN) + KMSDecryptForSecretsManager
- feat(infra/ecs): task-definition-{prod,staging}.json secrets 배열 5종 새 명명으로 교체 + GEMINI_API_KEY 추가 + DB_PORT 환경변수 → secret 이동
- docs(adr): ADR019 — Secrets Manager 5종 명명 + env-prefix 격리 + Task Role scope
- docs(operations): ts012 — Secrets Manager 1회성 셋업·검증·트러블슈팅 (CLI + 콘솔 + 6 트러블슈팅 + GitHub Secrets 폐기 + 회전 절차)
- (gitignored) workflow/task/pes/handoff/aws-setup-0.0.1v.md §7 (Stage 5) 본문 활성 + §15 후속 Story 표 갱신 (운영자 핸드오프)

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [x] docs  - [ ] test  - [ ] chore

## 테스트

- 코드 변경 없음 (infra spec JSON + 문서) — `./gradlew build` 영향 없음
- IAM 정책 문법 검증: AWS IAM Policy Simulator (사용자 측 ts012 §6.3 절차)
- 시크릿 등록 후 검증: ts012 §6.1 (list-secrets) + §6.2 (get-secret-value) + §6.3 (Task Role assume-role)

## 체크리스트

- [x] 빌드 / 테스트 통과 (코드 변경 없음)
- [x] 한 가지 논리적 변경 (5종 비밀 spec — 3 commits: infra / ADR / ts012)
- [x] BC 간 의존 방향 위반 없음 (infra·docs 만)
- [x] ADR019 등록 + index.md 갱신
- [x] 대상 브랜치 = `develop` 확인
- [ ] (후속) Story-053 (PR-B) — Spring Cloud AWS bootstrap 통합으로 application-prod.yml placeholder 자동 치환

## 관련 이슈

- Product: \`workflow/task/pes/workspectrum/sdd/in-progress/product-infra-ops.md\` (Epic 1)
- Milestone: \`workflow/task/milestones/version/0.0.1v/milestone.md\` (Tier 1 #15)
- 후속: Story-053 (Spring Cloud AWS bootstrap, PR-B)