### PR TITLE
feat(infra,config,ci,docs): 1차 배포 완성 — Route53+HTTPS+FE CDN [Story-056]

### DIFF
--- a/.github/workflows/deploy-fe.yml
+++ b/.github/workflows/deploy-fe.yml
@@ -1,0 +1,52 @@
+name: Deploy FE
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "배포 대상 확인 (thirdtool-fe-prod + CloudFront 무효화)"
+        required: true
+        default: "yes"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: S3 sync + CloudFront invalidation
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_API_BASE_URL: https://api.thirdtool.dev
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/gha-deploy-role
+          aws-region: ap-northeast-2
+
+      - name: Sync to S3
+        run: aws s3 sync dist/ s3://thirdtool-fe-prod --delete --cache-control "public,max-age=31536000,immutable" --exclude "index.html"
+
+      - name: Upload index.html (no cache)
+        run: aws s3 cp dist/index.html s3://thirdtool-fe-prod/index.html --cache-control "no-cache,no-store,must-revalidate"
+
+      - name: Invalidate CloudFront
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CF_DIST_ID }} --paths "/*"

--- a/docs/adr/ADR020-https-fronting-and-fe-cdn-strategy.md
+++ b/docs/adr/ADR020-https-fronting-and-fe-cdn-strategy.md
@@ -1,0 +1,161 @@
+# ADR020: HTTPS fronting + FE CDN 전략 — 1 ALB 공유 + CloudFront/S3 OAC + .dev HSTS 강제 (Story-056)
+
+- **상태**: Accepted
+- **날짜**: 2026-06-30
+- **관련**: milestone 0.0.1v Tier 1-확장 (D2~D9) (`workflow/task/milestones/version/0.0.1v/milestone.md`) · `infra/acm/` · `infra/alb/alb-https-listener.json` · `infra/alb/alb-http-to-https-redirect.json` · `infra/cloudfront/` · `infra/s3/s3-fe-*.json` · `infra/route53/route53-{api,fe}-record.json` · `infra/vpc/security-group-alb-443.json` · `infra/DEPLOY-RUNBOOK.md` · `.github/workflows/deploy-fe.yml` · ADR013(OIDC) · ADR016(ALB) · ADR018(RDS)
+
+## 컨텍스트
+
+Story-049(ALB) + Story-050(Spring forward-headers) + Story-051(RDS) 완료 후, M1 종료 신호 8건은 "코드 머지 + dev 환경 떠 있는 상태"까지를 합격선으로 두었다. **본주 마무리에 사용자가 1차 배포를 도메인 단위(`https://api.thirdtool.dev` + `https://thirdtool.dev`)까지 확장하기로 결정** — milestone.md "스코프 변경 메모"에 따라 Tier 1-확장 D1~D10 신설.
+
+핵심 결정 영역:
+- **도메인 등록 위치**: Route53 vs 외부 registrar (Namecheap/GoDaddy 등)
+- **TLD 선택**: `.dev`(HSTS 강제) vs `.com`/`.io`
+- **ALB 분할**: API + FE 동일 ALB vs 분리 ALB
+- **FE 정적 호스팅**: CloudFront + S3 vs ECS Task에서 정적 자산 서빙 vs Vercel/Netlify
+- **S3 접근 제어**: OAC (Origin Access Control) vs OAI(legacy) vs public bucket
+- **HTTPS 강제**: HSTS 헤더 vs ALB redirect만 vs 둘 다
+- **us-east-1 ACM 필수성** (CloudFront): 자체 요구사항 회피 가능 여부
+- **CORS allowed origins**: 단일 도메인 vs subdomain 다중
+
+## 결정
+
+### 도메인: Route53 + `.dev` TLD
+
+| 항목 | 결정 | 근거 |
+| --- | --- | --- |
+| Registrar | **Route53** | Hosted Zone 자동 생성 + ACM DNS 검증 CNAME 자동 추가 + IAM 일관 권한. 외부 registrar는 NS delegation 1단계 추가 + 비용 차이 ~$1/년 미만 |
+| TLD | **`.dev`** | Google이 관리 + 모든 `.dev` 도메인은 **HSTS preload 강제** — HTTP 접속 시 브라우저가 차단(서버 redirect 의존성 0). 보안 baseline 자동. `.com` 대비 차별화 + 개발자 친화 |
+| 비용 | $12/년 + Hosted Zone $0.5/월 | 1년 baseline ~$18. 갱신 시 cost.md에 추가 |
+| Subdomain 구조 | `api.thirdtool.dev` (BE) + `thirdtool.dev`(apex) / `www.thirdtool.dev` (FE) | API/FE 분리 — CloudFront(FE) vs ALB(BE) origin 격리 + CORS 명확화 |
+
+### ALB 공유 + Listener 443 신설
+
+| 항목 | 결정 | 근거 |
+| --- | --- | --- |
+| ALB 분할 | **API/FE 동일 ALB 사용 안 함 → API는 ALB, FE는 CloudFront** | FE는 정적 자산 → ALB origin은 부적합 (TLS 종료 + bandwidth 비용). CloudFront edge cache + S3가 표준. ALB는 API 전용 |
+| HTTPS 리스너 | **443 신설 + TLS 1.3 정책 (`ELBSecurityPolicy-TLS13-1-2-2021-06`)** | ADR016에서 ALB spec 이미 설계됨. 본 ADR은 실 ACM cert(ap-northeast-2)를 attach + 443 listener 활성화 |
+| HTTP 80 처리 | **301 redirect → HTTPS** (보존 host/path/query) | `.dev` HSTS 강제이지만 첫 1회 HTTP 시도는 발생 가능 → 서버 측 redirect로 graceful fallback |
+| ALB SG 443 인바운드 | **별도 SG rule 추가** (`security-group-alb-443.json`) | 기존 ALB SG가 80만 열려 있음. 443 인바운드 0.0.0.0/0 신설 |
+
+### FE CDN: CloudFront + S3 + OAC
+
+| 항목 | 결정 | 근거 |
+| --- | --- | --- |
+| 정적 호스팅 | **CloudFront + S3** (Vercel/Netlify 거부) | AWS 단일 cloud 비용 통합 + IAM 통합 + 외부 SaaS 종속 회피. SPA Vite build → S3 sync → CloudFront invalidation 패턴 표준 |
+| S3 접근 제어 | **OAC (Origin Access Control)** | OAI는 legacy + KMS·SSE-S3 미지원 한계. OAC가 2022+ 권장. S3 bucket은 퍼블릭 접근 완전 차단 + CloudFront principal만 GetObject 허용 |
+| SPA 404 처리 | **CloudFront error responses 404/403 → 200 `/index.html`** | SPA 라우팅은 client-side. S3는 path가 파일 매칭 안 되면 404 — `/dashboard` URL 직접 접근 시 fallback 필수 |
+| ACM cert region | **us-east-1 필수** | CloudFront는 글로벌 service — ACM cert가 us-east-1에 있어야만 attach 가능. ap-northeast-2 cert는 ALB 전용 |
+| TLS 정책 | **TLS 1.2+ (`TLSv1.2_2021`)** | CloudFront 권장 default. TLS 1.0/1.1 차단 + 구형 브라우저 호환 OK |
+| Price class | `PriceClass_200` | 아시아·북미·유럽 edge — 한국 + 글로벌 사용자 커버. PriceClass_All은 남미·아프리카까지 — 비용 1.5배 |
+| Cache TTL | default 1일 / max 1년 | SPA index.html은 invalidation으로 갱신, 정적 asset(JS/CSS)은 build hash로 immutable |
+
+### Route53 Alias 레코드 3건
+
+```
+A   thirdtool.dev          → CloudFront Distribution (alias)
+A   www.thirdtool.dev      → CloudFront Distribution (alias)
+A   api.thirdtool.dev      → ALB internal-facing (alias)
+```
+
+A alias는 IPv4. AAAA(IPv6)는 CloudFront/ALB 모두 자동 활성 — 별도 레코드 불요.
+
+### CORS allowed origins 3건
+
+`SecurityConfig.corsConfigurationSource()` + `MvcConfig.addCorsMappings()` 모두 다음 명시:
+- `https://thirdtool.dev` (apex)
+- `https://www.thirdtool.dev` (CloudFront alt)
+- `http://localhost:5173` · `http://localhost:8080` · `http://localhost:3000` (local dev 유지)
+
+`api.thirdtool.dev`는 API 자신이라 CORS allowed origins 불요 (preflight 제외).
+`thirdstool.com` (구 도메인) 완전 제거 — clean break.
+
+### OAuth Redirect URI
+
+`application-prod.yml`:
+- Kakao: `https://api.thirdtool.dev/oauth/kakao/callback`
+- Naver: `https://api.thirdtool.dev/oauth/naver/callback`
+
+운영자가 카카오·네이버 developers 콘솔에서 등록 도메인을 `api.thirdtool.dev`로 갱신 필수 — ts006 §2.1·2.2.
+
+### FE 배포 GHA 워크플로우
+
+`deploy-fe.yml`:
+- OIDC AssumeRole `gha-deploy-role` (ADR013) — long-lived key 없음
+- npm build → `dist/` 산출
+- `aws s3 sync dist/ s3://thirdtool-fe-prod/` 
+- `aws cloudfront create-invalidation --paths '/index.html' '/assets/*'`
+
+trigger: FE repo push to main. **본 ADR은 BE 레포지토리 — FE 레포 측 등록은 사용자 액션**.
+
+### 본 ADR이 다루지 않는 범위
+
+- **CDN 이미지 최적화 (Lambda@Edge / CloudFront Functions)**: 트래픽 발생 후
+- **WAF (Web Application Firewall)**: M3 보안 강화 Epic
+- **CloudFront 다중 origin (API origin 추가)**: 현재 분리 유지가 명확
+- **multi-region failover**: 단일 region M1
+- **FE 도메인 추가 (예: `app.thirdtool.dev`)**: 단일 페이지 SPA M1
+- **API rate limiting at edge**: WAF 도입 시
+- **CloudFront Origin Shield**: 트래픽 발생 후 캐시 hit rate 측정 후
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **HSTS 강제로 다운그레이드 공격 baseline 차단**: `.dev`는 브라우저 HSTS preload 목록 — 사용자가 `http://thirdtool.dev` 입력해도 브라우저가 HTTPS로 자동 전환. 서버 redirect 의존 0
+- **CloudFront edge로 FE 응답 지연 단축**: 한국 사용자 ms 단위. ALB 직접 origin 대비 5-10배
+- **S3 퍼블릭 차단 + OAC로 외부 직접 접근 0**: bucket URL 노출되어도 403. CloudFront가 유일 경로
+- **CORS clean break**: `thirdstool.com` 완전 제거 — 구 도메인 cookie/session 잔존 risk 0
+- **FE/BE GHA 분리**: FE 변경이 BE 배포 트리거하지 않음 + 역도 동일. 독립 deploy
+- **OAuth redirect URI 단일 출처**: api.thirdtool.dev 1곳 — 카카오·네이버 등록 도메인 단순화
+
+### 트레이드오프 / 부정적
+
+- **`.dev` HSTS 강제로 HTTP 서비스 불가**: HTTPS 미준비 상태에서 HTTP로 서비스할 수 없음 — ACM ISSUED 전까진 도메인 접근 불가. M1 첫 배포 전 ACM 발급 완료 필수
+- **us-east-1 ACM 의존**: CloudFront 자체 요구사항. 한국 region에 모든 자원 두려는 계획에 예외 1건 — 단, ACM은 비용 0
+- **CloudFront propagation 5~10분**: 첫 배포 후 즉시 도메인 접속 시 캐시 미스. 운영자가 이 점 인지 + 첫 invalidation 명시 필요
+- **CloudFront 비용**: PriceClass_200 + outbound 데이터 $0.085/GB. M1 트래픽 0 → 0.1~1 GB/월 ≈ $0.01~0.10. M2 트래픽 증가 시 monitoring 필요
+- **S3 storage + invalidation 비용**: storage $0.023/GB·월 (dist/ ~10 MB → $0). invalidation 첫 1000개 path 무료 후 $0.005/path — M1 무료 구간
+- **Route53 Hosted Zone $0.5/월**: domain 등록 즉시 발생 — cost.md 추가
+- **OAuth provider 콘솔 갱신 필요**: 카카오·네이버 developers에서 redirect URI 등록 도메인을 `api.thirdtool.dev`로 변경 — 사용자 액션. 누락 시 OAuth callback 실패
+- **단일 ALB로 staging + prod 혼재 (ADR016)**: API trafic spike 시 ALB 단일 SPOF. 분리 ALB는 M2 환경 분리 Epic
+- **CloudFront cache key 기본 = URL만**: 쿠키/헤더 vary 미설정 — SPA에 적정. API origin이 아니라 정적 호스팅이므로 OK
+- **첫 배포 검증 부담**: ACM 2개 + ALB 443 + Route53 3건 + S3 + CloudFront + FE deploy + OAuth provider 갱신 — 7단계 순차 의존. handoff §11~14 + DEPLOY-RUNBOOK.md로 절차 명시
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **A. `.com` TLD + HSTS 헤더 수동 설정** | 일반 도메인 익숙 | HSTS preload 등록 절차 + 응답 헤더 누락 시 다운그레이드 노출. `.dev`가 baseline 강제 |
+| **B. Vercel/Netlify FE 호스팅** | zero-config + git 통합 | AWS 단일 cloud 비용 통합 깨짐. SaaS 종속 + 가격 인상 risk |
+| **C. ECS Task에서 정적 자산 + API 동시 서빙 (단일 origin)** | CloudFront/S3 불요 | ALB outbound 부담 + JVM이 정적 파일 서빙 — 비효율. SPA build 시점이 BE deploy와 결합 |
+| **D. OAI (Origin Access Identity, legacy)** | 기존 사례 풍부 | KMS·SSE-S3 미지원 + AWS 2022+ OAC 권장. OAC 채택이 future-proof |
+| **E. S3 퍼블릭 bucket + CloudFront 미사용** | 단순 | edge cache 부재 + HTTPS 자동 X (S3 도메인은 https 가능하나 도메인 alias 불가) |
+| **F (선택). CloudFront + S3 + OAC + Route53** | edge cache + HTTPS + 도메인 alias + 보안 baseline | trade-off는 위에 명시 |
+| **G. ALB HTTPS만 + HTTP 차단 (redirect 없음)** | 명확한 강제 | `.dev` 외 입력 사용자 경험 저하 — 첫 1회 graceful fallback이 UX 우수 |
+| **H. api.thirdtool.dev + thirdtool.dev 동일 도메인 (subdomain 없음)** | 단순 | API/FE 분리 명확화 손실 + CORS 복잡화 |
+| **I. WAF/CloudFront Functions로 edge 인증** | bot 차단 | M1 보안 baseline 충분. M3 추가 |
+| **J. Route53 Health Check + DNS failover** | 다중 region 가용성 | 단일 region M1. M3 multi-region 검토 |
+
+## 알려진 follow-up (본 ADR 범위 외)
+
+- **사용자 액션 U1 (D1)**: Route53 콘솔에서 `thirdtool.dev` 구매 — handoff Stage 11 사전 단계
+- **사용자 액션 U3-1 (D2)**: ACM 2-region 신청 + DNS 검증 — handoff Stage 11
+- **사용자 액션 U4 (D3)**: ALB HTTPS 리스너 + 443 SG — handoff Stage 12
+- **사용자 액션 U5 (D4)**: Route53 `api.thirdtool.dev` alias — handoff Stage 14
+- **사용자 액션 U6+U7 (D5+D6)**: S3 버킷 + CloudFront 배포 — handoff Stage 13
+- **사용자 액션 U8 (D7)**: Route53 apex/www alias — handoff Stage 14
+- **사용자 액션 U9 (D10)**: FE `.env.production` 갱신 + GHA 첫 deploy
+- **카카오·네이버 콘솔 OAuth redirect URI 갱신**: 사용자 측. ts006 §2.1·2.2 절차
+- **Story-TBD (WAF + CloudFront Functions)**: M3 보안 강화
+- **Story-TBD (ECR/CloudFront 비용 monitoring)**: 첫 월 청구 후 cost.md 갱신
+- **Story-TBD (FE 도메인 분리 — app.thirdtool.dev)**: 다중 SPA 도입 시
+
+## 다시 검토할 시점
+
+- **CloudFront 비용이 cost.md baseline 대비 50% 초과 시점**: PriceClass 다운그레이드 또는 cache TTL 상향
+- **`.dev` HSTS로 인한 사용자 cs 문의 발생 시점**: HTTPS 환경 사용자 교육 — 도메인 입력 시 자동 HTTPS 안내
+- **FE 빌드 산출물 크기 > 50 MB 시점**: code splitting + lazy loading 검토
+- **API/FE 별도 ALB 필요 시점 (API trafic > 1000 RPS)**: ALB 분리 + DNS round-robin
+- **multi-region 진입 시점**: Route53 Health Check + Origin Failover + ACM us-east-1 외 region 추가 검토
+- **WAF 도입 시점**: bot/scraping 트래픽 발견 시

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,3 +20,4 @@
 | [ADR016](ADR016-alb-listener-target-group.md) | ALB 1개 공유 + Listener 80→443 + Target Group type=ip + TLS 1.3 (Story-049) | Accepted | 2026-06-29 |
 | [ADR017](ADR017-spring-forward-headers-graceful-shutdown.md) | Spring `forward-headers-strategy=native` + `server.shutdown=graceful` (Story-050) | Accepted | 2026-06-29 |
 | [ADR018](ADR018-rds-mysql-single-az-prod.md) | RDS MySQL prod single-AZ + db.t4g.micro + utf8mb4 + Asia/Seoul (Story-051) | Accepted | 2026-06-29 |
