### PR TITLE
feat(facade,card): 축 스코프 Card 조회 GET 엔드포인트 [Fix-Story 4]

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryService.java
@@ -1,5 +1,8 @@
 package com.example.thirdtool.LearningFacade.application.service;
 
+import com.example.thirdtool.Card.application.service.CardQueryService;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.presentation.dto.CardResponse;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.Deck.application.service.DeckQueryService;
 import com.example.thirdtool.Deck.domain.model.Deck;
@@ -31,6 +34,7 @@ public class LearningFacadeQueryService {
     private final LearningFacadeRepository facadeRepository;
     private final TopicMaterialRepository topicMaterialRepository;
     private final DeckQueryService deckQueryService;
+    private final CardQueryService cardQueryService;
 
     /**
      * Cross-BC inbound (Story 6-1 Layer 1 한정) — 사용자 LearningFacade가 보유한 모든 axis ID를 반환.
@@ -57,6 +61,27 @@ public class LearningFacadeQueryService {
     @Transactional(readOnly = true)
     public Map<Long, String> findAxisNamesByIds(Collection<Long> axisIds) {
         return facadeRepository.findAxisNamesByIds(axisIds);
+    }
+
+    /**
+     * fix-deck-axis-visibility (0.0.2v) Story 4 — 축 스코프 Card 조회.
+     *
+     * <p>"내 축을 누르면 그 축의 카드가 보인다"는 사용자 의도를 단일 호출로 충족한다. facade/axis
+     * 소유권을 검증(Story 2 createDeckUnderAxis와 동형)한 뒤 Card BC의 단일 read-model
+     * {@link CardQueryService#findByAxisIds}로 위임 — today 집계와 동일 쿼리를 공유한다.
+     *
+     * @throws LearningFacadeDomainException facade 미보유(LEARNING_FACADE_NOT_FOUND) /
+     *                                       axis 미소유(LEARNING_AXIS_NOT_FOUND)
+     */
+    @Transactional(readOnly = true)
+    public List<CardResponse.Summary> findAxisCards(Long userId, Long axisId, CardStatus status) {
+        LearningFacade facade = facadeRepository.findByUserId(userId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND));
+        boolean owned = facade.getAxes().stream().anyMatch(a -> a.getId().equals(axisId));
+        if (!owned) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_NOT_FOUND);
+        }
+        return cardQueryService.findByAxisIds(userId, List.of(axisId), status);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
@@ -1,5 +1,7 @@
 package com.example.thirdtool.LearningFacade.presentation;
 
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.presentation.dto.CardResponse;
 import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeCommand;
 import com.example.thirdtool.LearningFacade.application.dto.LearningFacadeQuery;
 import com.example.thirdtool.LearningFacade.application.dto.LearningMaterialCommand;
