### PR TITLE
feat(card,review): 축 스코프 Card 단일 read-model + today 위임 [Fix-Story 3]

### DIFF
--- a/src/main/java/com/example/thirdtool/Card/application/service/CardQueryService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardQueryService.java
@@ -4,6 +4,7 @@ package com.example.thirdtool.Card.application.service;
 import com.example.thirdtool.Card.domain.exception.CardDomainException;
 import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.CardRelationFinder;
+import com.example.thirdtool.Card.domain.model.CardStatus;
 import com.example.thirdtool.Card.domain.model.RelatedCardCandidate;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Card.presentation.dto.CardResponse;
@@ -45,6 +46,18 @@ public class CardQueryService {
 
     public List<CardResponse.Summary> findByTag(Long tagId, Long userId) {
         return cardRepository.findByTagIdAndUserIdAndDeletedFalse(tagId, userId)
+                             .stream()
+                             .map(CardResponse.Summary::of)
+                             .toList();
+    }
+
+    // ─── 축 스코프 카드 조회 (fix-deck-axis-visibility 0.0.2v Story 3·4) ───
+    // 사용자의 axes에 연결된 Deck의 특정 status 카드를 단일 호출로 반환.
+    // GET /learning-facade/axes/{axisId}/cards가 사용하며, today 집계와 동일 read-model
+    // (CardRepository.findByUserIdAndAxisIdsAndStatus)을 공유한다.
+
+    public List<CardResponse.Summary> findByAxisIds(Long userId, List<Long> axisIds, CardStatus status) {
+        return cardRepository.findByUserIdAndAxisIdsAndStatus(userId, axisIds, status)
                              .stream()
                              .map(CardResponse.Summary::of)
                              .toList();

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardJpaRepository.java
@@ -118,21 +118,26 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, CardReposi
                                           );
 
     /**
-     * Story 6-1 Layer 1 한정 — 사용자의 LearningFacade(Layer 1)에 속한 axes에 연결된 Deck의
-     * ON_FIELD 활성 카드만 반환. axisIds 빈 입력은 Port/Adapter에서 단락(빈 리스트 반환).
+     * fix-deck-axis-visibility (0.0.2v) Story 3 — 축 스코프 Card 단일 read-model.
+     * <p>사용자의 axes에 연결된 Deck의 특정 status 활성 카드를 반환한다. 축 카드 뷰
+     * (GET /learning-facade/axes/{axisId}/cards)와 today 집계가 공유한다.
+     * <p>today의 eligibility(최소 간격) 재판정은 SoftScheduleTemplate가 in-memory로 수행하므로
+     * 본 쿼리는 threshold를 갖지 않는다(상위 호출자가 스케줄 분류를 얹는다).
+     * axisIds 빈 입력은 Port/Adapter에서 단락(빈 리스트 반환).
+     * <p>Deck만 fetch join(응답 매핑에 deckId 필요). keywordCues/cardTags는 미fetch
+     * (MultipleBagFetchException 회피).
      */
     @Query("""
             SELECT c FROM Card c
             JOIN FETCH c.deck d
             WHERE d.user.id = :userId
               AND d.axisId IN :axisIds
-              AND c.status = com.example.thirdtool.Card.domain.model.CardStatus.ON_FIELD
+              AND c.status = :status
               AND c.deleted = false
-              AND (c.lastViewedAt IS NULL OR c.lastViewedAt <= :threshold)
             """)
-    List<Card> findOnFieldEligibleByUserIdAndAxisIds(
+    List<Card> findByUserIdAndAxisIdsAndStatus(
             @Param("userId") Long userId,
-            @Param("threshold") java.time.LocalDateTime threshold,
-            @Param("axisIds") List<Long> axisIds
-                                                    );
+            @Param("axisIds") List<Long> axisIds,
+            @Param("status") CardStatus status
+                                              );
 }

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepository.java
@@ -52,10 +52,12 @@ public interface CardRepository {
     List<Card> findOnFieldEligibleByUserId(Long userId, LocalDateTime threshold);
 
     /**
-     * Story 6-1 Layer 1 한정 — 사용자의 LearningFacade에 속한 axes에 연결된 Deck 한정 후보.
-     * axisIds null/빈 입력은 Adapter에서 빈 리스트로 단락.
+     * fix-deck-axis-visibility (0.0.2v) Story 3 — 축 스코프 Card 단일 read-model.
+     * <p>사용자의 axes에 연결된 Deck의 특정 status 활성 카드를 반환한다. 축 카드 뷰와 today 집계가 공유한다.
+     * eligibility(최소 간격) 재판정은 상위 호출자(Review)의 SoftScheduleTemplate가 in-memory로 수행하므로
+     * 본 메서드는 threshold를 받지 않는다. axisIds null/빈 입력은 Adapter에서 빈 리스트로 단락.
      */
-    List<Card> findOnFieldEligibleByUserIdAndAxisIds(Long userId, LocalDateTime threshold, List<Long> axisIds);
+    List<Card> findByUserIdAndAxisIdsAndStatus(Long userId, List<Long> axisIds, CardStatus status);
 
     /**
      * ON_FIELD 만료 배치용 카드 조회.

--- a/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapter.java
@@ -85,10 +85,10 @@ public class CardRepositoryAdapter implements CardRepository {
     }
 
     @Override
-    public List<Card> findOnFieldEligibleByUserIdAndAxisIds(
-            Long userId, LocalDateTime threshold, List<Long> axisIds) {
+    public List<Card> findByUserIdAndAxisIdsAndStatus(
+            Long userId, List<Long> axisIds, CardStatus status) {
         if (axisIds == null || axisIds.isEmpty()) return List.of();
-        return cardJpaRepository.findOnFieldEligibleByUserIdAndAxisIds(userId, threshold, axisIds);
+        return cardJpaRepository.findByUserIdAndAxisIdsAndStatus(userId, axisIds, status);
     }
 
 }

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -1,6 +1,7 @@
 package com.example.thirdtool.Review.application;
 
 import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
 import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.SoftScheduleState;
 import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
@@ -112,10 +113,15 @@ public class ReviewQueryService {
 
         // Story 6-1 Layer 1 한정: 사용자의 LearningFacade(직업 컨셉) 안의 axes 범위로만 수집.
         // LearningFacade 미보유 사용자는 axisIds 빈 리스트 → 전체 카드 fallback (Spec 6-1 엣지 케이스).
+        //
+        // fix-deck-axis-visibility (0.0.2v) Story 3: axis 한정 경로는 축 카드 뷰와 공유하는
+        // 단일 read-model(findByUserIdAndAxisIdsAndStatus)로 위임. 최소 간격(threshold) 재판정은
+        // 아래 template.resolveState()가 in-memory로 책임지므로 쿼리 단계 threshold가 불필요하다
+        // (NOT_YET 필터가 최종 게이트). fallback(전체 카드) 경로는 threshold 1차 필터를 유지한다.
         List<Long> axisIds = learningFacadeQueryService.findAxisIdsByUserId(userId);
         List<Card> candidates = axisIds.isEmpty()
                 ? cardRepository.findOnFieldEligibleByUserId(userId, threshold)
-                : cardRepository.findOnFieldEligibleByUserIdAndAxisIds(userId, threshold, axisIds);
+                : cardRepository.findByUserIdAndAxisIdsAndStatus(userId, axisIds, CardStatus.ON_FIELD);
 
         Map<SoftScheduleState, List<ReviewResponse.TodayCandidates.CandidateItem>> byState =
                 candidates.stream()

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapterAxisCardsTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAdapterAxisCardsTest.java
@@ -1,0 +1,36 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * fix-deck-axis-visibility (0.0.2v) Story 3 — Adapter 단락 가드.
+ *
+ * <p>axisIds가 null/빈 입력이면 DB 호출 없이 빈 리스트를 반환한다 (빈 IN 절 SQL 회피).
+ */
+@DisplayName("CardRepositoryAdapter — findByUserIdAndAxisIdsAndStatus 빈 입력 단락")
+class CardRepositoryAdapterAxisCardsTest {
+
+    private final CardJpaRepository jpa = mock(CardJpaRepository.class);
+    private final CardRepositoryAdapter adapter = new CardRepositoryAdapter(jpa);
+
+    @Test
+    @DisplayName("빈 axisIds — JpaRepository 미호출, 빈 리스트")
+    void emptyAxisIds_shortCircuits() {
+        assertThat(adapter.findByUserIdAndAxisIdsAndStatus(1L, List.of(), CardStatus.ON_FIELD)).isEmpty();
+        verify(jpa, never()).findByUserIdAndAxisIdsAndStatus(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("null axisIds — JpaRepository 미호출, 빈 리스트")
+    void nullAxisIds_shortCircuits() {
+        assertThat(adapter.findByUserIdAndAxisIdsAndStatus(1L, null, CardStatus.ON_FIELD)).isEmpty();
+        verify(jpa, never()).findByUserIdAndAxisIdsAndStatus(any(), any(), any());
+    }
+}

--- a/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAxisCardsSliceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/infrastructure/persistence/CardRepositoryAxisCardsSliceTest.java
@@ -1,0 +1,152 @@
+package com.example.thirdtool.Card.infrastructure.persistence;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * fix-deck-axis-visibility (0.0.2v) Story 3 — findByUserIdAndAxisIdsAndStatus 슬라이스.
+ *
+ * <p>축 카드 뷰와 today 집계가 공유하는 단일 read-model의 필터 규칙 검증:
+ *   - 본인 axis 결합 Deck의 해당 status 카드만 포함
+ *   - 고아 덱(axisId=null)·다른 유저·다른 status·soft delete 제외
+ *   - 다중 axisIds 모두 수집
+ *   - threshold(최소 간격) 필터를 갖지 않음 — eligibility 재판정은 상위(Review) 인메모리 책임
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("CardRepository slice — Story 3 findByUserIdAndAxisIdsAndStatus")
+class CardRepositoryAxisCardsSliceTest {
+
+    private static final Long AXIS_A = 10L;
+    private static final Long AXIS_B = 20L;
+
+    @Autowired TestEntityManager em;
+    @Autowired CardJpaRepository cardJpaRepository;
+
+    private UserEntity owner;
+    private UserEntity other;
+    private Deck ownerAxisADeck;   // axisId = 10, owner
+    private Deck ownerAxisBDeck;   // axisId = 20, owner
+    private Deck ownerOrphanDeck;  // axisId = null, owner
+    private Deck otherAxisADeck;   // axisId = 10, other user
+
+    @BeforeEach
+    void setUp() {
+        owner = UserEntity.ofLocal("owner", "pw", "n", "o@e.com");
+        other = UserEntity.ofLocal("other", "pw", "n", "x@e.com");
+        em.persist(owner);
+        em.persist(other);
+
+        ownerAxisADeck = deckUnderAxis(owner, AXIS_A, "owner-axisA");
+        ownerAxisBDeck = deckUnderAxis(owner, AXIS_B, "owner-axisB");
+        ownerOrphanDeck = Deck.of("owner-orphan", null, owner);
+        otherAxisADeck = deckUnderAxis(other, AXIS_A, "other-axisA");
+        em.persist(ownerAxisADeck);
+        em.persist(ownerAxisBDeck);
+        em.persist(ownerOrphanDeck);
+        em.persist(otherAxisADeck);
+        em.flush();
+    }
+
+    // axisId 결합 덱 — Story 2의 Deck.createUnderAxis에 의존하지 않도록 raw 컬럼만 세팅.
+    private Deck deckUnderAxis(UserEntity user, Long axisId, String name) {
+        Deck deck = Deck.of(name, null, user);
+        ReflectionTestUtils.setField(deck, "axisId", axisId);
+        return deck;
+    }
+
+    private Card persistCard(Deck deck, boolean archived) {
+        Card card = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"));
+        if (archived) card.archive();
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+
+    @Test
+    @DisplayName("정상: 본인 axis 결합 덱의 ON_FIELD 카드만 — 고아 덱·다른 유저·ARCHIVE 제외")
+    void onField_axisScoped_ownerOnly() {
+        Card included = persistCard(ownerAxisADeck, false);  // 포함
+        persistCard(ownerAxisADeck, true);                   // ARCHIVE — 제외
+        persistCard(ownerOrphanDeck, false);                 // 고아 덱 — 제외
+        persistCard(otherAxisADeck, false);                  // 다른 유저 — 제외
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findByUserIdAndAxisIdsAndStatus(
+                owner.getId(), List.of(AXIS_A), CardStatus.ON_FIELD);
+
+        assertThat(result).extracting(Card::getId).containsExactly(included.getId());
+    }
+
+    @Test
+    @DisplayName("status=ARCHIVE 지정 시 ARCHIVE 카드만 반환")
+    void archive_statusFilter() {
+        persistCard(ownerAxisADeck, false);                 // ON_FIELD — 제외
+        Card archived = persistCard(ownerAxisADeck, true);  // ARCHIVE — 포함
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findByUserIdAndAxisIdsAndStatus(
+                owner.getId(), List.of(AXIS_A), CardStatus.ARCHIVE);
+
+        assertThat(result).extracting(Card::getId).containsExactly(archived.getId());
+    }
+
+    @Test
+    @DisplayName("다중 axisIds — 두 축의 ON_FIELD 카드 모두 수집")
+    void multipleAxisIds_collectsAll() {
+        Card a = persistCard(ownerAxisADeck, false);
+        Card b = persistCard(ownerAxisBDeck, false);
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findByUserIdAndAxisIdsAndStatus(
+                owner.getId(), List.of(AXIS_A, AXIS_B), CardStatus.ON_FIELD);
+
+        assertThat(result).extracting(Card::getId).containsExactlyInAnyOrder(a.getId(), b.getId());
+    }
+
+    @Test
+    @DisplayName("soft delete된 카드는 제외")
+    void excludesSoftDeleted() {
+        Card alive = persistCard(ownerAxisADeck, false);
+        Card removed = persistCard(ownerAxisADeck, false);
+        removed.softDelete();
+        em.flush();
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findByUserIdAndAxisIdsAndStatus(
+                owner.getId(), List.of(AXIS_A), CardStatus.ON_FIELD);
+
+        assertThat(result).extracting(Card::getId).containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("해당 축에 카드가 없으면 빈 리스트")
+    void emptyWhenNoMatches() {
+        persistCard(ownerAxisBDeck, false); // 다른 축에만 존재
+        em.clear();
+
+        List<Card> result = cardJpaRepository.findByUserIdAndAxisIdsAndStatus(
+                owner.getId(), List.of(AXIS_A), CardStatus.ON_FIELD);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTodayCandidatesTest.java
@@ -1,6 +1,7 @@
 package com.example.thirdtool.Review.application;
 
 import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
 import com.example.thirdtool.Card.domain.model.MainNote;
 import com.example.thirdtool.Card.domain.model.SoftScheduleState;
 import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
@@ -231,7 +232,7 @@ class ReviewQueryServiceTodayCandidatesTest {
                 .thenReturn(List.of(10L, 20L));
 
         Card card = cardWith(1000L, null);
-        when(cardRepository.findOnFieldEligibleByUserIdAndAxisIds(eq(1L), any(), eq(List.of(10L, 20L))))
+        when(cardRepository.findByUserIdAndAxisIdsAndStatus(eq(1L), eq(List.of(10L, 20L)), eq(CardStatus.ON_FIELD)))
                 .thenReturn(List.of(card));
 
         ReviewResponse.TodayCandidates result = service.getTodayCandidates(user);
@@ -258,7 +259,7 @@ class ReviewQueryServiceTodayCandidatesTest {
         assertThat(result.total()).isEqualTo(1);
         // axisIds 적용 메서드는 호출되지 않아야 함
         org.mockito.Mockito.verify(cardRepository, org.mockito.Mockito.never())
-                .findOnFieldEligibleByUserIdAndAxisIds(any(), any(), any());
+                .findByUserIdAndAxisIdsAndStatus(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 배경
fix-deck-axis-visibility (0.0.2v) Story 3 — today 집계와 축 카드 뷰가 `axis→deck(axisId)→card` 집계를 각자 복제할 위험을 차단한다.

## 변경
- `CardRepository.findByUserIdAndAxisIdsAndStatus(userId, axisIds, status)` 단일 read-model 신설 (port/adapter/JPQL). 빈 axisIds는 adapter에서 단락.
- `CardQueryService.findByAxisIds` — 축 카드 뷰용 Summary 매핑 (Story 4가 사용).
- `ReviewQueryService.collectToday` 의 axis 한정 분기를 위 read-model로 위임. 구 `findOnFieldEligibleByUserIdAndAxisIds` 제거.
- eligibility(최소 간격) 재판정은 `SoftScheduleTemplate` 인메모리 게이트가 책임 → read-model은 threshold 미보유.

## 검증
- **today 회귀 동일 결과**: `ReviewQueryServiceTodayCandidatesTest` 통과 (위임 전환 후 동작 불변).
- 신규 `CardRepositoryAxisCardsSliceTest`(@DataJpaTest) — axis 결합/고아/타유저/status/soft-delete/다중축.
- 신규 `CardRepositoryAdapterAxisCardsTest` — 빈 입력 단락 가드.

관련: ADR020 (별도 docs PR). 후속: Story 4(`GET /axes/{axisId}/cards`)가 본 read-model 위에 stack.