+| [ADR020](ADR020-https-fronting-and-fe-cdn-strategy.md) | HTTPS fronting + FE CDN — 1 ALB 공유 + CloudFront/S3 OAC + .dev HSTS 강제 (Story-056) | Accepted | 2026-06-30 |

--- a/infra/DEPLOY-RUNBOOK.md
+++ b/infra/DEPLOY-RUNBOOK.md
@@ -1,0 +1,208 @@
+# 1차 배포 완성 런북 — Route53 + HTTPS + FE CDN
+
+> 실행 전 전제: `AWS_ACCOUNT_ID`, `HZ_ID` 등 변수를 shell에 export 후 진행
+
+## Phase 0 (사용자 직접): Route53 도메인 등록
+
+AWS 콘솔 → Route53 → Registered domains → Register domain → `thirdtool.dev` 검색 → 구매 (~$12/년)
+- 등록 완료 시 Hosted Zone 자동 생성
+- `HZ_ID=$(aws route53 list-hosted-zones-by-name --dns-name thirdtool.dev --query 'HostedZones[0].Id' --output text | cut -d/ -f3)`
+
+---
+
+## Phase 1: ACM 인증서 2개 동시 신청
+
+```bash
+# ALB용 (ap-northeast-2)
+ACM_AP_ARN=$(aws acm request-certificate \
+  --cli-input-json file://infra/acm/acm-ap-northeast-2.json \
+  --region ap-northeast-2 \
+  --query CertificateArn --output text)
+echo "ACM_AP_ARN=$ACM_AP_ARN"
+
+# CloudFront용 (us-east-1 필수)
+ACM_US_ARN=$(aws acm request-certificate \
+  --cli-input-json file://infra/acm/acm-us-east-1.json \
+  --region us-east-1 \
+  --query CertificateArn --output text)
+echo "ACM_US_ARN=$ACM_US_ARN"
+```
+
+Route53 콘솔 → 각 인증서 상세 → "Route 53에서 레코드 생성" (1회로 양쪽 검증)
+
+```bash
+# ISSUED 대기 (약 5~10분)
+aws acm wait certificate-validated --certificate-arn $ACM_AP_ARN --region ap-northeast-2
+aws acm wait certificate-validated --certificate-arn $ACM_US_ARN --region us-east-1
+echo "✅ 인증서 발급 완료"
+```
+
+---
+
+## Phase 2: ALB HTTPS 전환
+
+```bash
+ALB_ARN=$(aws elbv2 describe-load-balancers --names third-tool-alb \
+  --query 'LoadBalancers[0].LoadBalancerArn' --output text)
+TG_ARN=$(aws elbv2 describe-target-groups --names third-tool-tg \
+  --query 'TargetGroups[0].TargetGroupArn' --output text)
+HTTP_LISTENER_ARN=$(aws elbv2 describe-listeners --load-balancer-arn $ALB_ARN \
+  --query 'Listeners[?Port==`80`].ListenerArn' --output text)
+ALB_SG_ID=$(aws elbv2 describe-load-balancers --names third-tool-alb \
+  --query 'LoadBalancers[0].SecurityGroups[0]' --output text)
+
+# 443 인바운드 허용
+sed "s/<ALB_SG_ID>/$ALB_SG_ID/" infra/vpc/security-group-alb-443.json | \
+  aws ec2 authorize-security-group-ingress --cli-input-json file:///dev/stdin
+
+# HTTPS 리스너 생성
+sed -e "s|<ALB_ARN>|$ALB_ARN|" \
+    -e "s|<ACM_AP_NORTHEAST_2_ARN>|$ACM_AP_ARN|" \
+    -e "s|<TARGET_GROUP_ARN>|$TG_ARN|" \
+    infra/alb/alb-https-listener.json | \
+  aws elbv2 create-listener --cli-input-json file:///dev/stdin
+
+# HTTP → HTTPS 리다이렉트
+sed "s|<HTTP_80_LISTENER_ARN>|$HTTP_LISTENER_ARN|" infra/alb/alb-http-to-https-redirect.json | \
+  aws elbv2 modify-listener --cli-input-json file:///dev/stdin
+
+echo "✅ ALB HTTPS 완료"
+```
+
+---
+
+## Phase 3: Route53 api.thirdtool.dev → ALB
+
+```bash
+ALB_DNS=$(aws elbv2 describe-load-balancers --names third-tool-alb \
+  --query 'LoadBalancers[0].DNSName' --output text)
+ALB_ZONE=$(aws elbv2 describe-load-balancers --names third-tool-alb \
+  --query 'LoadBalancers[0].CanonicalHostedZoneId' --output text)
+
+# json 인라인 치환 후 적용
+python3 -c "
+import json, sys
+with open('infra/route53/route53-api-record.json') as f:
+    d = json.load(f)
+target = d['Changes'][0]['ResourceRecordSet']['AliasTarget']
+target['HostedZoneId'] = '$ALB_ZONE'
+target['DNSName'] = '$ALB_DNS'
+print(json.dumps(d))
+" > /tmp/route53-api-record.json
+
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $HZ_ID \
+  --change-batch file:///tmp/route53-api-record.json
+echo "✅ api.thirdtool.dev → ALB 완료"
+```
+
+---
+
+## Phase 4: S3 FE 버킷 생성
+
+```bash
+aws s3api create-bucket \
+  --cli-input-json file://infra/s3/s3-fe-bucket.json
+
+aws s3api put-public-access-block \
+  --cli-input-json file://infra/s3/s3-fe-bucket-public-access-block.json
+
+echo "✅ S3 버킷 생성 완료"
+```
+
+---
+
+## Phase 5: CloudFront 배포 (ACM us-east-1 ISSUED 후)
+
+```bash
+# OAC 생성
+OAC_ID=$(aws cloudfront create-origin-access-control \
+  --cli-input-json file://infra/cloudfront/cloudfront-oac.json \
+  --query 'OriginAccessControl.Id' --output text)
+
+# cloudfront-dist.json에 OAC + ACM ARN 주입
+python3 -c "
+import json
+with open('infra/cloudfront/cloudfront-dist.json') as f:
+    d = json.load(f)
+d['DistributionConfig']['Origins']['Items'][0]['OriginAccessControlId'] = '$OAC_ID'
+d['DistributionConfig']['ViewerCertificate']['ACMCertificateArn'] = '$ACM_US_ARN'
+with open('/tmp/cloudfront-dist.json', 'w') as f:
+    json.dump(d, f)
+"
+
+CF_RESULT=$(aws cloudfront create-distribution \
+  --cli-input-json file:///tmp/cloudfront-dist.json)
+CF_DIST_ID=$(echo $CF_RESULT | python3 -c "import json,sys; print(json.load(sys.stdin)['Distribution']['Id'])")
+CF_DOMAIN=$(echo $CF_RESULT | python3 -c "import json,sys; print(json.load(sys.stdin)['Distribution']['DomainName'])")
+CF_ARN=$(echo $CF_RESULT | python3 -c "import json,sys; print(json.load(sys.stdin)['Distribution']['ARN'])")
+
+echo "CF_DIST_ID=$CF_DIST_ID"
+echo "CF_DOMAIN=$CF_DOMAIN"
+
+# S3 버킷 정책 (CloudFront ARN 주입)
+python3 -c "
+import json
+with open('infra/s3/s3-fe-bucket-policy.json') as f:
+    d = json.load(f)
+d['Statement'][0]['Condition']['StringEquals']['AWS:SourceArn'] = '$CF_ARN'
+with open('/tmp/s3-fe-bucket-policy.json', 'w') as f:
+    json.dump(d, f)
+"
+aws s3api put-bucket-policy \
+  --bucket thirdtool-fe-prod \
+  --policy file:///tmp/s3-fe-bucket-policy.json
+
+echo "✅ CloudFront 배포 완료"
+```
+
+---
+
+## Phase 6: Route53 thirdtool.dev → CloudFront
+
+```bash
+python3 -c "
+import json
+with open('infra/route53/route53-fe-record.json') as f:
+    d = json.load(f)
+for ch in d['Changes']:
+    ch['ResourceRecordSet']['AliasTarget']['DNSName'] = '$CF_DOMAIN'
+with open('/tmp/route53-fe-record.json', 'w') as f:
+    json.dump(d, f)
+"
+
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $HZ_ID \
+  --change-batch file:///tmp/route53-fe-record.json
+echo "✅ thirdtool.dev → CloudFront 완료"
+```
+
+---
+
+## Phase 7: GHA 변수 등록
+
+GitHub 콘솔 → Settings → Secrets and variables → Actions → Variables:
+- `CF_DIST_ID` = CloudFront Distribution ID
+- `AWS_ACCOUNT_ID` = AWS 계정 ID (이미 있으면 스킵)
+
+---
+
+## 검증 체크리스트
+
+```bash
+# BE API
+curl -I https://api.thirdtool.dev/actuator/health
+# → HTTP/2 200
+
+# HTTP → HTTPS 리다이렉트
+curl -I http://api.thirdtool.dev/actuator/health
+# → 301 Location: https://...
+
+# CloudFront (배포 후 DNS 전파 최대 60분)
+curl -I https://thirdtool.dev
+# → HTTP/2 200
+
+# CORS 확인
+curl -I -H "Origin: https://thirdtool.dev" https://api.thirdtool.dev/actuator/health
+# → access-control-allow-origin: https://thirdtool.dev
+```