@@ -102,6 +104,16 @@ public class LearningFacadeController {
     ) {
         return facadeCommandService.reorderAxes(
                 new LearningFacadeCommand.ReorderAxes(user.getId(), request.orderedAxisIds()));
+    }
+
+    // 7-ter. GET /learning-facade/axes/{axisId}/cards  (Fix-Story 4: 축 스코프 Card 조회)
+    @GetMapping("/axes/{axisId}/cards")
+    public List<CardResponse.Summary> getAxisCards(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId,
+            @RequestParam(defaultValue = "ON_FIELD") CardStatus status
+    ) {
+        return facadeQueryService.findAxisCards(user.getId(), axisId, status);
     }
 
     // 8. POST /learning-facade/axes/{axisId}/topics

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryServiceTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeQueryServiceTest.java
@@ -36,6 +36,7 @@ class LearningFacadeQueryServiceTest {
     private LearningFacadeRepository facadeRepository;
     private TopicMaterialRepository topicMaterialRepository;
     private DeckQueryService deckQueryService;
+    private com.example.thirdtool.Card.application.service.CardQueryService cardQueryService;
     private LearningFacadeQueryService service;
 
     private UserEntity user;
@@ -55,8 +56,9 @@ class LearningFacadeQueryServiceTest {
         facadeRepository = mock(LearningFacadeRepository.class);
         topicMaterialRepository = mock(TopicMaterialRepository.class);
         deckQueryService = mock(DeckQueryService.class);
+        cardQueryService = mock(com.example.thirdtool.Card.application.service.CardQueryService.class);
         when(deckQueryService.findByAxisIds(anyCollection())).thenReturn(List.of());
-        service = new LearningFacadeQueryService(facadeRepository, topicMaterialRepository, deckQueryService);
+        service = new LearningFacadeQueryService(facadeRepository, topicMaterialRepository, deckQueryService, cardQueryService);
 
         user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/src/test/java/com/example/thirdtool/LearningFacade/integration/AxisCardsQueryIntegrationTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/integration/AxisCardsQueryIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.example.thirdtool.LearningFacade.integration;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.domain.model.CardStatus;
+import com.example.thirdtool.Card.domain.model.MainNote;
+import com.example.thirdtool.Card.domain.model.Summary;
+import com.example.thirdtool.Card.presentation.dto.CardResponse;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * fix-deck-axis-visibility (0.0.2v) Story 4 — 축 스코프 Card 조회 통합 테스트.
+ *
+ * <p>GET /api/v1/learning-facade/axes/{axisId}/cards 흐름의 BC 협력(LearningFacade →
+ * Card 단일 read-model) + 소유권 검증 + DB 영속화까지 검증. Controller는 facade.findAxisCards로
+ * 위임만 하므로 Service-level 통합으로 핵심 흐름 커버.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("findAxisCards 통합 (Fix-Story 4)")
+class AxisCardsQueryIntegrationTest {
+
+    @Autowired LearningFacadeQueryService facadeQueryService;
+
+    @PersistenceContext EntityManager em;
+
+    private UserEntity user;
+    private LearningFacade facade;
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("owner", "encoded-pw", "닉네임", "owner@example.com");
+        em.persist(user);
+
+        facade = LearningFacade.create(user, "백엔드");
+        axis = facade.addAxis("Spring 내부");
+        em.persist(facade);
+        em.flush();
+    }
+
+    // axisId 결합 덱 — Story 2의 Deck.createUnderAxis에 의존하지 않도록 raw 컬럼만 세팅.
+    private Deck deckUnderAxis(UserEntity user, Long axisId, String name) {
+        Deck deck = Deck.of(name, null, user);
+        ReflectionTestUtils.setField(deck, "axisId", axisId);
+        return deck;
+    }
+
+    private Card persistCard(Deck deck, boolean archived) {
+        Card card = Card.create(deck, MainNote.of("본문", null), Summary.of("한 문장."), List.of("k"));
+        if (archived) card.archive();
+        em.persist(card);
+        em.flush();
+        return card;
+    }
+
+    @Test
+    @DisplayName("정상 — 축 결합 덱들의 ON_FIELD 카드만 단일 호출로 반환 (ARCHIVE·고아 덱 제외)")
+    void 정상_onField() {
+        Deck axisDeck1 = deckUnderAxis(user, axis.getId(),"deck1");
+        Deck axisDeck2 = deckUnderAxis(user, axis.getId(),"deck2");
+        Deck orphan = Deck.of("orphan", null, user);
+        em.persist(axisDeck1);
+        em.persist(axisDeck2);
+        em.persist(orphan);
+        em.flush();
+
+        Card onField1 = persistCard(axisDeck1, false);
+        Card onField2 = persistCard(axisDeck2, false);
+        persistCard(axisDeck1, true);   // ARCHIVE — 제외
+        persistCard(orphan, false);     // 고아 덱 — 제외
+        em.clear();
+
+        List<CardResponse.Summary> result =
+                facadeQueryService.findAxisCards(user.getId(), axis.getId(), CardStatus.ON_FIELD);
+
+        assertThat(result).extracting(CardResponse.Summary::cardId)
+                .containsExactlyInAnyOrder(onField1.getId(), onField2.getId());
+        assertThat(result).extracting(CardResponse.Summary::status)
+                .containsOnly(CardStatus.ON_FIELD);
+    }
+
+    @Test
+    @DisplayName("status=ARCHIVE 지정 시 ARCHIVE 카드만 반환")
+    void archive_status() {
+        Deck axisDeck = deckUnderAxis(user, axis.getId(),"deck");
+        em.persist(axisDeck);
+        em.flush();
+        persistCard(axisDeck, false);                 // ON_FIELD — 제외
+        Card archived = persistCard(axisDeck, true);  // ARCHIVE — 포함
+        em.clear();
+
+        List<CardResponse.Summary> result =
+                facadeQueryService.findAxisCards(user.getId(), axis.getId(), CardStatus.ARCHIVE);
+
+        assertThat(result).extracting(CardResponse.Summary::cardId)
+                .containsExactly(archived.getId());
+    }
+
+    @Test
+    @DisplayName("본인 facade에 없는 axisId — LEARNING_AXIS_NOT_FOUND")
+    void 미소유_axisId_거부() {
+        assertThatThrownBy(() ->
+                facadeQueryService.findAxisCards(user.getId(), 99_999L, CardStatus.ON_FIELD))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .matches(e -> ((LearningFacadeDomainException) e).getErrorCode()
+                        == ErrorCode.LEARNING_AXIS_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("facade 미보유 사용자 — LEARNING_FACADE_NOT_FOUND")
+    void facade_미보유() {
+        UserEntity newUser = UserEntity.ofLocal("nofacade", "pw", "닉", "nf@example.com");
+        em.persist(newUser);
+        em.flush();
+
+        assertThatThrownBy(() ->
+                facadeQueryService.findAxisCards(newUser.getId(), 999L, CardStatus.ON_FIELD))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .matches(e -> ((LearningFacadeDomainException) e).getErrorCode()
+                        == ErrorCode.LEARNING_FACADE_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 배경
fix-deck-axis-visibility (0.0.2v) Story 4 — "내 축을 누르면 그 축 카드가 보인다"를 단일 호출로 충족(FE N+1 회피). FE(`untitled`)는 이미 `listAxisCards(axisId, status)`로 본 계약을 호출 중.

## ⚠️ Stacked PR
**base = `fix/card-axis-readmodel`(Story 3 #189)** — Story 3의 `CardQueryService.findByAxisIds`에 의존. **Story 3 머지 후 base를 develop으로 retarget** 예정. 또한 `LearningFacadeController`를 Story 2(#188)도 같은 위치에 수정하므로 머지 순서상 충돌 가능 → rebase로 해소.

## 변경
- `GET /api/v1/learning-facade/axes/{axisId}/cards?status=ON_FIELD|ARCHIVE` (`LearningFacadeController`).
- `LearningFacadeQueryService.findAxisCards` — facade/axis 소유권 검증 후 `CardQueryService.findByAxisIds`로 위임(BC 의존 `LearningFacade → Card`, 비순환).
- 신규 ErrorCode 미도입 — Story 2 선례대로 기존 `LEARNING_FACADE_FORBIDDEN`/`LEARNING_AXIS_NOT_FOUND` 재사용.

## 검증
- `AxisCardsQueryIntegrationTest`(@SpringBootTest) — ON_FIELD/ARCHIVE 필터, 고아 덱 제외, 미소유 axis 403/404 계열, facade 미보유.
- `LearningFacadeQueryServiceTest` 갱신(cardQueryService 협력).