### PR TITLE
docs: Deck↔Axis 가시화 ADR020 + DOMAIN/PACKAGE 갱신 [Fix-Story 5]

### DIFF
--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -111,6 +111,7 @@ ON_FIELD ↔ ARCHIVE
 - `recordView()` 호출 시점 = ReviewSession 안에서만 (외부 직접 접근 금지, 캡슐화).
 - maxView / maxDuration은 `UserScheduleConfig.resolveOnFieldBudget()`에서 유저별 매핑.
 - SoftScheduleTemplate 간격 단계는 `LearningMode`(10D/20D/30D)가 결정.
+- **축 스코프 카드 조회는 ReviewSession Layer 1 수집과 별개의 "사용자 표현 흐름"** (fix-deck-axis-visibility 0.0.2v Story 3·4, ADR020). `CardRepository.findByUserIdAndAxisIdsAndStatus`(삭제 제외·상태·`axisId IN`)를 today 집계와 축 카드 뷰(`GET /learning-facade/axes/{axisId}/cards`)가 공유한다. eligibility(최소 간격) 재판정은 이 read-model이 아니라 `SoftScheduleTemplate`가 인메모리로 책임진다 — 따라서 read-model 쿼리는 threshold를 갖지 않는다.
 
 ---
 
@@ -144,8 +145,13 @@ ON_FIELD ↔ ARCHIVE
 13. `recalculateProgressStatus()`는 활성 Card 컬렉션 기준 — 0개 → NOT_STARTED / 전부 ARCHIVE → COMPLETED / 그 외 → IN_PROGRESS.
 
 **팩토리 메서드**:
-- `Deck.of(name, parentDeck, user)` — 사용자가 직접 생성 (기존 흐름).
-- `Deck.createFromAxis(user, axisId, name)` — Axis 등록 이벤트 핸들러가 호출 (Fix-Story 1 / ADR007 Amended). 이름은 `LearningAxis.name`을 그대로 사용.
+- `Deck.of(name, parentDeck, user)` — 사용자가 직접 생성 (기존 흐름, axisId=null 고아 덱).
+- `Deck.createFromAxis(user, axisId, name)` — Axis 등록 이벤트 핸들러가 호출 (Fix-Story 1 / ADR007 Amended). 이름은 `LearningAxis.name`을 그대로 사용. 멱등(`existsByAxisIdAndDeletedFalse`).
+- `Deck.createUnderAxis(user, axisId, name)` — 사용자가 축에 **명시적으로** 신규 덱을 추가 (fix-deck-axis-visibility 0.0.2v Story 2, `POST /learning-facade/axes/{axisId}/decks`). 멱등 검사 없는 단순 신규 생성, 이름 중복은 `DECK_NAME_DUPLICATE`.
+
+**axis 결합 정책 (fix-deck-axis-visibility 0.0.2v / ADR020)**:
+- 한 축당 **자동 생성 1개**(`createFromAxis`, 멱등) + **사용자 명시 추가 N개**(`createUnderAxis`) + **고아 덱 보존**(`Deck.of`, axisId=null)을 모두 허용한다. 축당 단일 덱 제약은 두지 않는다(UX 검증 후 재평가).
+- 응답 DTO(`DeckResponse.Summary`/`Detail`)는 `axisId`/`axisName`을 노출한다. `axisName`은 도메인 연관 승격 없이 `DeckQueryService`가 `LearningFacadeQueryService.findAxisNamesByIds`로 배치 보강한다(read-model 노출, ADR020 — Option B 도메인 연관 승격은 거부). QueryDSL 검색 경로(`DeckSummaryRow`)는 raw `axisId`만 투영한다.
 
 **진행 상태 자동 갱신 트리거 (Story-005-2)**:
 - `CardCommandService.create`가 카드 추가 후 `deck.markInProgress()` 호출 → `NOT_STARTED → IN_PROGRESS`.
@@ -353,3 +359,4 @@ NO_MATERIAL ─ TopicMaterial 연결 → PARTIALLY_COVERED ─ proficiencyLevel�
 | 버전 | 날짜 | 변경 내용 |
 | --- | --- | --- |
 | v0.1 | 2026-05-14 | 신설. `private-docs/domain/{도메인모델,용어사전,BC별 6개}.md`(약 8,000줄)를 단일 파일로 압축. 전역 용어 35개 + BC별 6개 섹션(책임/Aggregate Root/Entity·VO/불변식/상태전이/주의 메모) + v4 결정 12건 + 관련 ADR(003·004·005) 인용. Plan mode + Story 단위 협업 전제로 매트릭스·필드 나열을 모두 제거하고 의도 레이어만 보존 |