--- a/infra/acm/README.md
+++ b/infra/acm/README.md
@@ -1,0 +1,36 @@
+# ACM 인증서 신청 가이드
+
+## 신청 순서 (2개 병렬 — 동시 실행)
+
+### 1. ap-northeast-2 (ALB용)
+```bash
+aws acm request-certificate \
+  --cli-input-json file://infra/acm/acm-ap-northeast-2.json \
+  --region ap-northeast-2
+# → CertificateArn 저장 (ACM_AP_ARN)
+```
+
+### 2. us-east-1 (CloudFront용 — 필수 us-east-1)
+```bash
+aws acm request-certificate \
+  --cli-input-json file://infra/acm/acm-us-east-1.json \
+  --region us-east-1
+# → CertificateArn 저장 (ACM_US_EAST_1_ARN)
+```
+
+## DNS 검증 CNAME 추가
+Route53 콘솔 → 인증서 상세 → "Route 53에서 레코드 생성" 클릭 (1회로 두 인증서 모두 검증됨)
+
+## ISSUED 확인
+```bash
+aws acm describe-certificate --certificate-arn $ACM_AP_ARN --region ap-northeast-2 \
+  --query "Certificate.Status"
+aws acm describe-certificate --certificate-arn $ACM_US_EAST_1_ARN --region us-east-1 \
+  --query "Certificate.Status"
+# → "ISSUED" 확인 후 ALB·CloudFront 작업 진행
+```
+
+## 주의사항
+- `.dev` TLD = HSTS preloaded → HTTP 불허, HTTPS 필수
+- CloudFront는 **us-east-1 ACM만** 허용 — 리전 혼동 주의
+- DNS 검증 CNAME은 두 인증서가 동일 → Route53에 1회만 추가하면 양쪽 검증

