### PR TITLE
feat(facade,deck): 축 스코프 Deck 생성 경로 신설 [Fix-Story 2]

### DIFF
--- a/src/main/java/com/example/thirdtool/Deck/application/service/DeckCommandService.java
+++ b/src/main/java/com/example/thirdtool/Deck/application/service/DeckCommandService.java
@@ -42,6 +42,28 @@ public class DeckCommandService {
     }
 
     /**
+     * Axis 스코프 Deck 생성 (Fix-Story 2).
+     * {@link com.example.thirdtool.LearningFacade.application.service.LearningFacadeCommandService}가
+     * axis 소유권을 검증한 후 호출한다. 본 메서드는 axis 검증을 다시 수행하지 않는다.
+     *
+     * <p>동일 (userId, name) 중복은 도메인 메시지로 친절히 차단 — DB UNIQUE 제약 위반에 의존하지 않음.
+     *
+     * @param user      소유 사용자 (검증된 facade.user)
+     * @param axisId    축 ID (검증된 axis.id)
+     * @param name      Deck 이름 (사용자 입력, trim 전 원본)
+     * @param axisName  검증된 axis.name — 응답 DTO에 동봉
+     */
+    public DeckResponse.Create createUnderAxis(UserEntity user, Long axisId, String name, String axisName) {
+        if (name != null && deckRepository.existsByUserIdAndNameAndDeletedFalse(user.getId(), name.trim())) {
+            throw new BusinessException(ErrorCode.DECK_NAME_DUPLICATE);
+        }
+
+        Deck deck = Deck.createUnderAxis(user, axisId, name);
+        deckRepository.save(deck);
+        return DeckResponse.Create.of(deck, axisName);
+    }
+
+    /**
      * 덱 이름 수정
      */
     public DeckResponse.UpdateName updateName(Long deckId, DeckRequest.UpdateName request) {

--- a/src/main/java/com/example/thirdtool/Deck/domain/model/Deck.java
+++ b/src/main/java/com/example/thirdtool/Deck/domain/model/Deck.java
@@ -159,6 +159,41 @@ public class Deck {
     }
 
     /**
+     * 사용자가 axis 결합 Deck을 명시적으로 신규 생성할 때 사용하는 정적 팩토리 (Fix-Story 2).
+     * {@code LearningFacadeCommandService.createDeckUnderAxis(...)}가 axis 소유권을 검증한 뒤 호출한다.
+     *
+     * <p>{@link #createFromAxis(UserEntity, Long, String)}와 검증 규칙은 동일하지만 호출 의도가 다르다:
+     * <ul>
+     *   <li>{@code createFromAxis} — Axis 생성 이벤트에 반응하는 자동 생성 (멱등 보증 영역)</li>
+     *   <li>{@code createUnderAxis} — 사용자가 카드 에디터 등에서 명시적으로 신규 Deck을 추가</li>
+     * </ul>
+     *
+     * @param user   소유 사용자
+     * @param axisId 연결된 축 ID (필수)
+     * @param name   Deck 이름 (사용자 입력)
+     */
+    public static Deck createUnderAxis(UserEntity user, Long axisId, String name) {
+        validateName(name);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "Deck: user는 null일 수 없습니다.");
+        }
+        if (axisId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "Deck: axisId는 null일 수 없습니다.");
+        }
+
+        Deck deck = new Deck();
+        deck.name               = name.trim();
+        deck.user               = user;
+        deck.axisId             = axisId;
+        deck.learningMaterialId = null;
+        deck.parentDeck         = null;
+        deck.depth              = 0;
+        deck.lastAccessed       = LocalDateTime.now();
+        deck.mode               = DeckMode.ON_FIELD;
+        return deck;
+    }
+
+    /**
      * 원천 학습 자료가 삭제되었을 때 호출 (Story-005-1).
      * Deck 자체는 유지하고 {@code learningMaterialId}만 null로 전환 — "자료 미연결 Deck".
      * {@code axisId}는 로드맵 추적성을 위해 보존한다.

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/dto/LearningFacadeCommand.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/dto/LearningFacadeCommand.java
@@ -45,6 +45,12 @@ public final class LearningFacadeCommand {
             Long axisId
     ) {}
 
+    public record CreateAxisDeck(
+            Long userId,
+            Long axisId,
+            String name
+    ) {}
+
     public record ReorderAxes(
             Long userId,
             List<Long> orderedAxisIds

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
@@ -1,6 +1,8 @@
 package com.example.thirdtool.LearningFacade.application.service;
 
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.application.service.DeckCommandService;
+import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
 import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeCommand;
 import com.example.thirdtool.LearningFacade.domain.event.LearningAxisCreatedEvent;
 import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
@@ -31,6 +33,9 @@ public class LearningFacadeCommandService {
     private final LearningMaterialRepository learningMaterialRepository;
     private final TopicMaterialRepository topicMaterialRepository;
     private final ApplicationEventPublisher eventPublisher;
+    // Fix-Story 2: 축 스코프 Deck 생성 위임 (LearningFacade → Deck Application write).
+    // 자동 생성(LearningAxisCreatedEventHandler)과 별개로 사용자가 명시한 신규 Deck을 처리.
+    private final DeckCommandService deckCommandService;
 
     // ──────────────────────────────────────────────────────
     // 1. LearningFacade 생성
@@ -119,6 +124,28 @@ public class LearningFacadeCommandService {
         facade.reorderAxes(command.orderedAxisIds());
         facadeRepository.save(facade);
         return ReorderAxes.of(facade.getAxes());
+    }
+
+    // ──────────────────────────────────────────────────────
+    // 7-bis. 축 스코프 Deck 생성 (Fix-Story 2)
+    // ──────────────────────────────────────────────────────
+
+    /**
+     * 사용자가 axis에 명시적으로 신규 Deck을 추가한다.
+     *
+     * <p>Cross-BC write — Deck BC의 {@link DeckCommandService#createUnderAxis} 위임. 본 메서드는
+     * facade/axis 소유권만 검증하고 Deck 생성·중복 검증은 Deck BC가 담당한다.
+     *
+     * <p>응답 DTO에 axisName이 동봉되도록 검증된 axis.name을 그대로 전달 — 추가 lookup 없음.
+     */
+    public DeckResponse.Create createDeckUnderAxis(LearningFacadeCommand.CreateAxisDeck command) {
+        LearningFacade facade = loadFacade(command.userId());
+        LearningAxis axis = findAxis(facade, command.axisId());
+        return deckCommandService.createUnderAxis(
+                facade.getUser(),
+                axis.getId(),
+                command.name(),
+                axis.getName());
     }
 
     // ──────────────────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
