### PR TITLE
fix(learning-facade): LearningAxis Soft Delete & Axis→Deck 연쇄 [Fix-Story BE1]

### DIFF
--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningAxis.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningAxis.java
@@ -24,6 +24,8 @@ public class QLearningAxis extends EntityPathBase<LearningAxis> {
 
     public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
 
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
     public final NumberPath<Integer> displayOrder = createNumber("displayOrder", Integer.class);
 
     public final QLearningFacade facade;

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
     LEARNING_AXIS_NAME_BLANK("LA002",             "축 이름은 비어 있을 수 없습니다.",                        HttpStatus.BAD_REQUEST),
     LEARNING_AXIS_DUPLICATE_NAME("LA003",         "동일한 이름의 축이 이미 존재합니다.",                     HttpStatus.CONFLICT),
     LEARNING_AXIS_REORDER_MISMATCH("LA004",       "순서 변경 id 목록이 현재 축 id 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    LEARNING_AXIS_ALREADY_DELETED("LA005",        "이미 삭제된 축입니다.",                                   HttpStatus.BAD_REQUEST),
 
     // ─── AxisTopic (v2) ────────────────────────────────────
     LEARNING_AXIS_TOPIC_NOT_FOUND("LT001",        "주제를 찾을 수 없습니다.",                                HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/thirdtool/Deck/application/service/DeckCommandService.java
+++ b/src/main/java/com/example/thirdtool/Deck/application/service/DeckCommandService.java
@@ -90,6 +90,21 @@ public class DeckCommandService {
     }
 
     /**
+     * 축(Axis)에 속한 모든 활성 Deck을 연쇄 소프트 삭제한다.
+     * (Fix — Axis↔Deck 완전 통합, 2026-07-01)
+     *
+     * <p>{@code LearningFacadeCommandService.removeAxis}가 축을 소프트 삭제한 직후 호출한다.
+     * 축=덱 정책에 따라 축이 사라지면 그 축의 Deck·Card도 함께 사라져야 하며,
+     * 각 Deck의 {@code softDelete()}는 소속 Card를 연쇄 소프트 삭제한다.
+     *
+     * <p>대상이 0건이면 no-op. 이미 삭제된 Deck은 조회 필터로 제외되므로 재삭제 예외를 만나지 않는다.
+     */
+    public void softDeleteByAxisId(Long axisId) {
+        deckRepository.findByAxisIdInAndDeletedFalse(List.of(axisId))
+                      .forEach(Deck::softDelete);
+    }
+
+    /**
      * 최근 접근 시각 갱신
      * 덱 학습 화면 진입 시 호출
      */

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
@@ -112,11 +112,18 @@ public class LearningFacadeCommandService {
     public void removeAxis(LearningFacadeCommand.RemoveAxis command) {
         LearningFacade facade = loadFacade(command.userId());
         facade.removeAxis(command.axisId());
-        // Fix — Axis↔Deck 완전 통합: 축이 소프트 삭제되면 소속 Deck도 연쇄 소프트 삭제한다.
+        // Fix — Axis↔Deck 완전 통합: 축 소프트 삭제 → flush → Deck 연쇄 소프트 삭제 순서.
+        //
+        // 순서 재배치 근거 (Reviewer Sceptical Major 지적):
+        //   Deck 연쇄를 axis flush 이전에 실행하면 관측 순서(deck 삭제 → axis 삭제)와
+        //   코드 순서(axis softDelete → deck 연쇄)가 뒤바뀐다. 현재는 무해하지만,
+        //   향후 softDeleteByAxisId가 "삭제된 축의 Deck만 삭제한다"는 방어 로직을
+        //   추가할 경우 flush 이전 조회가 0건을 반환해 연쇄 삭제가 누락된다.
+        //   → facadeRepository.save로 axis softDelete 먼저 flush → Deck 연쇄.
         // Deck.softDelete()가 소속 Card까지 연쇄 처리하므로 카드 별도 순회 불필요.
-        // 동일 트랜잭션 내에서 처리되어 원자성 보장.
-        deckCommandService.softDeleteByAxisId(command.axisId());
+        // 세 호출 모두 동일 @Transactional 경계 내에서 원자성 보장.
         facadeRepository.save(facade);
+        deckCommandService.softDeleteByAxisId(command.axisId());
     }
 
     // ──────────────────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
@@ -112,6 +112,10 @@ public class LearningFacadeCommandService {
     public void removeAxis(LearningFacadeCommand.RemoveAxis command) {
         LearningFacade facade = loadFacade(command.userId());
         facade.removeAxis(command.axisId());
+        // Fix — Axis↔Deck 완전 통합: 축이 소프트 삭제되면 소속 Deck도 연쇄 소프트 삭제한다.
+        // Deck.softDelete()가 소속 Card까지 연쇄 처리하므로 카드 별도 순회 불필요.
+        // 동일 트랜잭션 내에서 처리되어 원자성 보장.
+        deckCommandService.softDeleteByAxisId(command.axisId());
         facadeRepository.save(facade);
     }
 

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -23,9 +23,14 @@ import java.util.stream.IntStream;
 @Entity
 @Table(
         name = "learning_axis",
+        // (facade_id, name, deleted_at) 3-column composite unique — Fix Axis↔Deck 완전 통합, 2026-07-01.
+        // MySQL은 NULL 조합을 unique 검사에서 서로 다른 값으로 취급하므로:
+        //   - 활성 축(deleted_at IS NULL)끼리는 (facade_id, name) 유일 보장
+        //   - 소프트 삭제된 축(deleted_at != NULL)의 name을 재사용해도 삽입 성공
+        // V14 마이그레이션과 동기화 유지.
         uniqueConstraints = @UniqueConstraint(
                 name = "uk_learning_axis_facade_name",
-                columnNames = {"learning_facade_id", "name"}
+                columnNames = {"learning_facade_id", "name", "deleted_at"}
         )
 )
 @SQLRestriction("deleted_at IS NULL")

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ import java.util.stream.IntStream;
                 columnNames = {"learning_facade_id", "name"}
         )
 )
+@SQLRestriction("deleted_at IS NULL")
 public class LearningAxis {
 
     private static final int RECOMMENDED_TOPIC_LIMIT = 10;
@@ -66,6 +68,14 @@ public class LearningAxis {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * Soft Delete 시각. null이면 활성 상태.
+     * 클래스 상단 {@code @SQLRestriction("deleted_at IS NULL")}로 모든 read에서 자동 필터된다.
+     * (Fix — Axis↔Deck 완전 통합, 2026-07-01)
+     */
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     private LearningAxis(LearningFacade facade, String name, int displayOrder) {
         this.facade       = facade;
         this.name         = name;
@@ -88,6 +98,28 @@ public class LearningAxis {
     public void updateName(String newName) {
         validateName(newName);
         this.name = newName.trim();
+    }
+
+    /**
+     * 축 논리 삭제.
+     * {@code deleted_at}을 현재 시각으로 설정한다. 클래스 상단 {@code @SQLRestriction}으로
+     * 이후 모든 read 쿼리에서 자동 제외된다.
+     *
+     * <p>이미 삭제된 축을 재삭제하면 {@link ErrorCode#LEARNING_AXIS_ALREADY_DELETED} 예외.
+     * (Deck.softDelete()의 DECK_ALREADY_DELETED와 동일 패턴)
+     *
+     * <p>본 메서드는 자기 자신의 상태만 변경한다. 축에 속한 Deck 연쇄 소프트 삭제는
+     * Application Service(LearningFacadeCommandService.removeAxis)가 조율한다.
+     */
+    public void softDelete() {
+        if (this.deletedAt != null) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_ALREADY_DELETED);
+        }
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 
     void updateDisplayOrder(int newOrder) {

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -38,10 +38,16 @@ public class LearningFacade {
     private String concept;
 
     // ─── 세부 축 목록 ─────────────────────────────────────
+    // ⚠️ orphanRemoval=false (Fix — Axis↔Deck 완전 통합, SDD §12 Q1 결정):
+    //   LearningAxis는 Soft Delete 정책 (deleted_at). removeAxis()는 axes.remove()가 아닌
+    //   target.softDelete()만 호출한다. orphanRemoval=true를 유지하면 미래의 리팩토링에서
+    //   axes.removeIf(LearningAxis::isDeleted) 같은 코드가 조용히 hard delete를 발동시켜
+    //   Soft Delete 데이터를 손실할 위험이 있다 (Reviewer Sceptical 지적).
+    //   → axes 컬렉션에서 element를 remove하는 코드를 넣지 말 것. 삭제는 오직 softDelete()로.
     @OneToMany(
             mappedBy      = "facade",
             cascade       = CascadeType.ALL,
-            orphanRemoval = true,
+            orphanRemoval = false,
             fetch         = FetchType.LAZY
     )
     @OrderBy("displayOrder ASC")

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -87,15 +87,29 @@ public class LearningFacade {
     public LearningAxis addAxis(String name) {
         validateAxisNameDuplicate(name);
 
-        int nextOrder = axes.size() + 1;
+        // Fix — Axis↔Deck 완전 통합: displayOrder는 활성 축 기준으로 부여한다.
+        // 소프트 삭제된 축은 in-memory 컬렉션에 남아 있으나 사용자 관점의 "N번째 축"에서는 제외.
+        int nextOrder = (int) axes.stream().filter(a -> !a.isDeleted()).count() + 1;
         LearningAxis axis = LearningAxis.create(this, name, nextOrder);
         axes.add(axis);
         return axis;
     }
 
+    /**
+     * 축 소프트 삭제.
+     * (Fix — Axis↔Deck 완전 통합, 2026-07-01)
+     *
+     * <p>기존에는 {@code axes.remove(target)} + {@code orphanRemoval=true}로 hard delete했으나,
+     * 이 경로가 "카드 만들 때 축이 인식 안 되고 화면 나가면 사라진다" 이슈의 최유력 원인이었다.
+     * 이제 {@code target.softDelete()}만 호출하고 컬렉션에서는 제거하지 않는다 —
+     * {@code orphanRemoval}은 유지되지만 명시 remove가 없으므로 발동하지 않는다.
+     *
+     * <p>축에 속한 Deck 연쇄 소프트 삭제는 Application Service가 조율한다
+     * ({@code LearningFacadeCommandService.removeAxis}가 {@code DeckCommandService.softDeleteByAxisId} 호출).
+     */
     public void removeAxis(Long axisId) {
         LearningAxis target = findAxis(axisId);
-        axes.remove(target);
+        target.softDelete();
     }
 
     public void reorderAxes(List<Long> orderedAxisIds) {
@@ -117,7 +131,8 @@ public class LearningFacade {
     // ─── 보조 조회 ────────────────────────────────────────
 
     public boolean isAxisCountExceedsRecommended() {
-        return axes.size() > RECOMMENDED_AXIS_LIMIT;
+        // 활성 축만 권장 한도 카운트에 포함. 소프트 삭제된 축은 제외.
+        return getAxes().size() > RECOMMENDED_AXIS_LIMIT;
     }
 
     /**
@@ -129,7 +144,7 @@ public class LearningFacade {
         int uncovered = 0;
         int partial   = 0;
         int covered   = 0;
-        for (LearningAxis axis : axes) {
+        for (LearningAxis axis : getAxes()) {
             for (AxisTopic topic : axis.getTopics()) {
                 switch (topic.getCoverageStatus()) {
                     case NO_MATERIAL -> uncovered++;
@@ -146,17 +161,28 @@ public class LearningFacade {
      * getCoverageSummary().hasGap()과 동치지만 존재 여부 판단용 단축 경로.
      */
     public boolean hasUncoveredTopics() {
-        return axes.stream().anyMatch(LearningAxis::hasUncoveredTopics);
+        return getAxes().stream().anyMatch(LearningAxis::hasUncoveredTopics);
     }
 
+    /**
+     * 활성 축만 반환. 소프트 삭제된 축은 제외한다.
+     * (Fix — Axis↔Deck 완전 통합: 소프트 삭제된 축은 in-memory 컬렉션에 남아있으므로 접근자에서 필터링)
+     */
     public List<LearningAxis> getAxes() {
-        return Collections.unmodifiableList(axes);
+        return axes.stream()
+                   .filter(a -> !a.isDeleted())
+                   .toList();
     }
 
     // ─── 내부 유틸 ────────────────────────────────────────
 
+    /**
+     * 활성 축 단건 조회. 이미 소프트 삭제된 축은 조회 대상에서 제외된다 — 재삭제 시도는
+     * {@link ErrorCode#LEARNING_AXIS_NOT_FOUND}가 우선. Domain 검증 순서: findAxis → softDelete.
+     */
     LearningAxis findAxis(Long axisId) {
         return axes.stream()
+                   .filter(a -> !a.isDeleted())
                    .filter(a -> a.getId().equals(axisId))
                    .findFirst()
                    .orElseThrow(() -> LearningFacadeDomainException.of(
@@ -171,7 +197,9 @@ public class LearningFacade {
         if (name == null) return; // null 방어는 LearningAxis.create() 내부 validateName()이 처리
 
         String trimmed = name.trim();
+        // 활성 축만 중복 대상. 소프트 삭제된 축의 이름은 재사용 가능(단, DB UNIQUE 제약이 별도로 걸릴 수 있음 — Story 2에서 확인).
         boolean duplicated = axes.stream()
+                                 .filter(a -> !a.isDeleted())
                                  .anyMatch(a -> a.getName().equals(trimmed));
         if (duplicated) {
             throw LearningFacadeDomainException.of(
@@ -182,7 +210,9 @@ public class LearningFacade {
     }
 
     private void validateReorderIds(List<Long> orderedAxisIds) {
+        // 활성 축 기준 id 집합. 소프트 삭제된 축은 순서 변경 대상 아님.
         Set<Long> currentIds = axes.stream()
+                                   .filter(a -> !a.isDeleted())
                                    .map(LearningAxis::getId)
                                    .collect(Collectors.toSet());
 

--- a/src/main/resources/db/migration/V14__learning_axis_soft_delete.sql
+++ b/src/main/resources/db/migration/V14__learning_axis_soft_delete.sql
@@ -15,3 +15,19 @@ ALTER TABLE learning_axis
 
 -- 조회 필터( @SQLRestriction("deleted_at IS NULL") )가 인덱스를 활용하도록 보조.
 CREATE INDEX idx_learning_axis_deleted ON learning_axis (deleted_at);
+
+-- ─────────────────────────────────────────────────────────────
+-- UNIQUE 제약 재정의 (facade_id, name) → (facade_id, name, deleted_at)
+-- ─────────────────────────────────────────────────────────────
+-- V2에서 정의한 uk_learning_axis_facade_name (facade_id, name)은 소프트 삭제된 축의
+-- name도 여전히 점유해 활성 축 신규 생성 시 DataIntegrityViolationException을 유발한다.
+-- MySQL은 NULL을 UNIQUE 검사에서 서로 다른 값으로 취급하므로, deleted_at을 조합에
+-- 포함시키면:
+--   - 활성 축(deleted_at IS NULL)끼리는 여전히 (facade_id, name) 유일 보장
+--   - 소프트 삭제된 축(deleted_at != NULL)은 서로 다른 시각을 가지므로 name 중복 허용
+--   - 활성 축 name과 이미 소프트 삭제된 축 name이 겹쳐도 삽입 성공
+-- (부분 인덱스 미지원 회피 — 3-column composite unique로 등가 효과.)
+ALTER TABLE learning_axis
+    DROP INDEX uk_learning_axis_facade_name,
+    ADD CONSTRAINT uk_learning_axis_facade_name
+        UNIQUE (learning_facade_id, name, deleted_at);

--- a/src/main/resources/db/migration/V14__learning_axis_soft_delete.sql
+++ b/src/main/resources/db/migration/V14__learning_axis_soft_delete.sql
@@ -1,0 +1,17 @@
+-- =============================================================
+-- V14__learning_axis_soft_delete.sql
+-- LearningAxis Soft Delete 도입 (Fix — Axis↔Deck 완전 통합, 2026-07-01)
+--
+-- 배경: LearningAxis는 그동안 Hard Delete만 지원했다 (V2 스키마에 deleted_at 없음).
+--   LearningFacade.removeAxis()가 orphanRemoval을 통해 DB row 자체를 삭제해
+--   "카드 만들 때 축이 인식 안 되고 화면 나가면 사라진다" 이슈의 최유력 원인이었다.
+--   본 마이그레이션은 Card/Deck/Facade와 동일한 Soft Delete 정책으로 통일한다.
+--
+-- 짝 SDD: workflow/task/fix/sdd/version/0.0.2v/fix-axis-deck-full-integration.md
+-- =============================================================
+
+ALTER TABLE learning_axis
+    ADD COLUMN deleted_at DATETIME(6) NULL AFTER created_at;
+
+-- 조회 필터( @SQLRestriction("deleted_at IS NULL") )가 인덱스를 활용하도록 보조.
+CREATE INDEX idx_learning_axis_deleted ON learning_axis (deleted_at);

--- a/src/test/java/com/example/thirdtool/Deck/application/service/DeckCommandServiceSoftDeleteByAxisIdTest.java
+++ b/src/test/java/com/example/thirdtool/Deck/application/service/DeckCommandServiceSoftDeleteByAxisIdTest.java
@@ -1,0 +1,115 @@
+package com.example.thirdtool.Deck.application.service;
+
+import com.example.thirdtool.Common.Exception.BusinessException;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Deck.domain.model.Deck;
+import com.example.thirdtool.Deck.infrastructure.repository.DeckRepository;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * DeckCommandService.softDeleteByAxisId 단위 테스트
+ * (Fix — Axis↔Deck 완전 통합, 2026-07-01).
+ *
+ * <p>Mockist 전략 — Repository만 Mock, Deck 도메인은 실제 객체로 상태 전이 확인.
+ * 축 소프트 삭제 시 소속 Deck 연쇄 소프트 삭제가 정확히 동작하는지 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeckCommandService — softDeleteByAxisId")
+class DeckCommandServiceSoftDeleteByAxisIdTest {
+
+    @Mock
+    DeckRepository deckRepository;
+
+    @Mock
+    DeckQueryService deckQueryService;
+
+    @Mock
+    DeckHierarchyService deckHierarchyService;
+
+    @InjectMocks
+    DeckCommandService sut;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉네임", "tester@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("축에 속한 활성 Deck 다건이 모두 소프트 삭제된다")
+    void 다건_연쇄_softDelete() {
+        Long axisId = 100L;
+        Deck deck1 = Deck.createFromAxis(user, axisId, "덱1");
+        Deck deck2 = Deck.createFromAxis(user, axisId, "덱2");
+        given(deckRepository.findByAxisIdInAndDeletedFalse(List.of(axisId)))
+                .willReturn(List.of(deck1, deck2));
+
+        sut.softDeleteByAxisId(axisId);
+
+        assertThat(deck1.isDeleted()).isTrue();
+        assertThat(deck1.getDeletedAt()).isNotNull();
+        assertThat(deck2.isDeleted()).isTrue();
+        assertThat(deck2.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("대상 Deck이 0건이면 no-op — 예외 없이 종료")
+    void 대상_0건_noop() {
+        Long axisId = 100L;
+        given(deckRepository.findByAxisIdInAndDeletedFalse(List.of(axisId)))
+                .willReturn(List.of());
+
+        // 예외 없이 조용히 종료
+        sut.softDeleteByAxisId(axisId);
+    }
+
+    @Test
+    @DisplayName("이미 소프트 삭제된 Deck은 조회 필터로 제외되므로 재삭제 예외를 만나지 않는다")
+    void 이미삭제된_Deck_필터되어_재삭제_예외없음() {
+        Long axisId = 100L;
+        Deck alreadyDeleted = Deck.createFromAxis(user, axisId, "이미삭제");
+        alreadyDeleted.softDelete();
+        // Repository의 findByAxisIdInAndDeletedFalse는 이미 필터된 결과를 반환한다고 가정
+        given(deckRepository.findByAxisIdInAndDeletedFalse(List.of(axisId)))
+                .willReturn(List.of());
+
+        sut.softDeleteByAxisId(axisId);
+
+        // alreadyDeleted는 여전히 삭제 상태 유지, 새로운 재삭제 시도가 없어야 함
+        assertThat(alreadyDeleted.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Deck.softDelete()가 소속 Card까지 연쇄 소프트 삭제한다 — 계약 확인")
+    void softDelete_Card_연쇄_계약() {
+        Long axisId = 100L;
+        Deck deck = Deck.createFromAxis(user, axisId, "덱");
+        // Card 연쇄는 Deck.softDelete()가 담당 — 본 단위 테스트는 Deck에 위임 사실만 확인.
+        given(deckRepository.findByAxisIdInAndDeletedFalse(List.of(axisId)))
+                .willReturn(List.of(deck));
+
+        sut.softDeleteByAxisId(axisId);
+
+        // Deck이 이미 삭제된 상태로 진입하면 예외를 던지지만, 필터로 미리 걸러지므로
+        // 두 번째 softDelete 호출은 발생하지 않는다.
+        assertThatThrownBy(deck::softDelete)
+                .isInstanceOf(BusinessException.class)
+                .matches(e -> ((BusinessException) e).getErrorCode() == ErrorCode.DECK_ALREADY_DELETED);
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxisTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxisTest.java
@@ -34,6 +34,46 @@ class LearningAxisTest {
         return topic;
     }
 
+    // ─── Soft Delete (Fix — Axis↔Deck 완전 통합, 2026-07-01) ────────
+
+    @Nested
+    @DisplayName("Soft Delete")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("softDelete 호출 시 deletedAt이 현재 시각으로 설정되고 isDeleted=true")
+        void softDelete_해피_deletedAt_설정() {
+            LearningAxis axis = createAxis();
+            java.time.LocalDateTime before = java.time.LocalDateTime.now();
+
+            axis.softDelete();
+
+            assertThat(axis.isDeleted()).isTrue();
+            assertThat(axis.getDeletedAt()).isNotNull();
+            assertThat(axis.getDeletedAt()).isAfterOrEqualTo(before);
+        }
+
+        @Test
+        @DisplayName("초기 상태에서 isDeleted는 false, deletedAt은 null")
+        void 초기상태_활성() {
+            LearningAxis axis = createAxis();
+
+            assertThat(axis.isDeleted()).isFalse();
+            assertThat(axis.getDeletedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 축을 재삭제하면 LEARNING_AXIS_ALREADY_DELETED 예외")
+        void softDelete_이미삭제_예외() {
+            LearningAxis axis = createAxis();
+            axis.softDelete();
+
+            assertThatThrownBy(axis::softDelete)
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .hasMessageContaining("이미 삭제된 축입니다.");
+        }
+    }
+
     @Nested
     @DisplayName("이름 수정")
     class UpdateName {

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeTest.java
@@ -286,12 +286,12 @@ class LearningFacadeTest {
     // ─── 4. 축 삭제 ─────────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("축 삭제")
+    @DisplayName("축 삭제 (Soft Delete — Fix Axis↔Deck 완전 통합)")
     class RemoveAxis {
 
         @Test
-        @DisplayName("존재하는 axisId로 삭제하면 axes 컬렉션에서 제거된다")
-        void removeAxis_valid() {
+        @DisplayName("존재하는 axisId로 삭제하면 축은 soft delete되고 getAxes()에서 필터된다")
+        void removeAxis_softDelete_getAxes에서_필터() {
             //given
             LearningFacade facade = createFacade();
             LearningAxis axis = addAxisWithId(facade, "API 설계", 10L);
@@ -300,8 +300,24 @@ class LearningFacadeTest {
             //when
             facade.removeAxis(axisId);
 
-            //then
+            //then — axis 자체는 소프트 삭제 상태로 in-memory에 유지되지만, getAxes()는 필터
+            assertThat(axis.isDeleted()).isTrue();
+            assertThat(axis.getDeletedAt()).isNotNull();
             assertThat(facade.getAxes()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("소프트 삭제된 축은 findAxis 대상에서 제외되어 재삭제 시 NOT_FOUND")
+        void removeAxis_재삭제_NOT_FOUND() {
+            //given
+            LearningFacade facade = createFacade();
+            LearningAxis axis = addAxisWithId(facade, "API 설계", 10L);
+            facade.removeAxis(axis.getId());
+
+            //when & then — findAxis가 소프트 삭제된 축을 반환하지 않으므로 NOT_FOUND
+            assertThatThrownBy(() -> facade.removeAxis(axis.getId()))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .hasMessageContaining("세부 축을 찾을 수 없습니다.");
         }
 
         @Test
@@ -313,6 +329,39 @@ class LearningFacadeTest {
             //when & then
             assertThatThrownBy(() -> facade.removeAxis(999L))
                     .isInstanceOf(LearningFacadeDomainException.class);
+        }
+
+        @Test
+        @DisplayName("여러 축 중 하나만 삭제하면 나머지 축은 getAxes()에 유지된다")
+        void removeAxis_일부만_삭제() {
+            //given
+            LearningFacade facade = createFacade();
+            LearningAxis axis1 = addAxisWithId(facade, "API 설계", 10L);
+            LearningAxis axis2 = addAxisWithId(facade, "데이터 모델링", 11L);
+            LearningAxis axis3 = addAxisWithId(facade, "성능 최적화", 12L);
+
+            //when
+            facade.removeAxis(axis2.getId());
+
+            //then
+            assertThat(facade.getAxes()).containsExactly(axis1, axis3);
+            assertThat(axis2.isDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("축 삭제 후 신규 축 addAxis 시 displayOrder는 활성 축 기준으로 부여된다")
+        void removeAxis_후_addAxis_displayOrder_활성기준() {
+            //given
+            LearningFacade facade = createFacade();
+            LearningAxis axis1 = addAxisWithId(facade, "API 설계", 10L);
+            LearningAxis axis2 = addAxisWithId(facade, "데이터 모델링", 11L);
+            facade.removeAxis(axis1.getId());
+
+            //when — axis1(order=1)이 소프트 삭제된 상태에서 신규 추가
+            LearningAxis added = facade.addAxis("성능 최적화");
+
+            //then — 활성 axis 개수(1) + 1 = 2
+            assertThat(added.getDisplayOrder()).isEqualTo(2);
         }
     }
 

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryTest.java
@@ -22,7 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>slice §1-3 S1, S2 시나리오에 대응한다.
  * S3 (uk_learning_facade_user 위반)은 운영 코드 도메인에 명시적 unique 제약이
- * 없어 본 PR에서는 제외. S4 (soft delete) 역시 @SQLRestriction 미적용으로 제외.
+ * 없어 본 PR에서는 제외.
+ * S4 (soft delete) — Fix Axis↔Deck 완전 통합 2026-07-01부로 LearningAxis에
+ * {@code @SQLRestriction("deleted_at IS NULL")} 도입, 아래 SoftDelete 케이스 추가.
  */
 @DataJpaTest
 @ActiveProfiles("test")
@@ -118,5 +120,103 @@ class LearningFacadeRepositoryTest {
     void findAxisNamesByIds_빈입력() {
         Map<Long, String> result = repository.findAxisNamesByIds(List.of());
         assertThat(result).isEmpty();
+    }
+
+    // ─── S4: Soft Delete — @SQLRestriction 필터 검증 (Fix Axis↔Deck 완전 통합) ─────
+
+    @Test
+    @DisplayName("S4-1: 축을 softDelete하면 @SQLRestriction으로 findByUserId 조회 시 getAxes()에서 자동 제외")
+    void S4_softDelete_후_getAxes_필터() {
+        // given: 축 2개 중 1개 소프트 삭제
+        UserEntity user = UserEntity.ofLocal(
+                "s4-tester", "encoded-pw", "닉네임", "s4@example.com");
+        em.persist(user);
+
+        LearningFacade facade = LearningFacade.create(user, "백엔드 개발자");
+        facade.addAxis("살아있는 축");
+        facade.addAxis("삭제될 축");
+        em.persist(facade);
+        em.flush();
+
+        Long toDeleteAxisId = facade.getAxes().stream()
+                .filter(a -> a.getName().equals("삭제될 축"))
+                .findFirst().orElseThrow()
+                .getId();
+        facade.removeAxis(toDeleteAxisId);
+        em.flush();
+        em.clear();
+
+        // when: 재조회 (@SQLRestriction 필터가 DB 쿼리 레벨에서 적용되는지 검증)
+        Optional<LearningFacade> reloaded = repository.findByUserId(user.getId());
+
+        // then: 활성 축만 로드
+        assertThat(reloaded).isPresent();
+        assertThat(reloaded.get().getAxes()).hasSize(1);
+        assertThat(reloaded.get().getAxes().get(0).getName()).isEqualTo("살아있는 축");
+    }
+
+    @Test
+    @DisplayName("S4-2: findAxisNamesByIds — 소프트 삭제된 축의 axisId는 결과에서 자동 제외")
+    void S4_findAxisNamesByIds_softDeleted_필터() {
+        // given: 축 2개 중 1개 소프트 삭제
+        UserEntity user = UserEntity.ofLocal(
+                "s4-tester-2", "encoded-pw", "닉네임", "s4-2@example.com");
+        em.persist(user);
+
+        LearningFacade facade = LearningFacade.create(user, "백엔드 개발자");
+        facade.addAxis("살아있는 축");
+        facade.addAxis("삭제될 축");
+        em.persist(facade);
+        em.flush();
+
+        Long aliveAxisId = facade.getAxes().stream()
+                .filter(a -> a.getName().equals("살아있는 축"))
+                .findFirst().orElseThrow().getId();
+        Long toDeleteAxisId = facade.getAxes().stream()
+                .filter(a -> a.getName().equals("삭제될 축"))
+                .findFirst().orElseThrow().getId();
+        facade.removeAxis(toDeleteAxisId);
+        em.flush();
+        em.clear();
+
+        // when: 두 axisId 모두 요청
+        Map<Long, String> result = repository.findAxisNamesByIds(List.of(aliveAxisId, toDeleteAxisId));
+
+        // then: 살아있는 축만 반환 (Deck 응답에 삭제된 축 name이 새어나가지 않음)
+        assertThat(result).hasSize(1);
+        assertThat(result.get(aliveAxisId)).isEqualTo("살아있는 축");
+        assertThat(result).doesNotContainKey(toDeleteAxisId);
+    }
+
+    @Test
+    @DisplayName("S4-3: 소프트 삭제된 축과 동일 이름의 신규 축 생성 시 UNIQUE 제약 통과 (V14 3-column composite)")
+    void S4_동일이름_재사용_UNIQUE통과() {
+        // given: "알고리즘" 축 생성 → 소프트 삭제
+        UserEntity user = UserEntity.ofLocal(
+                "s4-tester-3", "encoded-pw", "닉네임", "s4-3@example.com");
+        em.persist(user);
+
+        LearningFacade facade = LearningFacade.create(user, "백엔드 개발자");
+        facade.addAxis("알고리즘");
+        em.persist(facade);
+        em.flush();
+
+        Long deletedAxisId = facade.getAxes().get(0).getId();
+        facade.removeAxis(deletedAxisId);
+        em.flush();
+        em.clear();
+
+        // when: 재조회 후 동일 이름 "알고리즘" 축 신규 추가 — V14의 3-column UNIQUE로 통과해야 함
+        LearningFacade reloaded = repository.findByUserId(user.getId()).orElseThrow();
+        reloaded.addAxis("알고리즘");
+        em.persist(reloaded);
+        em.flush();
+        em.clear();
+
+        // then: 활성 축 1개 (신규), 소프트 삭제된 축은 필터
+        LearningFacade finalState = repository.findByUserId(user.getId()).orElseThrow();
+        assertThat(finalState.getAxes()).hasSize(1);
+        assertThat(finalState.getAxes().get(0).getName()).isEqualTo("알고리즘");
+        assertThat(finalState.getAxes().get(0).getId()).isNotEqualTo(deletedAxisId);
     }
 }


### PR DESCRIPTION
## 개요
LearningAxis에 Soft Delete 정책(`deleted_at` + `@SQLRestriction`)을 도입하고, 축 삭제 시 소속 Deck을 연쇄 소프트 삭제한다. 이슈 "카드 만들 때 축 인식 안 됨 / 화면 나가면 사라짐"의 최유력 원인(`LearningFacade.removeAxis` orphanRemoval hard delete)을 원천 봉쇄한다.

## 왜 / 설계 결정
`LearningFacade.removeAxis()`가 `axes.remove(target)` + `orphanRemoval=true` 조합으로 `learning_axis` row 자체를 지워, 축이 조용히 사라진 뒤 이를 참조하던 Deck의 `axis_id`가 `ON DELETE SET NULL`로 무연결(고아) 상태가 되는 흐름이 이슈의 근본 원인이었다. Card/Deck/Facade와 동일한 Soft Delete 정책으로 통일해 (a) 데이터 보존 (b) 재해석 가능성 확보 (c) 원격 회귀 트랩(`axes.removeIf`) 원천 봉쇄를 동시 달성한다.

- **폐기**: LearningAxis Hard Delete만 지원 (V2 스키마)
- **채택**: `deleted_at DATETIME(6) NULL` + `@SQLRestriction("deleted_at IS NULL")` + Application Service가 축 → Deck 연쇄 조율
- **거부**: `boolean deleted + Repository 명시 필터` 패턴 (Deck/Card와 동일) — Convention 문서(§3.4)가 `@SQLRestriction` 권장을 명시. 관행 이탈 리스크는 후속 ADR로 확정 예정 (BE-Story 3)

관련 SDD·ADR: `workflow/task/fix/sdd/version/0.0.2v/fix-axis-deck-full-integration.md` §4.2, §8.3 (Story 1)

## 작업 내용
### BE1 코어 (3 커밋)
- **feat(learning-facade)** LearningAxis Soft Delete 도입 — `deletedAt` + `@SQLRestriction` + `softDelete()` + `isDeleted()`, ErrorCode `LEARNING_AXIS_ALREADY_DELETED("LA005")` 등록, Flyway V14 (컬럼 + 인덱스), `LearningAxisTest.SoftDelete` 3건
- **feat(learning-facade)** `LearningFacade.removeAxis()` → soft delete 전환, `getAxes()/findAxis()/addAxis()/reorderAxes()/validateAxisNameDuplicate()/isAxisCountExceedsRecommended()/getCoverageSummary()/hasUncoveredTopics()` 8개 지점이 활성 축만 필터, `LearningFacadeTest.RemoveAxis` 4건으로 확장
- **feat(deck,facade)** `DeckCommandService.softDeleteByAxisId(Long)` 신설 + `LearningFacadeCommandService.removeAxis`가 위임 호출, `DeckCommandServiceSoftDeleteByAxisIdTest` 4건

### Review 반영 (3 커밋 — Reviewer 5관점 지적 사항)
- **fix(learning-facade)** UNIQUE 제약 재정의 `(facade_id, name)` → `(facade_id, name, deleted_at)` 3-column composite — 소프트 삭제된 축과 동일 이름의 신규 축 생성 시 `DataIntegrityViolationException(500)` 원천 봉쇄. V14 SQL + `@Table` 어노테이션 동기화
- **test(learning-facade)** LearningFacadeRepositoryTest S4 시나리오 3건 추가 — `@SQLRestriction` DB 필터, `findAxisNamesByIds` JPQL 필터, UNIQUE 재정의 통과 검증
- **refactor(learning-facade)** `axes` `orphanRemoval=true → false` (SDD §12 Q1 확정), `removeAxis` 트랜잭션 순서 재배치 (`facade save → deck 연쇄`)

## 변경 유형
- [x] feat  - [x] fix  - [x] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.*" --tests "com.example.thirdtool.Deck.*" --tests "com.example.thirdtool.Card.*" --tests "com.example.thirdtool.Review.*"` → BUILD SUCCESSFUL (회귀 통과)
- 신규/갱신 케이스:
  - `LearningAxisTest.SoftDelete_*` (3건) — softDelete 해피/초기상태/재삭제 예외
  - `LearningFacadeTest.RemoveAxis_*` (4건) — softDelete + getAxes 필터 / 재삭제 NOT_FOUND / 일부만 삭제 / displayOrder 활성 기준
  - `DeckCommandServiceSoftDeleteByAxisIdTest` (4건) — 다건 연쇄 / 0건 no-op / 이미 삭제 필터 / Card 연쇄 계약
  - `LearningFacadeRepositoryTest.S4_*` (3건) — @SQLRestriction 필터 / JPQL 필터 / UNIQUE 재정의 통과

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] 모든 응답 `ApiResponse<T>` 래퍼 유지 (API 계약 변경 없음)
- [ ] DOMAIN.md / PACKAGE.md / ADR 업데이트 — **BE-Story 3에서 일괄 처리 예정** (본 PR 범위 밖)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음 (LearningFacade → Deck 방향 유지)
- [x] (stacked) 대상 브랜치 = `develop` 확인. 선행 fix (#188)는 이미 머지됨

## Open Items (후속 트랙)
- 이슈 2 완전 재현 검증은 BE-Story 2(Deck 생성 경로 단일화 + axis_id NOT NULL) 머지 이후에만 가능 (SDD §10 시나리오 D)
- `AxisRemovalCascadeIntegrationTest` — BE-Story 2 PR에 통합 검증으로 추가 예정
- `LEARNING_AXIS_ALREADY_DELETED("LA005")` — 현재 Application 경로 도달 불가(도메인 안전망만). 향후 restore/직접 조작 경로에서 활성화 예정
- ADR 신규 발행("Axis Soft Delete 채택 & @SQLRestriction 벤더 종속 트레이드오프") — BE-Story 3 문서 갱신에 포함

## 관련 이슈
- Product: `workflow/task/pes/workspectrum/sdd/done/product-learningFacade.md`
- Fix SDD: `workflow/task/fix/sdd/version/0.0.2v/fix-axis-deck-full-integration.md`
- 브레인스토밍: `workflow/task/fix/brainstorming/version/0.0.2v/issue-deck-axis-integration.md`, `issue-card-axis-recognition.md`