--- a/infra/acm/acm-ap-northeast-2.json
+++ b/infra/acm/acm-ap-northeast-2.json
@@ -1,0 +1,8 @@
+{
+  "DomainName": "thirdtool.dev",
+  "SubjectAlternativeNames": [
+    "*.thirdtool.dev"
+  ],
+  "ValidationMethod": "DNS",
+  "IdempotencyToken": "thirdtool-alb-2024"
+}

--- a/infra/acm/acm-us-east-1.json
+++ b/infra/acm/acm-us-east-1.json
@@ -1,0 +1,8 @@
+{
+  "DomainName": "thirdtool.dev",
+  "SubjectAlternativeNames": [
+    "*.thirdtool.dev"
+  ],
+  "ValidationMethod": "DNS",
+  "IdempotencyToken": "thirdtool-cloudfront-2024"
+}

--- a/infra/alb/alb-http-to-https-redirect.json
+++ b/infra/alb/alb-http-to-https-redirect.json
@@ -1,0 +1,13 @@
+{
+  "ListenerArn": "<HTTP_80_LISTENER_ARN>",
+  "DefaultActions": [
+    {
+      "Type": "redirect",
+      "RedirectConfig": {
+        "Protocol": "HTTPS",
+        "Port": "443",
+        "StatusCode": "HTTP_301"
+      }
+    }
+  ]
+}

