### PR TITLE
feat(config): Spring Cloud AWS Secrets Manager bootstrap [Story-053]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,18 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    // Story-053 (ADR019 §1.2): Spring Cloud AWS — Secrets Manager 부팅 통합.
+    // BOM으로 spring-cloud-aws-* 의존 버전을 단일 출처로 고정.
+    set('springCloudAwsVersion', '3.2.1')
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -63,7 +75,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.3.3'
 
-    implementation 'software.amazon.awssdk:s3:2.30.0'
+    // AWS SDK S3 — Spring Cloud AWS BOM(${springCloudAwsVersion})이 awssdk:core/regions 등을
+    // 함께 pin하므로 version 명시 없이 BOM 정렬에 위임 (s3:2.30.0 ↔ awssdk:core 버전 mismatch 회피).
+    implementation 'software.amazon.awssdk:s3'
+
+    // Story-053 (ADR019): Spring Cloud AWS Secrets Manager — application-prod.yml의
+    // spring.config.import 경로로 부팅 시 aws-secretsmanager:thirdtool/{env}/* 시크릿 fetch.
+    // M1 단계에서는 'optional:' prefix로 미존재 시 부팅 진행 (Task Def secrets env var가 주 경로).
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager'
 
     // Flyway
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,10 +1,29 @@
 # ===========================================
 # prod 프로필 — 운영 환경 (AWS RDS MySQL, HTTPS, Swagger 비활성화)
 # - 모든 secret은 환경변수 필수. default 없음 — Spring Boot가 placeholder 미해석 시 부팅 실패 (의도)
-# - SecretManager 마이그레이션 이후엔 Spring Cloud AWS가 환경변수 대신 fetch
+# - Story-053 (ADR019): Spring Cloud AWS Secrets Manager 보조 경로 활성.
+#   주 경로 = ECS Task Def secrets로 주입된 env var (`DB_HOST`, `JWT_SECRET_KEY` 등).
+#   보조 경로 = 아래 `spring.config.import` — Spring Cloud AWS가 동일 시크릿을 다시 fetch하여
+#   향후 application property 직접 참조(`${HOST}`) 마이그레이션 진입점 마련.
+#   `optional:` prefix로 AWS 미도달(로컬) 시에도 부팅 진행. 로컬에서 prod 시뮬레이션 시 안전.
 # - 로컬에서 prod 시뮬레이션: SPRING_PROFILES_ACTIVE=local,prod + 로컬 MySQL 또는 RDS 환경변수
 # ===========================================
 spring:
+  config:
+    import:
+      - optional:aws-secretsmanager:thirdtool/prod/db-credential
+      - optional:aws-secretsmanager:thirdtool/prod/jwt-secret
+      - optional:aws-secretsmanager:thirdtool/prod/oauth-kakao
+      - optional:aws-secretsmanager:thirdtool/prod/oauth-naver
+      - optional:aws-secretsmanager:thirdtool/prod/gemini-api-key
+
+  # Spring Cloud AWS 3.x region 단일 출처 — Secrets Manager bootstrap에서 사용.
+  # 하단 top-level `cloud.aws.*`는 legacy S3Config @ConfigurationProperties 전용.
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME}
@@ -63,7 +82,8 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   redirect-uri: https://thirdstool.com/oauth/naver/callback
 
-# AWS S3
+# AWS S3 — 기존 S3Config @ConfigurationProperties용 (Spring Cloud AWS 3.x로 전환 시 폐기).
+# spring.cloud.aws.region.static은 위쪽 spring: 블록에 단일 정의.
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
## 개요

milestone 0.0.1v Tier 2 #19 — Spring Boot 부팅 시점에 AWS Secrets Manager의 5종 시크릿을 `spring.config.import`로 fetch하는 보조 경로 통합. PR-A(Story-052) spec과 비밀 이름 정합. M1 단계는 ECS Task Def secrets env var가 주 경로 유지, 본 PR은 향후 직접 property 참조(`\${HOST}`) 마이그레이션의 진입점.

## 왜 / 설계 결정

- **이중 경로 (env var + spring.config.import)**: Task Def secrets 주입은 ECS에 강결합. Spring Cloud AWS는 application 측 단일 진실 소스 가능. M1은 두 경로 공존 — env var가 우선
- **'optional:' prefix**: 로컬 부팅 시 AWS 미도달 OK (`SPRING_PROFILES_ACTIVE=local,prod` 시뮬레이션)
- **BOM 도입**: spring-cloud-aws-dependencies 3.2.1로 awssdk:* 의존 단일 출처. `s3:2.30.0` 명시 제거로 `ClientEndpointProvider NoClassDefFoundError` 해소
- **region 단일 출처**: `spring.cloud.aws.region.static=ap-northeast-2`로 통합. 기존 top-level `cloud.aws.region.static`은 legacy S3Config 전용으로 명시

## 작업 내용

- feat(build): spring-cloud-aws-dependencies:3.2.1 BOM + spring-cloud-aws-starter-secrets-manager + awssdk:s3 version 정렬
- feat(config): application-prod.yml spring.config.import 5종 시크릿 optional fetch + spring.cloud.aws.region.static 단일 출처

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [ ] test  - [ ] chore

## 테스트

- \`./gradlew build\` → **698 tests, 0 failures, 0 ignored**
- 초기 23 tests 실패 (ClientEndpointProvider NoClassDefFoundError) → s3 version 명시 제거 후 해소
- 로컬 부팅(`SPRING_PROFILES_ACTIVE=local,prod`) 시 'optional:' import가 AWS 미도달에도 진행 — 통합 테스트 컨텍스트 로드 정상

## 체크리스트

- [x] 빌드 / 테스트 통과 (698/698)
- [x] 한 가지 논리적 변경 (Spring Cloud AWS 통합)
- [x] 모든 응답 ApiResponse<T> 래퍼 (코드 변경 없음)
- [x] OSIV=false 등 프로젝트 원칙 준수 (config 추가만)
- [x] BC 간 의존 방향 위반 없음
- [x] 대상 브랜치 = develop

## 관련 이슈

- Product: \`workflow/task/pes/workspectrum/sdd/in-progress/product-infra-ops.md\` (Epic 1 Story 1-2)
- Milestone: \`workflow/task/milestones/version/0.0.1v/milestone.md\` (Tier 2 #19)
- 의존: Story-052 (PR-A #182) — 시크릿 이름 정합

## 후속

- ts012 §8 GitHub Secrets 폐기 (Stage 9 부팅 검증 통과 후)
- S3Config DefaultCredentialsProvider 전환 + legacy \`cloud.aws.*\` 제거 (별도 Story)