### PR TITLE
feat(deck,facade): Deck 응답에 axisId/axisName 노출 [Fix-Story 1]

### DIFF
--- a/src/main/java/com/example/thirdtool/Deck/application/service/DeckCommandService.java
+++ b/src/main/java/com/example/thirdtool/Deck/application/service/DeckCommandService.java
@@ -25,7 +25,9 @@ public class DeckCommandService {
     private final DeckHierarchyService deckHierarchyService;
 
     /**
-     * 덱 생성
+     * 덱 생성 (고아 덱 경로).
+     * 본 경로는 항상 axisId=null인 고아 Deck을 만든다. axis 결합 Deck 생성은
+     * Fix-Story 2의 신규 경로(POST /api/v1/learning-facade/axes/{axisId}/decks)를 사용한다.
      */
     public DeckResponse.Create create(DeckRequest.Create request, UserEntity user) {
         Deck parentDeck = resolveParent(request.parentDeckId());
@@ -36,7 +38,7 @@ public class DeckCommandService {
                 user);
 
         deckRepository.save(deck);
-        return DeckResponse.Create.of(deck);
+        return DeckResponse.Create.of(deck, null);
     }
 
     /**

--- a/src/main/java/com/example/thirdtool/Deck/application/service/DeckQueryService.java
+++ b/src/main/java/com/example/thirdtool/Deck/application/service/DeckQueryService.java
@@ -6,33 +6,49 @@ import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Deck.domain.model.Deck;
 import com.example.thirdtool.Deck.infrastructure.repository.DeckRepository;
 import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
-import lombok.RequiredArgsConstructor;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DeckQueryService {
 
     private final DeckRepository deckRepository;
+    private final LearningFacadeQueryService learningFacadeQueryService;
+
+    public DeckQueryService(
+            DeckRepository deckRepository,
+            // Deck ↔ LearningFacade 양방향 read 협력 (PACKAGE.md §6).
+            // LearningFacadeQueryService 또한 DeckQueryService에 의존하므로 @Lazy로 순환을 해소한다.
+            @Lazy LearningFacadeQueryService learningFacadeQueryService
+    ) {
+        this.deckRepository = deckRepository;
+        this.learningFacadeQueryService = learningFacadeQueryService;
+    }
 
     // ─── 외부 API ─────────────────────────────────────────
 
     /**
      * 덱 단건 조회.
      * 삭제된 덱 접근 시 DECK_ALREADY_DELETED 예외.
+     * axisId가 설정되어 있으면 cross-BC read로 axisName도 함께 동봉한다.
      */
     public DeckResponse.Detail findById(Long deckId) {
-        return DeckResponse.Detail.of(getActiveDeck(deckId));
+        Deck deck = getActiveDeck(deckId);
+        String axisName = resolveAxisName(deck.getAxisId());
+        return DeckResponse.Detail.of(deck, axisName);
     }
 
     /**
@@ -42,9 +58,11 @@ public class DeckQueryService {
     public DeckResponse.Page findRootDecks(Long userId, Pageable pageable) {
         Page<Deck> page = deckRepository.findRootDecksByUserId(userId, pageable);
 
+        Map<Long, String> axisNames = resolveAxisNames(page.getContent());
+
         List<DeckResponse.Summary> content = page.getContent()
                                                  .stream()
-                                                 .map(DeckResponse.Summary::of)
+                                                 .map(deck -> DeckResponse.Summary.of(deck, lookupAxisName(axisNames, deck.getAxisId())))
                                                  .toList();
 
         return new DeckResponse.Page(
@@ -75,11 +93,16 @@ public class DeckQueryService {
     public DeckResponse.SubDeckList findSubDecks(Long deckId) {
         Deck parent = getActiveDeck(deckId);
 
-        List<DeckResponse.Summary> subDecks = parent.getSubDecks()
-                                                    .stream()
-                                                    .filter(sub -> !sub.isDeleted())
-                                                    .map(DeckResponse.Summary::of)
-                                                    .toList();
+        List<Deck> activeSubDecks = parent.getSubDecks()
+                                          .stream()
+                                          .filter(sub -> !sub.isDeleted())
+                                          .toList();
+
+        Map<Long, String> axisNames = resolveAxisNames(activeSubDecks);
+
+        List<DeckResponse.Summary> subDecks = activeSubDecks.stream()
+                                                            .map(deck -> DeckResponse.Summary.of(deck, lookupAxisName(axisNames, deck.getAxisId())))
+                                                            .toList();
 
         return new DeckResponse.SubDeckList(deckId, subDecks);
     }
@@ -99,5 +122,34 @@ public class DeckQueryService {
             throw new BusinessException(ErrorCode.DECK_ALREADY_DELETED);
         }
         return deck;
+    }
+
+    /**
+     * Deck 컬렉션이 참조하는 axisId들을 모아 cross-BC read 1회로 axisName Map을 만든다.
+     * 고아 덱(axisId == null)은 lookup 대상이 아니다 — N+1 회피.
+     */
+    private Map<Long, String> resolveAxisNames(Collection<Deck> decks) {
+        Set<Long> axisIds = decks.stream()
+                                  .map(Deck::getAxisId)
+                                  .filter(Objects::nonNull)
+                                  .collect(java.util.stream.Collectors.toCollection(HashSet::new));
+        return learningFacadeQueryService.findAxisNamesByIds(axisIds);
+    }
+
+    /**
+     * 단건 axisId에 대응하는 axisName 조회. null axisId이면 null 반환 — DB 호출 회피.
+     */
+    private String resolveAxisName(Long axisId) {
+        if (axisId == null) {
+            return null;
+        }
+        return learningFacadeQueryService.findAxisNamesByIds(List.of(axisId)).get(axisId);
+    }
+
+    /**
+     * Map.of()로 만든 불변 Map은 get(null)에서 NPE를 던지므로 null axisId 가드가 필요.
+     */
+    private String lookupAxisName(Map<Long, String> axisNames, Long axisId) {
+        return axisId == null ? null : axisNames.get(axisId);
     }
 }