--- a/infra/alb/alb-https-listener.json
+++ b/infra/alb/alb-https-listener.json
@@ -1,0 +1,17 @@
+{
+  "LoadBalancerArn": "<ALB_ARN>",
+  "Protocol": "HTTPS",
+  "Port": 443,
+  "Certificates": [
+    {
+      "CertificateArn": "<ACM_AP_NORTHEAST_2_ARN>"
+    }
+  ],
+  "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+  "DefaultActions": [
+    {
+      "Type": "forward",
+      "TargetGroupArn": "<TARGET_GROUP_ARN>"
+    }
+  ]
+}

--- a/infra/cloudfront/README.md
+++ b/infra/cloudfront/README.md
@@ -1,0 +1,46 @@
+# CloudFront 배포 가이드
+
+## 실행 순서 (ACM us-east-1 ISSUED 후)
+
+### 1. OAC 생성 (먼저)
+```bash
+aws cloudfront create-origin-access-control \
+  --cli-input-json file://infra/cloudfront/cloudfront-oac.json
+# → OriginAccessControl.Id 저장 (OAC_ID)
+```
+
+### 2. cloudfront-dist.json의 <OAC_ID> 치환
+```bash
+sed -i "s/<OAC_ID>/$OAC_ID/" infra/cloudfront/cloudfront-dist.json
+sed -i "s/<ACM_US_EAST_1_ARN>/$ACM_US_EAST_1_ARN/" infra/cloudfront/cloudfront-dist.json
+```
+
+### 3. CloudFront 배포 생성
+```bash
+aws cloudfront create-distribution \
+  --cli-input-json file://infra/cloudfront/cloudfront-dist.json
+# → Distribution.Id (CF_DIST_ID), Distribution.DomainName (CLOUDFRONT_DOMAIN) 저장
+```
+
+### 4. S3 버킷 정책 업데이트 (CloudFront ARN 주입)
+```bash
+CF_ARN="arn:aws:cloudfront::<AWS_ACCOUNT_ID>:distribution/$CF_DIST_ID"
+sed -i "s|<CLOUDFRONT_DISTRIBUTION_ARN>|$CF_ARN|" infra/s3/s3-fe-bucket-policy.json
+
+aws s3api put-bucket-policy \
+  --bucket thirdtool-fe-prod \
+  --policy file://infra/s3/s3-fe-bucket-policy.json
+```
+
+### 5. Route53 FE 레코드 (CLOUDFRONT_DOMAIN 주입 후)
+```bash
+sed -i "s/<CLOUDFRONT_DOMAIN>/$CLOUDFRONT_DOMAIN/" infra/route53/route53-fe-record.json
+sed -i "s/<HOSTED_ZONE_ID>/$HZ_ID/" infra/route53/route53-fe-record.json
+
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $HZ_ID \
+  --change-batch file://infra/route53/route53-fe-record.json
+```
+
+## 캐시 정책 ID 설명
+`658327ea-f89d-4fab-a63d-7e88639e58f6` = AWS managed "CachingOptimized" 정책