+| v0.2 | 2026-06-30 | fix-deck-axis-visibility (0.0.2v) 반영. §2.2 Deck — `createUnderAxis` 팩토리 + axis 결합 정책(자동 1 + 명시 N + 고아 보존) + `axisId`/`axisName` read-model 노출(ADR020). §2.1 Card — 축 스코프 조회는 ReviewSession Layer 1과 별개 사용자 표현 흐름이며 today와 단일 read-model(`findByUserIdAndAxisIdsAndStatus`) 공유 |

--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -232,7 +232,8 @@ public LearningFacadeResponse.UpdateAxisName updateAxisName(
 | `Deck → User` (`UserEntity` 참조) | ✅ | Deck이 소유 유저 보유 |
 | `Review → Card, Deck` | ✅ | ReviewSession이 카드를 순회 (ID 참조 권장, Aggregate 직접 포함 지양) |
 | `Review → UserSchedule` (Application 경유 read) | ✅ | `ReviewCommandService` / `ReviewQueryService`가 `UserScheduleQueryService.resolveOnFieldBudget(userId)`를 호출해 사용자별 maxView/maxDuration을 매 호출 주입(Story 2-1/2-3, Epic 4 합류). UserSchedule 엔티티는 BC 경계 밖으로 노출하지 않고 `OnFieldBudget`(Card 도메인 VO)만 반환 |
-| `Review → LearningFacade` (Application 경유 read) | ✅ | `ReviewQueryService.getTodayCandidates`가 `LearningFacadeQueryService.findAxisIdsByUserId(userId)`를 호출해 사용자 Layer 1(직업 컨셉) 안의 axes 범위로 카드 후보를 한정한다(Story 6-1). LearningFacade 엔티티는 BC 경계 밖으로 노출하지 않고 axis ID 리스트만 반환. 미보유 사용자는 빈 리스트 → 전체 카드 fallback |
+| `Review → LearningFacade` (Application 경유 read) | ✅ | `ReviewQueryService.getTodayCandidates`가 `LearningFacadeQueryService.findAxisIdsByUserId(userId)`를 호출해 사용자 Layer 1(직업 컨셉) 안의 axes 범위로 카드 후보를 한정한다(Story 6-1). LearningFacade 엔티티는 BC 경계 밖으로 노출하지 않고 axis ID 리스트만 반환. 미보유 사용자는 빈 리스트 → 전체 카드 fallback. **axis 한정 후보는 축 카드 뷰와 공유하는 단일 read-model `CardRepository.findByUserIdAndAxisIdsAndStatus`로 위임**(fix-deck-axis-visibility 0.0.2v Story 3) |
+| `LearningFacade → Card` (Application 경유 read) | ✅ | `LearningFacadeQueryService.findAxisCards`가 facade/axis 소유권 검증 후 `CardQueryService.findByAxisIds(...)`로 위임 — 축 스코프 카드 조회(`GET /learning-facade/axes/{axisId}/cards`, fix-deck-axis-visibility 0.0.2v Story 4). 비순환(Card는 LearningFacade 미의존). **Repository 직접 호출 금지** — Application Service 경유만 |
 | `Deck → LearningFacade` (이벤트 import) | ✅ | `LearningMaterialCreatedEvent` / `LearningMaterialDeletedEvent` 수신 — 동기 도메인 이벤트 협력 ([ADR007](adr/ADR007.md)) |
 | `LearningFacade → Deck` (Application 경유 read) | ✅ | `LearningFacadeQueryService`가 `DeckQueryService.findByAxisIds(...)` 호출 — facade 응답의 축별 linkedDecks 매핑(Story-005-2). **Repository 직접 호출 금지** — Application Service 경유만. presentation DTO(`AxisItem.linkedDecks`, `DeckItem`)는 Deck 도메인 객체 import 허용 |
 | `Card → Deck` 도메인 행위 호출 | ✅ | `CardCommandService` / `ReviewCommandService`가 카드 추가/archive 후 `deck.markInProgress()` / `recalculateProgressStatus()` 호출 (Story-005-2). Card 도메인 자체는 Deck 상태를 직접 변경하지 않음 |
@@ -290,3 +291,4 @@ src/test/java/com/example/thirdtool/
 | 버전 | 날짜 | 변경 내용 |
 | --- | --- | --- |
 | v0.1 | 2026-05-14 | 신설. 기존 `docs/architecture/package-structure-guide.md`(LearningFacade/UserSchedule BC 누락 상태) + `update-docs/architecture/application.md`(Controller↔Service 경계 패턴)을 흡수·통합. 표준 4-레이어 구조 + ADR005 Command/Query record 패턴 + BC 간 의존 규칙 + 테스트 위치 규칙 정착. 레거시 디렉토리 명명(Deck `repository/`, User BC 루트 `dto/`) 점진 통일 대상 명시 |
+| v0.2 | 2026-06-30 | fix-deck-axis-visibility (0.0.2v) 반영. §6 BC 의존 규칙에 `LearningFacade → Card`(Application 경유 read, 축 카드 조회) 신규 엣지 추가, `Review → LearningFacade` 비고에 today/축뷰 단일 read-model 공유 명시 (ADR020) |

--- a/docs/adr/ADR020-deck-axis-visibility.md
+++ b/docs/adr/ADR020-deck-axis-visibility.md
@@ -1,0 +1,53 @@
+# ADR020: Deck↔Axis 가시화는 read-model 노출로 한정하고 도메인 연관 승격은 거부한다
+
+- **상태**: Accepted
+- **날짜**: 2026-06-30
+- **관련**: fix-deck-axis-visibility (0.0.2v) — `workflow/task/fix/sdd/version/0.0.2v/fix-deck-axis-visibility.md`, 선행 ADR007(동기 도메인 이벤트), `docs/DOMAIN.md`(Deck/Card BC), `docs/PACKAGE.md`(BC 의존 방향)
+
+## 컨텍스트
+
+원본 SDD(`product-learningFacade.md`)는 4-level 계층(Facade→Axis→Topic→Material)의 응집을 지키고 Deck BC와 LearningFacade BC의 결합도를 낮추기 위해, **Deck가 Axis를 raw `Long` 컬럼(`deck.axis_id`)으로만 참조**하고 JPA 연관 매핑은 두지 않도록 결정했다. 그 결과:
+
+- Deck 응답 DTO 어디에도 `axisId`/`axisName`이 없어 FE가 "이 덱이 어느 축인가"를 표시할 수 없었다 (축별 그룹핑 UI 봉쇄).
+- "내 축을 누르면 그 축의 카드가 보인다"는 사용자 의도를 표현할 조회 경로(`GET /axes/{axisId}/cards`)가 없었다.
+- today 집계(Review BC)와 새로 필요한 축 카드 뷰가 같은 `axis→deck(axisId)→card` 집계를 각자 쿼리로 복제할 위험이 있었다.
+
+카드 에디터에서 만든 덱이 고아 덱이 되어 today/축 뷰에서 "사라지는" 현상까지 겹쳐, Deck↔Axis 관계를 응답·생성·조회 3축에서 일관되게 노출할 필요가 생겼다.
+
+## 결정
+
+**Deck↔Axis 가시화는 Application/조회(read-model) 레이어에서만 해결**하고, **도메인 연관 승격(`deck.axisId` → `@ManyToOne LearningAxis`)은 거부**한다.
+
+구체적으로:
+
+- **응답 DTO 노출**: `DeckResponse.Summary`/`Detail`에 `axisId`/`axisName`을 노출하되, `axisName`은 `DeckQueryService`가 `LearningFacadeQueryService.findAxisNamesByIds`로 **배치 조회**해 동봉한다 (cross-BC read, JPA 조인 아님). QueryDSL 검색 경로(`DeckSummaryRow`)도 raw `axisId`만 투영한다.
+- **단일 read-model**: 축 스코프 카드 집계를 `CardRepository.findByUserIdAndAxisIdsAndStatus(userId, axisIds, status)` **하나의 쿼리**로 모으고, 축 카드 뷰(`CardQueryService.findByAxisIds`)와 today 집계(`ReviewQueryService.collectToday`)가 공유한다. today의 최소 간격(eligibility) 재판정은 `SoftScheduleTemplate`가 인메모리로 책임지므로 read-model 쿼리는 threshold를 갖지 않는다.
+- **소유권 검증 위치**: 축 스코프 엔드포인트(`POST/GET /learning-facade/axes/{axisId}/...`)는 `LearningFacadeController`에 두고, `LearningFacadeQueryService`/`CommandService`가 facade/axis 소유권을 검증한 뒤 owning BC(Deck/Card)로 위임한다.
+
+## 결과 (Consequences)
+
+### 긍정적
+
+- **도메인 무변경**: `deck.axis_id`는 raw `Long` 그대로 — 4-level 응집(LearningFacade Aggregate)이 흐려지지 않고 Deck BC가 LearningAxis 엔티티를 알지 않는다.
+- **드리프트 차단**: 카드 필터 규칙(삭제 제외·상태·`axisId IN`)이 단일 Repository 메서드 한 곳에 모인다. today와 축 뷰의 카드 집합 합치도가 구조적으로 보장된다.
+- **사용자 의도의 API 표현**: "축에 덱을 단다"(생성)·"축을 누르면 카드가 보인다"(조회)가 경로에 명시되고, 단일 호출로 N+1을 회피한다.
+
+### 트레이드오프 / 부정적
+
+- **`axisName` 조인 비용**: 덱/카드 응답마다 axis 이름 cross-BC lookup 1회. N+1은 배치 조회(`findAxisNamesByIds`)로 회피하나, 도메인 조인 대비 라운드트립이 분리된다.
+- **BC 의존 신규 엣지**: `LearningFacade → Card`(조회) 의존이 추가된다. 비순환(Card는 LearningFacade 미의존)이며 `PACKAGE.md`에 명시했다.
+- **검색 경로 `axisName` 미동봉**: `DeckSummaryRow`는 raw `axisId`만 보유 — 이름이 필요한 소비자는 `findRootDecks`와 동일하게 서비스 레이어에서 배치 보강해야 한다.
+
+## 대안 비교
+
+| 대안 | 장점 | 거부 사유 |
+| --- | --- | --- |
+| **Option A — 응답 DTO/read-model 노출** (채택) | 도메인 무변경, BC 결합도 유지, 드리프트 단일화 | `axisName` cross-BC lookup 1회 비용 |
+| Option B — 도메인 연관 승격 (`deck.axisId` → `@ManyToOne LearningAxis`) | 조인 한 번에 axisName 동봉, FK 정합성 | **BC 경계(LearningFacade↔Deck) 결합도 상승**, Deck Aggregate가 LearningAxis를 알게 되어 4-level 응집이 흐려짐 |
+| Option C — facade 응답에 축별 deck/card 요약 동봉 | 추가 엔드포인트 불필요 | facade 초기 로드 비대화 — 지도 초기 로드는 가벼워야 함, 상세는 결국 별도 호출 필요 |
+
+## 다시 검토할 시점
+
+- **축당 기본 덱 1개 정책 도입 시점** — 현재는 다중 덱 허용. 카드 분류 UX 결정 후 도메인 제약 추가 여부 재평가 (fix 문서 §12 Q4).
+- **ID 직렬화 표준화(B2) 적용 시점** — 본 ADR이 추가한 `axisId`(Long→JSON 숫자)도 표준에 편입.
+- **고아 덱 경로(`POST /api/v1/decks`) 폐쇄 시점** — 사용 빈도 관측 후 (fix 문서 §12 Q2).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -21,3 +21,4 @@
 | [ADR017](ADR017-spring-forward-headers-graceful-shutdown.md) | Spring `forward-headers-strategy=native` + `server.shutdown=graceful` (Story-050) | Accepted | 2026-06-29 |
 | [ADR018](ADR018-rds-mysql-single-az-prod.md) | RDS MySQL prod single-AZ + db.t4g.micro + utf8mb4 + Asia/Seoul (Story-051) | Accepted | 2026-06-29 |
 | [ADR019](ADR019-secrets-manager-naming-and-task-role-scope.md) | Secrets Manager 5종 비밀 명명 + env-prefix 격리 + Task Role Resource scope (Story-052) | Accepted | 2026-06-30 |
+| [ADR020](ADR020-deck-axis-visibility.md) | Deck↔Axis 가시화는 read-model 노출로 한정, 도메인 연관 승격 거부 (fix-deck-axis-visibility 0.0.2v) | Accepted | 2026-06-30 |


### PR DESCRIPTION
## 배경
fix-deck-axis-visibility (0.0.2v) Story 5 — 본 fix의 결정을 문서에 박제. (백엔드 리포에 추적되는 `docs/`만 대상 — `workflow/` planning 트리는 별도.)

## 변경
- **ADR020** 신설 + index 등록: "Deck↔Axis 가시화는 read-model 노출(Option A), 도메인 연관 승격(Option B) 거부". 거부 사유(BC 결합도 상승, 4-level 응집 흐림) 박제.
- **DOMAIN.md** §2.1 Card(축 스코프 조회 = ReviewSession Layer1과 별개 사용자 표현 흐름, today와 단일 read-model 공유), §2.2 Deck(axis 결합 정책 = 자동 1 + 명시 N + 고아 보존, `createUnderAxis`, `axisId`/`axisName` read-model 노출), 변경 이력 v0.2.
- **PACKAGE.md** §6: `LearningFacade → Card`(축 카드 조회) 신규 의존 엣지 + `Review → LearningFacade` 비고에 단일 read-model 공유 명시.

독립 PR(문서만) — 코드 PR(#189/#190/#191)과 병렬 머지 가능.