--- a/src/main/java/com/example/thirdtool/Deck/presentation/dto/DeckResponse.java
+++ b/src/main/java/com/example/thirdtool/Deck/presentation/dto/DeckResponse.java
@@ -16,9 +16,11 @@ public class DeckResponse {
             boolean onLibrary,
             LocalDateTime publishedAt,
             LocalDateTime lastAccessed,
-            LocalDateTime createdDate
+            LocalDateTime createdDate,
+            Long axisId,
+            String axisName
     ) {
-        public static Create of(Deck deck) {
+        public static Create of(Deck deck, String axisName) {
             return new Create(
                     deck.getId(),
                     deck.getName(),
@@ -27,7 +29,9 @@ public class DeckResponse {
                     deck.isOnLibrary(),
                     deck.getPublishedAt(),
                     deck.getLastAccessed(),
-                    deck.getCreatedDate()
+                    deck.getCreatedDate(),
+                    deck.getAxisId(),
+                    axisName
             );
         }
     }
@@ -44,9 +48,11 @@ public class DeckResponse {
             int cardCount,
             int subDeckCount,
             LocalDateTime createdDate,
-            LocalDateTime updatedDate
+            LocalDateTime updatedDate,
+            Long axisId,
+            String axisName
     ) {
-        public static Detail of(Deck deck) {
+        public static Detail of(Deck deck, String axisName) {
             return new Detail(
                     deck.getId(),
                     deck.getName(),
@@ -58,7 +64,9 @@ public class DeckResponse {
                     deck.getCards().size(),
                     deck.getSubDecks().size(),
                     deck.getCreatedDate(),
-                    deck.getUpdatedDate()
+                    deck.getUpdatedDate(),
+                    deck.getAxisId(),
+                    axisName
             );
         }
     }
@@ -71,9 +79,11 @@ public class DeckResponse {
             boolean onLibrary,
             LocalDateTime lastAccessed,
             int cardCount,
-            int subDeckCount
+            int subDeckCount,
+            Long axisId,
+            String axisName
     ) {
-        public static Summary of(Deck deck) {
+        public static Summary of(Deck deck, String axisName) {
             return new Summary(
                     deck.getId(),
                     deck.getName(),
@@ -81,7 +91,9 @@ public class DeckResponse {
                     deck.isOnLibrary(),
                     deck.getLastAccessed(),
                     deck.getCards().size(),
-                    deck.getSubDecks().size()
+                    deck.getSubDecks().size(),
+                    deck.getAxisId(),
+                    axisName
             );
         }
     }
@@ -141,4 +153,3 @@ public class DeckResponse {
         }
     }
 }
-

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,15 @@ public class LearningFacadeQueryService {
                         .map(LearningAxis::getId)
                         .toList())
                 .orElseGet(List::of);
+    }
+
+    /**
+     * Cross-BC read — Deck BC가 응답 DTO에 axisName을 동봉할 때 사용한다.
+     * 입력이 null/empty면 빈 Map. 미존재 axisId는 결과에 포함되지 않는다 (= 호출자가 null로 처리).
+     */
+    @Transactional(readOnly = true)
+    public Map<Long, String> findAxisNamesByIds(Collection<Long> axisIds) {
+        return facadeRepository.findAxisNamesByIds(axisIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeJpaRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface LearningFacadeJpaRepository extends JpaRepository<LearningFacade, Long> {
@@ -17,4 +19,16 @@ public interface LearningFacadeJpaRepository extends JpaRepository<LearningFacad
     Optional<LearningFacade> findByUserId(@Param("userId") Long userId);
 
     boolean existsByUserId(Long userId);
+
+    /**
+     * Cross-BC read — axisId 목록에 대응하는 (id, name) 쌍 일괄 조회.
+     * Deck BC가 응답 DTO에 axisName을 동봉할 때 사용. facade 컨텍스트 없이 axisId만으로 조회.
+     */
+    @Query("SELECT a.id AS id, a.name AS name FROM LearningAxis a WHERE a.id IN :axisIds")
+    List<AxisIdNameProjection> findAxisIdNamePairsByIdIn(@Param("axisIds") Collection<Long> axisIds);
+
+    interface AxisIdNameProjection {
+        Long getId();
+        String getName();
+    }
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepository.java
@@ -2,6 +2,8 @@ package com.example.thirdtool.LearningFacade.infrastructure.persistence;
 
 import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 
@@ -12,4 +14,10 @@ public interface LearningFacadeRepository {
     boolean existsByUserId(Long userId);
 
     LearningFacade save(LearningFacade facade);
+
+    /**
+     * Cross-BC read — axisId 집합에 대응하는 axisName Map을 반환한다.
+     * Deck BC가 응답 DTO에 axisName을 동봉할 때 사용. 미존재 axisId는 결과에 포함되지 않는다.
+     */
+    Map<Long, String> findAxisNamesByIds(Collection<Long> axisIds);
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryAdapter.java
@@ -4,7 +4,10 @@ import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,5 +29,17 @@ public class LearningFacadeRepositoryAdapter implements LearningFacadeRepository
     @Override
     public LearningFacade save(LearningFacade facade) {
         return jpa.save(facade);
+    }
+
+    @Override
+    public Map<Long, String> findAxisNamesByIds(Collection<Long> axisIds) {
+        if (axisIds == null || axisIds.isEmpty()) {
+            return Map.of();
+        }
+        return jpa.findAxisIdNamePairsByIdIn(axisIds).stream()
+                .collect(Collectors.toMap(
+                        LearningFacadeJpaRepository.AxisIdNameProjection::getId,
+                        LearningFacadeJpaRepository.AxisIdNameProjection::getName
+                ));
     }
 }

--- a/src/test/java/com/example/thirdtool/Deck/application/service/DeckQueryServiceAxisNameEnrichmentTest.java
+++ b/src/test/java/com/example/thirdtool/Deck/application/service/DeckQueryServiceAxisNameEnrichmentTest.java
@@ -1,0 +1,164 @@
+package com.example.thirdtool.Deck.application.service;
+
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.infrastructure.repository.DeckRepository;
+import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * DeckQueryService 단위 테스트 — Fix-Story 1: axisName enrichment.
+ *
+ * Mockist 전략 — Repository와 LearningFacadeQueryService(cross-BC) Mock,
+ * 도메인(Deck) + 응답 DTO 매핑은 실제 객체로 검증.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeckQueryService — Fix-Story 1 axisName enrichment")
+class DeckQueryServiceAxisNameEnrichmentTest {
+
+    @Mock
+    DeckRepository deckRepository;
+
+    @Mock
+    LearningFacadeQueryService learningFacadeQueryService;
+
+    @InjectMocks
+    DeckQueryService sut;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester-1", "encoded-pw", "닉네임", "tester1@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    private Deck axisDeck(Long deckId, Long axisId, String name) {
+        Deck deck = Deck.createFromAxis(user, axisId, name);
+        ReflectionTestUtils.setField(deck, "id", deckId);
+        return deck;
+    }
+
+    private Deck orphanDeck(Long deckId, String name) {
+        Deck deck = Deck.of(name, null, user);
+        ReflectionTestUtils.setField(deck, "id", deckId);
+        return deck;
+    }
+
+    // ─── findById ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("findById")
+    class FindById {
+
+        @Test
+        @DisplayName("axis 결합 덱 → axisId + axisName 모두 응답에 포함")
+        void axis_결합덱_axisName포함() {
+            Deck deck = axisDeck(100L, 10L, "백엔드 덱");
+            given(deckRepository.findById(100L)).willReturn(Optional.of(deck));
+            given(learningFacadeQueryService.findAxisNamesByIds(List.of(10L)))
+                    .willReturn(Map.of(10L, "백엔드"));
+
+            DeckResponse.Detail result = sut.findById(100L);
+
+            assertThat(result.deckId()).isEqualTo(100L);
+            assertThat(result.axisId()).isEqualTo(10L);
+            assertThat(result.axisName()).isEqualTo("백엔드");
+        }
+
+        @Test
+        @DisplayName("고아 덱 → axisId / axisName 모두 null (LearningFacade 호출 회피)")
+        void 고아덱_axisName_null() {
+            Deck deck = orphanDeck(100L, "고아 덱");
+            given(deckRepository.findById(100L)).willReturn(Optional.of(deck));
+
+            DeckResponse.Detail result = sut.findById(100L);
+
+            assertThat(result.axisId()).isNull();
+            assertThat(result.axisName()).isNull();
+            verify(learningFacadeQueryService, never()).findAxisNamesByIds(anyCollection());
+        }
+    }
+
+    // ─── findRootDecks ───────────────────────────────────────
+
+    @Nested
+    @DisplayName("findRootDecks")
+    class FindRootDecks {
+
+        @Test
+        @DisplayName("axis 결합 덱과 고아 덱 혼재 — 결합 덱만 lookup 대상 (N+1 회피)")
+        void 혼재시_고아덱_lookup제외() {
+            Deck axisD = axisDeck(101L, 10L, "축 결합 덱");
+            Deck orphan = orphanDeck(102L, "고아 덱");
+            Pageable pageable = PageRequest.of(0, 20);
+            given(deckRepository.findRootDecksByUserId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(axisD, orphan), pageable, 2));
+            given(learningFacadeQueryService.findAxisNamesByIds(Set.of(10L)))
+                    .willReturn(Map.of(10L, "백엔드"));
+
+            DeckResponse.Page result = sut.findRootDecks(1L, pageable);
+
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.content().get(0).axisId()).isEqualTo(10L);
+            assertThat(result.content().get(0).axisName()).isEqualTo("백엔드");
+            assertThat(result.content().get(1).axisId()).isNull();
+            assertThat(result.content().get(1).axisName()).isNull();
+        }
+
+        @Test
+        @DisplayName("동일 axis 다중 덱 — lookup 1회 (Set으로 중복 제거)")
+        void 동일axis_다중덱_lookup1회() {
+            Deck d1 = axisDeck(101L, 10L, "덱1");
+            Deck d2 = axisDeck(102L, 10L, "덱2");
+            Pageable pageable = PageRequest.of(0, 20);
+            given(deckRepository.findRootDecksByUserId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(d1, d2), pageable, 2));
+            given(learningFacadeQueryService.findAxisNamesByIds(Set.of(10L)))
+                    .willReturn(Map.of(10L, "백엔드"));
+
+            DeckResponse.Page result = sut.findRootDecks(1L, pageable);
+
+            assertThat(result.content()).extracting(DeckResponse.Summary::axisName)
+                    .containsExactly("백엔드", "백엔드");
+            verify(learningFacadeQueryService).findAxisNamesByIds(Set.of(10L));
+        }
+
+        @Test
+        @DisplayName("빈 페이지 — LearningFacade 호출 회피 (빈 Set 인자)")
+        void 빈페이지() {
+            Pageable pageable = PageRequest.of(0, 20);
+            given(deckRepository.findRootDecksByUserId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(), pageable, 0));
+            given(learningFacadeQueryService.findAxisNamesByIds(Set.of()))
+                    .willReturn(Map.of());
+
+            DeckResponse.Page result = sut.findRootDecks(1L, pageable);
+
+            assertThat(result.content()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,6 +64,59 @@ class LearningFacadeRepositoryTest {
         Optional<LearningFacade> result = repository.findByUserId(999_999L);
 
         // then
+        assertThat(result).isEmpty();
+    }
+
+    // ─── findAxisNamesByIds — cross-BC read (Fix-Story 1) ─────────────
+
+    @Test
+    @DisplayName("findAxisNamesByIds — 여러 axisId 입력 시 (id, name) Map 반환")
+    void findAxisNamesByIds_정상() {
+        // given
+        UserEntity user = UserEntity.ofLocal(
+                "axis-name-tester", "encoded-pw", "닉네임", "axis@example.com");
+        em.persist(user);
+
+        LearningFacade facade = LearningFacade.create(user, "백엔드 개발자");
+        facade.addAxis("시스템 설계");
+        facade.addAxis("Spring 내부");
+        em.persist(facade);
+        em.flush();
+
+        List<Long> axisIds = facade.getAxes().stream()
+                .map(axis -> axis.getId())
+                .toList();
+
+        // when
+        Map<Long, String> result = repository.findAxisNamesByIds(axisIds);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(axisIds.get(0))).isEqualTo("시스템 설계");
+        assertThat(result.get(axisIds.get(1))).isEqualTo("Spring 내부");
+    }
+
+    @Test
+    @DisplayName("findAxisNamesByIds — 미존재 axisId는 결과 Map에 포함되지 않음")
+    void findAxisNamesByIds_미존재() {
+        // when
+        Map<Long, String> result = repository.findAxisNamesByIds(List.of(99_999L, 88_888L));
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findAxisNamesByIds — null 입력은 빈 Map (DB 호출 회피)")
+    void findAxisNamesByIds_null() {
+        Map<Long, String> result = repository.findAxisNamesByIds(null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findAxisNamesByIds — 빈 입력은 빈 Map (DB 호출 회피)")
+    void findAxisNamesByIds_빈입력() {
+        Map<Long, String> result = repository.findAxisNamesByIds(List.of());
         assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
## 개요

`DeckResponse.Summary` / `Detail` / `Create`에 `axisId`(Long?) + `axisName`(String?) 필드 추가. 고아 덱은 둘 다 null. FE가 응답만으로 축별 덱 그룹핑이 가능해진다(brainstorming `refactor-fe-intent.md` 후보 A1).

## 왜 / 설계 결정

원본 SDD `product-learningFacade.md`의 "Deck↔Axis는 raw `Long` 컬럼 1개로 표현" 결정을 **read-model 노출로 한정 폐기**. 도메인 연관 승격(거부 Option B)이 아닌 응답 레이어에서만 가시화 — BC 결합도 상승을 회피.

구현 트레이드오프:
- `LearningFacadeJpaRepository`에 axis 프로젝션 JPQL 추가(Spring Data 인터페이스 프로젝션). `DeckQueryRepository`에 cross-BC QueryDSL JOIN 도입은 거부 — Deck infra가 LearningFacade Q클래스를 import하는 선례가 없고 BC 결합도 상승 우려.
- `DeckQueryService` ↔ `LearningFacadeQueryService` 양방향 read 협력. 순환 DI는 `@Lazy`로 해소 (`docs/PACKAGE.md` §6 'BC ↔ BC 양방향' 패턴 정합).
- `DeckSummaryRow` / `searchDecks`는 외부 호출처 없음(검증 완료) — 본 PR 범위 제외, 사용 시점에 별도 갱신.

Refs SDD: `workflow/task/fix/sdd/version/0.0.2v/fix-deck-axis-visibility.md` §4.1, §8.3 (Fix-Story 1)

## 작업 내용

- feat(facade): `LearningFacadeRepository.findAxisNamesByIds(Collection<Long>) → Map<Long, String>` 추가 (port + adapter + JpaRepository 인터페이스 프로젝션)
- feat(facade): `LearningFacadeQueryService.findAxisNamesByIds(...)` 공개 — Deck BC가 호출
- feat(deck): `DeckResponse.Summary` / `Detail` / `Create`에 `axisId`, `axisName` 필드 추가, 팩토리 시그니처 `.of(deck, axisName)`로 변경
- feat(deck): `DeckQueryService` — `@Lazy LearningFacadeQueryService` 협력자 주입, N+1 회피 일괄 enrichment (Set 중복 제거, null axisId lookup 회피)
- feat(deck): `DeckCommandService.create` — 고아 덱 경로이므로 `axisName=null` 명시 전달
- test(facade): `LearningFacadeRepositoryTest` +4 케이스 (정상 / 미존재 / null / 빈 입력)
- test(deck): `DeckQueryServiceAxisNameEnrichmentTest` 신규 — 단건 / 페이지 enrichment / 고아 덱 lookup 회피 / 동일 axis 다중 덱 lookup 1회

## 변경 유형
- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "...LearningFacadeRepositoryTest" --tests "...DeckQueryServiceAxisNameEnrichmentTest"` → BUILD SUCCESSFUL (모든 케이스 통과)
- `./gradlew test` (전체) → BUILD SUCCESSFUL (회귀 없음)

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] 모든 응답 record 패턴 + 정적 팩토리
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 — Fix-Story 5에서 일괄 반영 예정 (본 SDD §8.3 step 5)
- [x] BC 간 의존 방향 위반 없음 — Deck → LearningFacade (Application 경유 read) 신규 양방향. PACKAGE.md §6 'BC ↔ BC 양방향' 명시 패턴
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈
- Product: `workflow/task/pes/workspectrum/sdd/done/product-learningFacade.md` (Deck↔Axis 표현 결정 부분 폐기)
- SDD: `workflow/task/fix/sdd/version/0.0.2v/fix-deck-axis-visibility.md`
- Brainstorming: `workflow/task/pes/brainstorming/0.0.2v/refactor-fe-intent.md` (후보 A1)
- Fix Story: 1 / 5