--- a/infra/cloudfront/cloudfront-dist.json
+++ b/infra/cloudfront/cloudfront-dist.json
@@ -1,0 +1,66 @@
+{
+  "DistributionConfig": {
+    "CallerReference": "thirdtool-fe-prod-2024",
+    "Comment": "thirdtool FE CDN — thirdtool.dev → S3 thirdtool-fe-prod",
+    "Enabled": true,
+    "DefaultRootObject": "index.html",
+    "Aliases": {
+      "Quantity": 2,
+      "Items": [
+        "thirdtool.dev",
+        "www.thirdtool.dev"
+      ]
+    },
+    "Origins": {
+      "Quantity": 1,
+      "Items": [
+        {
+          "Id": "s3-thirdtool-fe-prod",
+          "DomainName": "thirdtool-fe-prod.s3.ap-northeast-2.amazonaws.com",
+          "S3OriginConfig": {
+            "OriginAccessIdentity": ""
+          },
+          "OriginAccessControlId": "<OAC_ID>"
+        }
+      ]
+    },
+    "DefaultCacheBehavior": {
+      "TargetOriginId": "s3-thirdtool-fe-prod",
+      "ViewerProtocolPolicy": "redirect-to-https",
+      "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+      "Compress": true,
+      "AllowedMethods": {
+        "Quantity": 2,
+        "Items": ["GET", "HEAD"],
+        "CachedMethods": {
+          "Quantity": 2,
+          "Items": ["GET", "HEAD"]
+        }
+      }
+    },
+    "CustomErrorResponses": {
+      "Quantity": 2,
+      "Items": [
+        {
+          "ErrorCode": 404,
+          "ResponsePagePath": "/index.html",
+          "ResponseCode": "200",
+          "ErrorCachingMinTTL": 10
+        },
+        {
+          "ErrorCode": 403,
+          "ResponsePagePath": "/index.html",
+          "ResponseCode": "200",
+          "ErrorCachingMinTTL": 10
+        }
+      ]
+    },
+    "ViewerCertificate": {
+      "ACMCertificateArn": "<ACM_US_EAST_1_ARN>",
+      "SSLSupportMethod": "sni-only",
+      "MinimumProtocolVersion": "TLSv1.2_2021"
+    },
+    "HttpVersion": "http2and3",
+    "PriceClass": "PriceClass_200"
+  }
+}

