### PR TITLE
feat(deck): 검색 projection에 axisId 노출 [Fix-Story 1 잔여]

### DIFF
--- a/src/main/generated/com/example/thirdtool/Deck/infrastructure/dto/QDeckSummaryRow.java
+++ b/src/main/generated/com/example/thirdtool/Deck/infrastructure/dto/QDeckSummaryRow.java
@@ -13,8 +13,8 @@ public class QDeckSummaryRow extends ConstructorExpression<DeckSummaryRow> {
 
     private static final long serialVersionUID = -1034238638L;
 
-    public QDeckSummaryRow(com.querydsl.core.types.Expression<Long> deckId, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<com.example.thirdtool.Deck.domain.model.DeckMode> mode, com.querydsl.core.types.Expression<Integer> depth, com.querydsl.core.types.Expression<java.time.LocalDateTime> lastAccessed, com.querydsl.core.types.Expression<Integer> cardCount, com.querydsl.core.types.Expression<Integer> subDeckCount) {
-        super(DeckSummaryRow.class, new Class<?>[]{long.class, String.class, com.example.thirdtool.Deck.domain.model.DeckMode.class, int.class, java.time.LocalDateTime.class, int.class, int.class}, deckId, name, mode, depth, lastAccessed, cardCount, subDeckCount);
+    public QDeckSummaryRow(com.querydsl.core.types.Expression<Long> deckId, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<com.example.thirdtool.Deck.domain.model.DeckMode> mode, com.querydsl.core.types.Expression<Integer> depth, com.querydsl.core.types.Expression<java.time.LocalDateTime> lastAccessed, com.querydsl.core.types.Expression<Integer> cardCount, com.querydsl.core.types.Expression<Integer> subDeckCount, com.querydsl.core.types.Expression<Long> axisId) {
+        super(DeckSummaryRow.class, new Class<?>[]{long.class, String.class, com.example.thirdtool.Deck.domain.model.DeckMode.class, int.class, java.time.LocalDateTime.class, int.class, int.class, long.class}, deckId, name, mode, depth, lastAccessed, cardCount, subDeckCount, axisId);
     }
 
 }

--- a/src/main/java/com/example/thirdtool/Deck/infrastructure/dto/DeckSummaryRow.java
+++ b/src/main/java/com/example/thirdtool/Deck/infrastructure/dto/DeckSummaryRow.java
@@ -16,6 +16,11 @@ public class DeckSummaryRow {
     private final LocalDateTime lastAccessed;
     private final int           cardCount;
     private final int           subDeckCount;
+    // fix-deck-axis-visibility (0.0.2v) Story 1 잔여 — 검색 결과에도 축 참조를 노출.
+    // Deck 엔티티와 동일하게 raw axisId(Long, FK 없음)만 보유한다. 고아 덱은 null.
+    // axisName은 BC 경계 유지를 위해 조회 서비스에서 LearningFacadeQueryService 배치로 보강한다
+    // (findRootDecks와 동일 패턴) — QueryDSL 단계에서 LearningAxis를 조인하지 않는다.
+    private final Long          axisId;
 
     @QueryProjection
     public DeckSummaryRow(
@@ -25,7 +30,8 @@ public class DeckSummaryRow {
             int depth,
             LocalDateTime lastAccessed,
             int cardCount,
-            int subDeckCount
+            int subDeckCount,
+            Long axisId
                          ) {
         this.deckId       = deckId;
         this.name         = name;
@@ -34,5 +40,6 @@ public class DeckSummaryRow {
         this.lastAccessed = lastAccessed;
         this.cardCount    = cardCount;
         this.subDeckCount = subDeckCount;
+        this.axisId       = axisId;
     }
 }

--- a/src/main/java/com/example/thirdtool/Deck/infrastructure/repository/DeckQueryRepository.java
+++ b/src/main/java/com/example/thirdtool/Deck/infrastructure/repository/DeckQueryRepository.java
@@ -48,7 +48,8 @@ public class DeckQueryRepository {
                         deck.depth,
                         deck.lastAccessed,
                         deck.cards.size(),     // 카드 수
-                        deck.subDecks.size()   // 하위 덱 수
+                        deck.subDecks.size(),  // 하위 덱 수
+                        deck.axisId            // 축 참조(raw Long, 고아 덱은 null)
                 ))
                 .from(deck)
                 .where(


### PR DESCRIPTION
## 배경
fix-deck-axis-visibility (0.0.2v) Story 1은 사용자용 덱 목록(`findRootDecks`)에 `axisId`/`axisName`을 이미 노출했으나, QueryDSL 검색 경로(`searchDecks`/`DeckSummaryRow`)에는 축 정보가 빠져 있었다.

## 변경
- `DeckSummaryRow`에 raw `axisId`(Long, 고아 덱 null) 추가 + `searchDecks` projection에 `deck.axisId` 투영.
- **axisName은 의도적으로 미투영** — BC 경계 유지를 위해 도메인 JPA 조인 대신 조회 서비스의 `LearningFacadeQueryService.findAxisNamesByIds` 배치 보강에 위임(`findRootDecks`와 동일 패턴, ADR020 Option A). `searchDecks`는 현재 소비자가 없어, 향후 소비자가 서비스 레이어에서 이름을 보강한다.

## 비고
`Deck` 엔티티가 raw `axisId`만 보유하는 결정(연관 승격 거부)과 일관. 독립 PR — Story 2/3과 파일 겹침 없음.