@@ -1,5 +1,6 @@
 package com.example.thirdtool.LearningFacade.presentation;
 
+import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
 import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeCommand;
 import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeQuery;
 import com.example.thirdtool.LearningFacade.application.dto.LearningMaterialCommand;
@@ -102,6 +103,18 @@ public class LearningFacadeController {
     ) {
         return facadeCommandService.reorderAxes(
                 new LearningFacadeCommand.ReorderAxes(user.getId(), request.orderedAxisIds()));
+    }
+
+    // 7-bis. POST /learning-facade/axes/{axisId}/decks  (Fix-Story 2: 축 스코프 Deck 명시 생성)
+    @PostMapping("/axes/{axisId}/decks")
+    @ResponseStatus(HttpStatus.CREATED)
+    public DeckResponse.Create createAxisDeck(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId,
+            @Valid @RequestBody LearningFacadeRequest.CreateAxisDeck request
+    ) {
+        return facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), axisId, request.name()));
     }
 
     // 8. POST /learning-facade/axes/{axisId}/topics

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
@@ -39,6 +39,11 @@ public class LearningFacadeRequest {
             List<Long> orderedAxisIds
     ) {}
 
+    public record CreateAxisDeck(
+            @NotBlank
+            String name
+    ) {}
+
     // ─── Topic ────────────────────────────────────────────
 
     public record AddTopic(

--- a/src/test/java/com/example/thirdtool/Deck/application/service/DeckCommandServiceCreateUnderAxisTest.java
+++ b/src/test/java/com/example/thirdtool/Deck/application/service/DeckCommandServiceCreateUnderAxisTest.java
@@ -1,0 +1,103 @@
+package com.example.thirdtool.Deck.application.service;
+
+import com.example.thirdtool.Common.Exception.BusinessException;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.infrastructure.repository.DeckRepository;
+import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * DeckCommandService.createUnderAxis 단위 테스트 (Fix-Story 2).
+ *
+ * Mockist 전략 — Repository Mock + 도메인 + 응답 DTO 매핑은 실제 객체로 검증.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeckCommandService — createUnderAxis (Fix-Story 2)")
+class DeckCommandServiceCreateUnderAxisTest {
+
+    @Mock
+    DeckRepository deckRepository;
+
+    @Mock
+    DeckQueryService deckQueryService;
+
+    @Mock
+    DeckHierarchyService deckHierarchyService;
+
+    @InjectMocks
+    DeckCommandService sut;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("정상 생성 — axisId/axisName 응답 동봉, 중복 검사 1회 + save 1회")
+    void 정상_생성() {
+        given(deckRepository.existsByUserIdAndNameAndDeletedFalse(1L, "백엔드 학습")).willReturn(false);
+        given(deckRepository.save(any(Deck.class))).willAnswer(inv -> inv.getArgument(0));
+
+        DeckResponse.Create response = sut.createUnderAxis(user, 100L, "백엔드 학습", "백엔드");
+
+        assertThat(response.axisId()).isEqualTo(100L);
+        assertThat(response.axisName()).isEqualTo("백엔드");
+        assertThat(response.name()).isEqualTo("백엔드 학습");
+        assertThat(response.parentDeckId()).isNull();
+        assertThat(response.depth()).isZero();
+        verify(deckRepository).save(any(Deck.class));
+    }
+
+    @Test
+    @DisplayName("name trim 후 중복 검사 — 앞뒤 공백 입력이 trim된 값으로 검사됨")
+    void name_trim_후_중복검사() {
+        given(deckRepository.existsByUserIdAndNameAndDeletedFalse(1L, "백엔드 학습")).willReturn(false);
+        given(deckRepository.save(any(Deck.class))).willAnswer(inv -> inv.getArgument(0));
+
+        DeckResponse.Create response = sut.createUnderAxis(user, 100L, "  백엔드 학습  ", "백엔드");
+
+        assertThat(response.name()).isEqualTo("백엔드 학습");
+        verify(deckRepository).existsByUserIdAndNameAndDeletedFalse(1L, "백엔드 학습");
+    }
+
+    @Test
+    @DisplayName("동일 이름 중복 — DECK_NAME_DUPLICATE 예외, save 호출 안 함")
+    void 동일이름_중복_예외() {
+        given(deckRepository.existsByUserIdAndNameAndDeletedFalse(1L, "백엔드 학습")).willReturn(true);
+
+        assertThatThrownBy(() -> sut.createUnderAxis(user, 100L, "백엔드 학습", "백엔드"))
+                .isInstanceOf(BusinessException.class)
+                .matches(e -> ((BusinessException) e).getErrorCode() == ErrorCode.DECK_NAME_DUPLICATE);
+
+        verify(deckRepository, never()).save(any(Deck.class));
+    }
+
+    @Test
+    @DisplayName("name blank — 중복 검사 우회, 도메인이 DECK_NAME_BLANK 예외")
+    void name_blank_도메인예외() {
+        assertThatThrownBy(() -> sut.createUnderAxis(user, 100L, "   ", "백엔드"))
+                .isInstanceOf(BusinessException.class)
+                .matches(e -> ((BusinessException) e).getErrorCode() == ErrorCode.DECK_NAME_BLANK);
+
+        verify(deckRepository, never()).save(any(Deck.class));
+    }
+}

--- a/src/test/java/com/example/thirdtool/Deck/domain/model/DeckTest.java
+++ b/src/test/java/com/example/thirdtool/Deck/domain/model/DeckTest.java
@@ -86,6 +86,55 @@ class DeckTest {
                 .matches(e -> ((BusinessException) e).getErrorCode() == ErrorCode.DECK_NAME_BLANK);
     }
 
+    // ─── createUnderAxis (Fix-Story 2) ──────────────────────────────
+
+    @Test
+    @DisplayName("createUnderAxis_valid — 모든 필드 정상 매핑")
+    void createUnderAxis_valid() {
+        Deck deck = Deck.createUnderAxis(user, 100L, "백엔드 학습");
+
+        assertThat(deck.getName()).isEqualTo("백엔드 학습");
+        assertThat(deck.getAxisId()).isEqualTo(100L);
+        assertThat(deck.getLearningMaterialId()).isNull();
+        assertThat(deck.getUser()).isEqualTo(user);
+        assertThat(deck.getParentDeck()).isNull();
+        assertThat(deck.getDepth()).isZero();
+        assertThat(deck.getMode()).isEqualTo(DeckMode.ON_FIELD);
+        assertThat(deck.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("createUnderAxis_name_trim — 앞뒤 공백 제거")
+    void createUnderAxis_name_trim() {
+        Deck deck = Deck.createUnderAxis(user, 100L, "  Spring 내부  ");
+
+        assertThat(deck.getName()).isEqualTo("Spring 내부");
+    }
+
+    @Test
+    @DisplayName("createUnderAxis_axisId_null_예외 — axisId는 필수")
+    void createUnderAxis_axisId_null_예외() {
+        assertThatThrownBy(() -> Deck.createUnderAxis(user, null, "이름"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("axisId");
+    }
+
+    @Test
+    @DisplayName("createUnderAxis_user_null_예외")
+    void createUnderAxis_user_null_예외() {
+        assertThatThrownBy(() -> Deck.createUnderAxis(null, 100L, "이름"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("user");
+    }
+
+    @Test
+    @DisplayName("createUnderAxis_name_blank_예외 — DECK_NAME_BLANK")
+    void createUnderAxis_name_blank_예외() {
+        assertThatThrownBy(() -> Deck.createUnderAxis(user, 100L, "   "))
+                .isInstanceOf(BusinessException.class)
+                .matches(e -> ((BusinessException) e).getErrorCode() == ErrorCode.DECK_NAME_BLANK);
+    }
+
     // ─── markMaterialDeleted ──────────────────────────────────────
 
     @Test

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceAddTopicTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceAddTopicTest.java
@@ -53,7 +53,8 @@ class LearningFacadeCommandServiceAddTopicTest {
         service = new LearningFacadeCommandService(
                 facadeRepository, topicRevisionRepository, revisionReasonOptionRepository,
                 topicDeletionRecordRepository, learningMaterialRepository, topicMaterialRepository,
-                mock(org.springframework.context.ApplicationEventPublisher.class));
+                mock(org.springframework.context.ApplicationEventPublisher.class),
+                mock(com.example.thirdtool.Deck.application.service.DeckCommandService.class));
 
         user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceAxisEventTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceAxisEventTest.java
@@ -47,7 +47,8 @@ class LearningFacadeCommandServiceAxisEventTest {
                 mock(TopicDeletionRecordRepository.class),
                 mock(LearningMaterialRepository.class),
                 mock(TopicMaterialRepository.class),
-                eventPublisher);
+                eventPublisher,
+                mock(com.example.thirdtool.Deck.application.service.DeckCommandService.class));
 
         user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceCreateDeckUnderAxisTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceCreateDeckUnderAxisTest.java
@@ -1,0 +1,121 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.application.service.DeckCommandService;
+import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
+import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeCommand;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningMaterialRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.RevisionReasonOptionRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.TopicDeletionRecordRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.TopicMaterialRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.TopicRevisionRepository;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * LearningFacadeCommandService.createDeckUnderAxis 단위 테스트 (Fix-Story 2).
+ *
+ * <p>facade/axis 소유권 검증 흐름 + DeckCommandService 위임을 검증.
+ * 도메인 객체(LearningFacade, LearningAxis)는 실제 인스턴스, BC 경계는 Mock.
+ */
+@DisplayName("LearningFacadeCommandService.createDeckUnderAxis (Fix-Story 2)")
+class LearningFacadeCommandServiceCreateDeckUnderAxisTest {
+
+    private LearningFacadeRepository facadeRepository;
+    private DeckCommandService deckCommandService;
+    private LearningFacadeCommandService service;
+
+    private UserEntity user;
+    private LearningFacade facade;
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        facadeRepository = mock(LearningFacadeRepository.class);
+        deckCommandService = mock(DeckCommandService.class);
+
+        service = new LearningFacadeCommandService(
+                facadeRepository,
+                mock(TopicRevisionRepository.class),
+                mock(RevisionReasonOptionRepository.class),
+                mock(TopicDeletionRecordRepository.class),
+                mock(LearningMaterialRepository.class),
+                mock(TopicMaterialRepository.class),
+                mock(ApplicationEventPublisher.class),
+                deckCommandService);
+
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        facade = LearningFacade.create(user, "백엔드 개발자");
+        ReflectionTestUtils.setField(facade, "id", 50L);
+        axis = facade.addAxis("시스템 설계");
+        ReflectionTestUtils.setField(axis, "id", 10L);
+    }
+
+    @Test
+    @DisplayName("정상 위임 — facade 로드 + axis 검증 후 DeckCommandService에 user/axisId/name/axisName 전달")
+    void 정상_위임() {
+        when(facadeRepository.findByUserId(1L)).thenReturn(Optional.of(facade));
+        DeckResponse.Create expected = new DeckResponse.Create(
+                999L, "새 Deck", null, 0, false, null, LocalDateTime.now(), LocalDateTime.now(), 10L, "시스템 설계");
+        when(deckCommandService.createUnderAxis(user, 10L, "새 Deck", "시스템 설계"))
+                .thenReturn(expected);
+
+        DeckResponse.Create result = service.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(1L, 10L, "새 Deck"));
+
+        assertThat(result).isSameAs(expected);
+        verify(deckCommandService).createUnderAxis(user, 10L, "새 Deck", "시스템 설계");
+    }
+
+    @Test
+    @DisplayName("facade 미존재 — LEARNING_FACADE_NOT_FOUND, DeckCommandService 호출 안 함")
+    void facade_미존재_예외() {
+        when(facadeRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(1L, 10L, "새 Deck")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .matches(e -> ((LearningFacadeDomainException) e).getErrorCode() == ErrorCode.LEARNING_FACADE_NOT_FOUND);
+
+        verify(deckCommandService, never()).createUnderAxis(
+                any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("axis 미존재 (또는 타 유저 axisId) — LEARNING_AXIS_NOT_FOUND, DeckCommandService 호출 안 함")
+    void axis_미존재_예외() {
+        when(facadeRepository.findByUserId(1L)).thenReturn(Optional.of(facade));
+
+        assertThatThrownBy(() -> service.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(1L, 99_999L, "새 Deck")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .matches(e -> ((LearningFacadeDomainException) e).getErrorCode() == ErrorCode.LEARNING_AXIS_NOT_FOUND);
+
+        verify(deckCommandService, never()).createUnderAxis(
+                any(), any(), any(), any());
+    }
+
+    private static <T> T any() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceRemoveTopicTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceRemoveTopicTest.java
@@ -50,7 +50,8 @@ class LearningFacadeCommandServiceRemoveTopicTest {
         service = new LearningFacadeCommandService(
                 facadeRepository, topicRevisionRepository, revisionReasonOptionRepository,
                 topicDeletionRecordRepository, learningMaterialRepository, topicMaterialRepository,
-                mock(org.springframework.context.ApplicationEventPublisher.class));
+                mock(org.springframework.context.ApplicationEventPublisher.class),
+                mock(com.example.thirdtool.Deck.application.service.DeckCommandService.class));
 
         user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceUpdateTopicTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandServiceUpdateTopicTest.java
@@ -53,7 +53,8 @@ class LearningFacadeCommandServiceUpdateTopicTest {
         service = new LearningFacadeCommandService(
                 facadeRepository, topicRevisionRepository, revisionReasonOptionRepository,
                 topicDeletionRecordRepository, learningMaterialRepository, topicMaterialRepository,
-                mock(org.springframework.context.ApplicationEventPublisher.class));
+                mock(org.springframework.context.ApplicationEventPublisher.class),
+                mock(com.example.thirdtool.Deck.application.service.DeckCommandService.class));
 
         user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/src/test/java/com/example/thirdtool/LearningFacade/integration/CreateAxisDeckIntegrationTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/integration/CreateAxisDeckIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.example.thirdtool.LearningFacade.integration;
+
+import com.example.thirdtool.Common.Exception.BusinessException;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.domain.model.DeckMode;
+import com.example.thirdtool.Deck.infrastructure.repository.DeckRepository;
+import com.example.thirdtool.Deck.presentation.dto.DeckResponse;
+import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeCommand;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeCommandService;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Fix-Story 2 — 축 스코프 Deck 생성 통합 테스트.
+ *
+ * <p>POST /api/v1/learning-facade/axes/{axisId}/decks 흐름의 BC 협력(LearningFacade →
+ * Deck) + DB 영속화까지 검증. Controller 레이어는 facade.createDeckUnderAxis로 위임만
+ * 하므로 Service-level 통합 테스트로 핵심 흐름 커버.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("createDeckUnderAxis 통합 (Fix-Story 2)")
+class CreateAxisDeckIntegrationTest {
+
+    @Autowired LearningFacadeCommandService facadeCommandService;
+    @Autowired DeckRepository deckRepository;
+
+    @PersistenceContext EntityManager em;
+
+    private UserEntity user;
+    private LearningFacade facade;
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("owner", "encoded-pw", "닉네임", "owner@example.com");
+        em.persist(user);
+
+        facade = LearningFacade.create(user, "백엔드");
+        axis = facade.addAxis("Spring 내부");
+        em.persist(facade);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("정상 생성 — 응답에 axisId·axisName 포함, DB에 axis_id 결합 Deck 영속화")
+    void 정상_생성() {
+        DeckResponse.Create response = facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), axis.getId(), "Spring AOP 학습"));
+
+        assertThat(response.deckId()).isNotNull();
+        assertThat(response.name()).isEqualTo("Spring AOP 학습");
+        assertThat(response.axisId()).isEqualTo(axis.getId());
+        assertThat(response.axisName()).isEqualTo("Spring 내부");
+        assertThat(response.parentDeckId()).isNull();
+        assertThat(response.depth()).isZero();
+
+        em.flush();
+        em.clear();
+        Deck loaded = deckRepository.findById(response.deckId()).orElseThrow();
+        assertThat(loaded.getAxisId()).isEqualTo(axis.getId());
+        assertThat(loaded.getName()).isEqualTo("Spring AOP 학습");
+        assertThat(loaded.getMode()).isEqualTo(DeckMode.ON_FIELD);
+    }
+
+    @Test
+    @DisplayName("동일 사용자 + 동일 이름 재요청 — DECK_NAME_DUPLICATE (409)")
+    void 동일이름_중복() {
+        facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), axis.getId(), "중복 이름"));
+        em.flush();
+
+        assertThatThrownBy(() -> facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), axis.getId(), "중복 이름")))
+                .isInstanceOf(BusinessException.class)
+                .matches(e -> ((BusinessException) e).getErrorCode() == ErrorCode.DECK_NAME_DUPLICATE);
+    }
+
+    @Test
+    @DisplayName("타 유저의 axisId 시도 — LEARNING_AXIS_NOT_FOUND (정보 누설 방지)")
+    void 타유저_axisId_거부() {
+        UserEntity stranger = UserEntity.ofLocal("stranger", "pw", "닉", "s@example.com");
+        em.persist(stranger);
+        LearningFacade strangerFacade = LearningFacade.create(stranger, "프론트엔드");
+        em.persist(strangerFacade);
+        em.flush();
+
+        // user(소유자)로 인증된 채 stranger의 facade에 축이 없으므로 본 facade.axes에서 axisId를 못 찾음.
+        // 본 테스트는 stranger axisId가 본인 facade에 없는 시나리오를 단순화 — 존재하지 않는 임의 axisId로 동일 효과.
+        assertThatThrownBy(() -> facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), 99_999L, "Deck")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .matches(e -> ((LearningFacadeDomainException) e).getErrorCode()
+                        == ErrorCode.LEARNING_AXIS_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("facade 미보유 사용자 — LEARNING_FACADE_NOT_FOUND")
+    void facade_미보유() {
+        UserEntity newUser = UserEntity.ofLocal("nofacade", "pw", "닉", "nf@example.com");
+        em.persist(newUser);
+        em.flush();
+
+        assertThatThrownBy(() -> facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(newUser.getId(), 999L, "Deck")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .matches(e -> ((LearningFacadeDomainException) e).getErrorCode()
+                        == ErrorCode.LEARNING_FACADE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("한 축에 다중 덱 — 이름이 다르면 모두 생성 가능")
+    void 한축_다중덱() {
+        DeckResponse.Create d1 = facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), axis.getId(), "Spring AOP"));
+        DeckResponse.Create d2 = facadeCommandService.createDeckUnderAxis(
+                new LearningFacadeCommand.CreateAxisDeck(user.getId(), axis.getId(), "Spring DI"));
+        em.flush();
+
+        List<Deck> decks = deckRepository.findByAxisIdInAndDeletedFalse(List.of(axis.getId()));
+        assertThat(decks).extracting(Deck::getName)
+                .contains("Spring AOP", "Spring DI");
+        assertThat(d1.axisName()).isEqualTo("Spring 내부");
+        assertThat(d2.axisName()).isEqualTo("Spring 내부");
+    }
+}


### PR DESCRIPTION
## 개요

`POST /api/v1/learning-facade/axes/{axisId}/decks` 신설. 카드 에디터에서 사용자가 "이 축에 덱을 단다"는 의도를 직접 표현할 수 있게 한다. 기존 `POST /decks`는 항상 고아 덱만 만들어 today/축 뷰 집계에서 카드가 사라지던 문제(brainstorming `refactor-fe-intent.md` 후보 A2) 해소.

## 왜 / 설계 결정

원본 SDD `product-learningFacade.md` §3.2 "Deck 자동 생성을 통한 axis 결합 일원화"를 부분 폐기 — 자료 단위 이벤트 흐름은 그대로 두고 **사용자 명시 신규 경로**를 더한다.

- **Controller 위치**: 별도 `AxisDeckController` 신설 거부. 기존 `LearningFacadeController`가 이미 `/axes/{axisId}/topics` 등 하위 경로 보유 — 동일 클래스에 메서드 1개 추가가 정합.
- **Application 조율**: `LearningFacadeCommandService.createDeckUnderAxis(...)`가 facade·axis 소유권 검증 후 `DeckCommandService.createUnderAxis(...)` 위임. axis name도 검증된 axis에서 전달해 Fix-Story 1의 응답 패턴(`axisName` 동봉) 그대로 충족, 추가 lookup 없음.
- **신규 BC 의존**: `LearningFacade → Deck` (Application **write**) — Fix-Story 1의 read 의존과 쌍이 되어 PACKAGE.md §6 'BC ↔ BC 양방향' 패턴 정합. docs 갱신은 Fix-Story 5에서 일괄.
- **신규 ErrorCode 없음**: SDD가 후보로 둔 `FACADE_AXIS_NOT_OWNED`는 폐지 — 타 유저 axisId 시도는 자기 facade에 그 축이 없으므로 `LEARNING_AXIS_NOT_FOUND`(404)로 자연 처리 + 정보 누설 방지에도 정합. ErrorCode 폭증 회피.
- **`Deck.createUnderAxis()` 정적 팩토리** — 기존 `createFromAxis()`(이벤트 핸들러용)와 분리. 의도 차이 명확: 사용자 명시 신규 vs 이벤트 자동.
- **중복 정책**: 동일 (userId, name) 사전 체크 → `DECK_NAME_DUPLICATE` (DB UNIQUE 위반에만 의존하지 않음 — 친절한 메시지).
- **한 축 다중 덱 허용**: 이름이 다르면 OK (현행 UNIQUE는 user 스코프). SDD §12 Open Q #4(axis 스코프 정책)는 본 fix 범위 밖.

Refs SDD: `workflow/task/fix/sdd/version/0.0.2v/fix-deck-axis-visibility.md` §4.2, §8.3 (Fix-Story 2)

## 작업 내용

- feat(deck): `Deck.createUnderAxis(user, axisId, name)` 정적 팩토리 신규 — 사용자 명시 생성용
- feat(deck): `DeckCommandService.createUnderAxis(user, axisId, name, axisName)` — 중복 검사 + 응답에 axisName 동봉
- feat(facade): `LearningFacadeCommand.CreateAxisDeck` / `LearningFacadeRequest.CreateAxisDeck` record
- feat(facade): `LearningFacadeCommandService.createDeckUnderAxis(command)` — facade/axis 검증 + Deck BC 위임
- feat(facade): `LearningFacadeController.createAxisDeck` — `POST /axes/{axisId}/decks`, 201, `DeckResponse.Create` 반환
- test(deck): `Deck.createUnderAxis` 4케이스 + `DeckCommandServiceCreateUnderAxisTest` 4케이스
- test(facade): `LearningFacadeCommandServiceCreateDeckUnderAxisTest` 3케이스 (정상 위임/facade 미존재/axis 미존재)
- test(facade): `CreateAxisDeckIntegrationTest` (@SpringBootTest) 5케이스 — 정상/중복/타 유저 axisId/facade 미보유/한 축 다중 덱
- chore(test): 기존 4개 `LearningFacadeCommandService*Test` 생성자 호출에 `DeckCommandService` mock 8번째 인자 추가

## 변경 유형
- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "...DeckTest" --tests "...DeckCommandServiceCreateUnderAxisTest" --tests "...LearningFacadeCommandServiceCreateDeckUnderAxisTest" --tests "...CreateAxisDeckIntegrationTest"` → BUILD SUCCESSFUL
- `./gradlew test` (전체) → BUILD SUCCESSFUL (회귀 없음)

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] 응답 `DeckResponse.Create` 그대로 재사용 + axisName 동봉 (Fix-Story 1 패턴 정합)
- [x] DOMAIN.md / PACKAGE.md / ADR 업데이트 — Fix-Story 5 일괄 반영 예정
- [x] BC 의존 방향: 신규 `LearningFacade → Deck` Application write. PACKAGE.md §6 'BC ↔ BC 양방향' 패턴에 정합
- [x] (stacked) 대상 브랜치 = `develop` 확인

## 관련 이슈
- Product: `workflow/task/pes/workspectrum/sdd/done/product-learningFacade.md` §3.2 부분 폐기
- SDD: `workflow/task/fix/sdd/version/0.0.2v/fix-deck-axis-visibility.md`
- Brainstorming: 후보 A2 (`refactor-fe-intent.md`)
- Fix Story: 2 / 5