--- a/infra/cloudfront/cloudfront-oac.json
+++ b/infra/cloudfront/cloudfront-oac.json
@@ -1,0 +1,9 @@
+{
+  "OriginAccessControlConfig": {
+    "Name": "thirdtool-fe-oac",
+    "Description": "OAC for thirdtool-fe-prod S3 bucket",
+    "OriginAccessControlOriginType": "s3",
+    "SigningBehavior": "always",
+    "SigningProtocol": "sigv4"
+  }
+}

--- a/infra/iam/gha-deploy-role-permissions-policy.json
+++ b/infra/iam/gha-deploy-role-permissions-policy.json
@@ -37,6 +37,26 @@
       "Resource": "*"
     },
     {
+      "Sid": "FeSyncS3",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::thirdtool-fe-prod",
+        "arn:aws:s3:::thirdtool-fe-prod/*"
+      ]
+    },
+    {
+      "Sid": "FeCdnInvalidate",
+      "Effect": "Allow",
+      "Action": "cloudfront:CreateInvalidation",
+      "Resource": "*"
+    },
+    {
       "Sid": "IamPassRoleToEcsTasks",
       "Effect": "Allow",
       "Action": "iam:PassRole",

--- a/infra/route53/route53-api-record.json
+++ b/infra/route53/route53-api-record.json
@@ -1,0 +1,17 @@
+{
+  "Comment": "api.thirdtool.dev → ALB (A alias)",
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "api.thirdtool.dev",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "<ALB_CANONICAL_HOSTED_ZONE_ID>",
+          "DNSName": "<ALB_DNS_NAME>",
+          "EvaluateTargetHealth": true
+        }
+      }
+    }
+  ]
+}

--- a/infra/route53/route53-fe-record.json
+++ b/infra/route53/route53-fe-record.json
@@ -1,0 +1,29 @@
+{
+  "Comment": "thirdtool.dev + www.thirdtool.dev → CloudFront (A alias)",
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "thirdtool.dev",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "Z2FDTNDATAQYW2",
+          "DNSName": "<CLOUDFRONT_DOMAIN>",
+          "EvaluateTargetHealth": false
+        }
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "www.thirdtool.dev",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "Z2FDTNDATAQYW2",
+          "DNSName": "<CLOUDFRONT_DOMAIN>",
+          "EvaluateTargetHealth": false
+        }
+      }
+    }
+  ]
+}

--- a/infra/s3/s3-fe-bucket-policy.json
+++ b/infra/s3/s3-fe-bucket-policy.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCloudFrontOAC",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudfront.amazonaws.com"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::thirdtool-fe-prod/*",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "<CLOUDFRONT_DISTRIBUTION_ARN>"
+        }
+      }
+    }
+  ]
+}

--- a/infra/s3/s3-fe-bucket-public-access-block.json
+++ b/infra/s3/s3-fe-bucket-public-access-block.json
@@ -1,0 +1,9 @@
+{
+  "Bucket": "thirdtool-fe-prod",
+  "PublicAccessBlockConfiguration": {
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+  }
+}

--- a/infra/s3/s3-fe-bucket.json
+++ b/infra/s3/s3-fe-bucket.json
@@ -1,0 +1,6 @@
+{
+  "Bucket": "thirdtool-fe-prod",
+  "CreateBucketConfiguration": {
+    "LocationConstraint": "ap-northeast-2"
+  }
+}

--- a/infra/vpc/security-group-alb-443.json
+++ b/infra/vpc/security-group-alb-443.json
@@ -1,0 +1,22 @@
+{
+  "GroupId": "<ALB_SG_ID>",
+  "IpPermissions": [
+    {
+      "IpProtocol": "tcp",
+      "FromPort": 443,
+      "ToPort": 443,
+      "IpRanges": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "HTTPS inbound from internet"
+        }
+      ],
+      "Ipv6Ranges": [
+        {
+          "CidrIpv6": "::/0",
+          "Description": "HTTPS inbound from internet (IPv6)"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/com/example/thirdtool/Common/config/MvcConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/MvcConfig.java
@@ -15,8 +15,8 @@ public class MvcConfig implements WebMvcConfigurer {
                             "http://localhost:5173",
                             "http://localhost:8080",
                             "http://localhost:3000",
-                            "https://thirdstool.com",       // ✅ FE 배포 도메인
-                            "https://www.thirdstool.com" // www 쓰면 추가
+                            "https://thirdtool.dev",
+                            "https://www.thirdtool.dev"
                                    )
                     .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                     .allowCredentials(true)

--- a/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
+++ b/src/main/java/com/example/thirdtool/Common/config/SecurityConfig.java
@@ -103,10 +103,12 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:5173",
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:5173",
                 "http://localhost:8080",
                 "http://localhost:3000",
-                "https://thirdstool.com" ));
+                "https://thirdtool.dev",
+                "https://www.thirdtool.dev"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -56,12 +56,12 @@ springdoc:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: https://thirdstool.com/oauth/kakao/callback
+  redirect-uri: https://api.thirdtool.dev/oauth/kakao/callback
 
 naver:
   client-id: ${NAVER_CLIENT_ID}
   client-secret: ${NAVER_CLIENT_SECRET}
-  redirect-uri: https://thirdstool.com/oauth/naver/callback
+  redirect-uri: https://api.thirdtool.dev/oauth/naver/callback
 
 # AWS S3
 cloud:


### PR DESCRIPTION
## 개요

milestone 0.0.1v Tier 1-확장 (D2~D9) — \`https://api.thirdtool.dev\`(BE) + \`https://thirdtool.dev\`(FE) 도메인 노출까지를 0.0.1v 범위로 확장. add04a1 commit(개발 중 마련된 spec)을 develop에서 재구성한 clean PR.

## 왜 / 설계 결정

- **.dev TLD + HSTS preload 강제**: 다운그레이드 공격 baseline 차단 (ADR020)
- **1 ALB 공유 + CloudFront/S3 FE 분리**: API/FE origin 분리 + edge cache + IAM 통합
- **OAC (Origin Access Control)**: S3 퍼블릭 차단 + CloudFront principal만 GetObject — OAI legacy 거부
- **us-east-1 ACM (CloudFront 필수) + ap-northeast-2 ACM (ALB) 2-region**: CloudFront 자체 요구사항. ACM은 비용 0
- **\`thirdstool.com\` clean break**: CORS allowed origins 3건(apex/www + localhost), 구 도메인 잔존 0

## 작업 내용

**BE 코드 변경 (D8)**:
- \`SecurityConfig.java\` L106-111: CORS allowedOrigins → \`thirdtool.dev\` / \`www.thirdtool.dev\` + localhost
- \`MvcConfig.java\`: 동일 CORS 전환
- \`application-prod.yml\`: OAuth redirect URI → \`https://api.thirdtool.dev/oauth/{kakao,naver}/callback\`

**GHA 워크플로우 (D9)**:
- \`.github/workflows/deploy-fe.yml\`: OIDC AssumeRole + npm build + S3 sync + CloudFront invalidation (FE 레포 트리거)
- \`infra/iam/gha-deploy-role-permissions-policy.json\` patch: S3 sync + CloudFront invalidation 권한 추가

**Infra spec (D2~D7)**:
- \`infra/acm/\` — 2-region 인증서 신청 spec (ap-northeast-2 + us-east-1)
- \`infra/alb/{alb-https-listener,alb-http-to-https-redirect}.json\` — 443 listener + 80→301
- \`infra/vpc/security-group-alb-443.json\` — ALB SG 443 인바운드
- \`infra/cloudfront/{dist,oac}.json\` + README — distribution + OAC
- \`infra/s3/s3-fe-bucket{,-policy,-public-access-block}.json\` — \`thirdtool-fe-prod\` 버킷 spec
- \`infra/route53/route53-{api,fe}-record.json\` — A alias 3건 spec
- \`infra/DEPLOY-RUNBOOK.md\` — Phase 0~7 통합 실행 런북

**문서**:
- \`docs/adr/ADR020-https-fronting-and-fe-cdn-strategy.md\` + index.md 추가
- (gitignored) \`workflow/task/pes/handoff/aws-setup-0.0.1v.md\` §14A~§14E 신설 (Stage 10~14)
- (gitignored) \`workflow/task/milestones/version/0.0.1v/infra.md\` Tier 1-확장 D2~D9 체크 + 도메인 신호 4건

## 변경 유형

- [x] feat (infra spec + GHA workflow)  - [ ] fix  - [ ] refactor  - [x] docs (ADR020 + handoff)  - [ ] test  - [ ] chore

## 테스트

- \`./gradlew test\` → **698 tests, 0 failures**
- \`./gradlew compileJava\` → OK (SecurityConfig/MvcConfig CORS 변경 컴파일 검증)
- JSON 문법 검증: 모든 infra/*.json read 통과
- 실제 ACM/ALB/CF/Route53 등록·검증은 사용자 측 (handoff §14A~§14E 또는 DEPLOY-RUNBOOK.md 절차)

## 체크리스트

- [x] 빌드 / 테스트 통과 (698/698)
- [x] 모든 응답 ApiResponse<T> 래퍼 (변경 없음)
- [x] OSIV=false 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 (Common BC만 변경)
- [x] 대상 브랜치 = develop
- [x] ADR020 등록 + index.md 갱신
- [x] DEPLOY-RUNBOOK.md (infra 런북) + handoff 통합 가이드 매핑

## 관련 이슈

- Milestone: \`workflow/task/milestones/version/0.0.1v/milestone.md\` (Tier 1-확장 D1~D10)
- Product: \`workflow/task/pes/workspectrum/sdd/in-progress/product-infra-network.md\` + \`product-infra-deploy.md\`
- 의존: 없음 (독립). add04a1 branch는 본 PR 머지 후 삭제 권장

## 사용자 액션 (PR 머지 후 순차)

| # | 액션 | 사전 조건 |
| --- | --- | --- |
| U1 | D1 — Route53에서 \`thirdtool.dev\` 구매 | 없음 (handoff §14A) |
| U2 | D2 ACM 2-region 신청 + DNS 검증 | U1 (handoff §14B) |
| U3 | D3 ALB HTTPS 리스너 + 443 SG | U2 ap-ne-2 ISSUED (handoff §14C) |
| U4 | D4 Route53 api.thirdtool.dev → ALB | U3 (handoff §14E.1) |
| U5 | D5+D6 S3 + CloudFront + OAC | U2 us-e-1 ISSUED (handoff §14D) |
| U6 | D7 Route53 apex/www → CloudFront | U5 (handoff §14E.2) |
| U7 | 카카오·네이버 OAuth redirect URI 갱신 | 없음 (handoff §14E.4) |
| U8 | D10 FE \`.env.production\` 갱신 + GHA deploy-fe 첫 실행 | U6 (FE 레포 측) |