### PR TITLE
feat(learning-facade): LT Epic 1 — concepts[] 도메인 완주 [Story-LT-E1-S2~S5]

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -74,8 +74,15 @@ public enum ErrorCode {
     // ─── LearningFacade ───────────────────────────────────
     LEARNING_FACADE_NOT_FOUND("LF001",       "LearningFacade를 찾을 수 없습니다.",   HttpStatus.NOT_FOUND),
     LEARNING_FACADE_ALREADY_EXISTS("LF002",  "이미 LearningFacade가 존재합니다.",    HttpStatus.CONFLICT),
-    LEARNING_FACADE_CONCEPT_BLANK("LF003",   "직업적 컨셉은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    LEARNING_FACADE_CONCEPT_BLANK("LF003",   "컨셉 값은 비어있을 수 없습니다.",     HttpStatus.BAD_REQUEST),
     LEARNING_FACADE_FORBIDDEN("LF004",       "본인의 LearningFacade가 아닙니다.",    HttpStatus.FORBIDDEN),
+
+    // ─── LearningFacade.concepts[] (Story-LT-E1-S2 / S5) ──
+    LEARNING_FACADE_CONCEPTS_SIZE_INVALID("LF005", "컨셉은 1~5개 이내여야 합니다.",   HttpStatus.BAD_REQUEST),
+    LEARNING_FACADE_CONCEPT_DUPLICATE("LF006",     "이미 등록된 컨셉입니다.",          HttpStatus.CONFLICT),
+    LEARNING_FACADE_CONCEPT_TOO_LONG("LF007",      "컨셉 값은 100자 이내여야 합니다.", HttpStatus.BAD_REQUEST),
+    LEARNING_FACADE_CONCEPTS_REORDER_MISMATCH("LF008",
+            "전달된 concept id 목록이 현재 컨셉 집합과 일치하지 않습니다.",       HttpStatus.BAD_REQUEST),
 
     // ─── LearningAxis ─────────────────────────────────────
     LEARNING_AXIS_NOT_FOUND("LA001",              "세부 축을 찾을 수 없습니다.",                             HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/dto/LearningFacadeCommand.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/dto/LearningFacadeCommand.java
@@ -21,12 +21,12 @@ public final class LearningFacadeCommand {
 
     public record CreateFacade(
             UserEntity user,
-            String concept
+            List<String> concepts
     ) {}
 
-    public record UpdateConcept(
+    public record UpdateConcepts(
             Long userId,
-            String concept
+            List<String> concepts
     ) {}
 
     public record AddAxis(

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
@@ -45,21 +45,21 @@ public class LearningFacadeCommandService {
         if (facadeRepository.existsByUserId(command.user().getId())) {
             throw LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_ALREADY_EXISTS);
         }
-        LearningFacade facade = LearningFacade.create(command.user(), command.concept());
+        LearningFacade facade = LearningFacade.create(command.user(), command.concepts());
         return CreateFacade.of(facadeRepository.save(facade));
     }
 
     // ──────────────────────────────────────────────────────
-    // 3. 컨셉 수정
+    // 3. 컨셉 수정 (Story-LT-E1-S4: concepts[] 통째 교체)
     // ──────────────────────────────────────────────────────
 
-    public UpdateConcept updateConcept(LearningFacadeCommand.UpdateConcept command) {
+    public UpdateConcepts updateConcepts(LearningFacadeCommand.UpdateConcepts command) {
         LearningFacade facade = loadFacade(command.userId());
-        ConceptChangeRecord record = facade.updateConcept(command.concept());
+        ConceptsChangeRecord record = facade.updateConcepts(command.concepts());
         if (record.isChanged()) {
             facadeRepository.save(facade);
         }
-        return UpdateConcept.of(facade, record);
+        return UpdateConcepts.of(facade, record);
     }
 
     // ──────────────────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/ConceptsChangeRecord.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/ConceptsChangeRecord.java
@@ -1,0 +1,47 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link LearningFacade#updateConcepts(List)}의 결과 VO.
+ *
+ * <p>이전/현재 값 리스트와 변화 분류(added/removed/kept)를 반환한다.
+ * 순서만 바뀌어도 {@link #isChanged()}는 true — 리스트 순서 자체가 도메인 의미이기 때문.
+ *
+ * <p>Story-LT-E1-S3.
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ConceptsChangeRecord {
+
+    private final List<String> previous;
+    private final List<String> current;
+    private final List<String> added;
+    private final List<String> removed;
+    private final List<String> kept;
+
+    static ConceptsChangeRecord of(
+            List<String> previous,
+            List<String> current,
+            List<String> added,
+            List<String> removed,
+            List<String> kept
+    ) {
+        return new ConceptsChangeRecord(
+                Collections.unmodifiableList(previous),
+                Collections.unmodifiableList(current),
+                Collections.unmodifiableList(added),
+                Collections.unmodifiableList(removed),
+                Collections.unmodifiableList(kept)
+        );
+    }
+
+    public boolean isChanged() {
+        return !previous.equals(current);
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -103,6 +103,42 @@ public class LearningFacade {
         return facade;
     }
 
+    /**
+     * concepts 다건 진입점 (Story-LT-E1-S4).
+     * size/blank/중복 검증 후 legacy {@code concept}은 첫 값으로 초기화되고 컬렉션은 1..N 순서로 채워진다.
+     */
+    public static LearningFacade create(UserEntity user, List<String> newConcepts) {
+        requireNonNull(user, "user");
+        if (newConcepts == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "concepts는 null일 수 없습니다."
+            );
+        }
+        if (newConcepts.size() < MIN_CONCEPT_COUNT || newConcepts.size() > MAX_CONCEPT_COUNT) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID,
+                    "size=" + newConcepts.size()
+            );
+        }
+        List<String> normalized = new ArrayList<>();
+        for (String v : newConcepts) {
+            String n = LearningFacadeConcept.normalizeValue(v);
+            if (normalized.contains(n)) {
+                throw LearningFacadeDomainException.of(
+                        ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE,
+                        "value=" + n
+                );
+            }
+            normalized.add(n);
+        }
+        LearningFacade facade = new LearningFacade(user, normalized.get(0));
+        for (int i = 0; i < normalized.size(); i++) {
+            facade.concepts.add(LearningFacadeConcept.of(facade, normalized.get(i), i + 1));
+        }
+        return facade;
+    }
+
     // ─── 행위 ─────────────────────────────────────────────
 
     public ConceptChangeRecord updateConcept(String newConcept) {

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -212,6 +212,68 @@ public class LearningFacade {
     }
 
     /**
+     * concepts를 전달된 리스트로 통째 교체한다 (다건 부분성공 불허).
+     *
+     * <p>규칙:
+     * <ul>
+     *   <li>null 리스트 → {@code INVALID_INPUT}</li>
+     *   <li>size가 {@link #MIN_CONCEPT_COUNT}~{@link #MAX_CONCEPT_COUNT} 범위 밖 → {@code LEARNING_FACADE_CONCEPTS_SIZE_INVALID}</li>
+     *   <li>각 값은 trim + blank 거부 + 길이 검증</li>
+     *   <li>정규화 후 리스트 내 중복 → {@code LEARNING_FACADE_CONCEPT_DUPLICATE}</li>
+     *   <li>기존 concepts 전체를 제거 후 신규 리스트 순서대로 1-based displayOrder 부여</li>
+     *   <li>legacy {@code concept} 컬럼은 첫 항목과 동기화</li>
+     * </ul>
+     *
+     * @return {@link ConceptsChangeRecord} — previous / current / added / removed / kept
+     */
+    public ConceptsChangeRecord updateConcepts(List<String> newValues) {
+        if (newValues == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "concepts는 null일 수 없습니다."
+            );
+        }
+        if (newValues.size() < MIN_CONCEPT_COUNT || newValues.size() > MAX_CONCEPT_COUNT) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID,
+                    "size=" + newValues.size()
+            );
+        }
+        List<String> normalized = new ArrayList<>();
+        for (String v : newValues) {
+            String n = LearningFacadeConcept.normalizeValue(v);
+            if (normalized.contains(n)) {
+                throw LearningFacadeDomainException.of(
+                        ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE,
+                        "value=" + n
+                );
+            }
+            normalized.add(n);
+        }
+
+        List<String> previous = getConceptValues();
+        List<String> added    = normalized.stream()
+                                          .filter(n -> !previous.contains(n))
+                                          .toList();
+        List<String> removed  = previous.stream()
+                                        .filter(p -> !normalized.contains(p))
+                                        .toList();
+        List<String> kept     = normalized.stream()
+                                          .filter(previous::contains)
+                                          .toList();
+
+        // 통째 교체 — orphanRemoval=true 로 detach된 자식은 flush 시 삭제된다.
+        concepts.clear();
+        for (int i = 0; i < normalized.size(); i++) {
+            concepts.add(LearningFacadeConcept.of(this, normalized.get(i), i + 1));
+        }
+        // legacy 단수 concept 필드 동기화 (컬럼 DROP 전까지 유지)
+        this.concept = normalized.get(0);
+
+        return ConceptsChangeRecord.of(previous, normalized, added, removed, kept);
+    }
+
+    /**
      * 현재 concepts를 displayOrder ASC 순으로 반환. 반환된 리스트는 unmodifiable.
      */
     public List<LearningFacadeConcept> getConcepts() {

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -23,6 +23,12 @@ public class LearningFacade {
 
     private static final int RECOMMENDED_AXIS_LIMIT = 5;
 
+    // ─── concepts[] 정책 상수 (Story-LT-E1-S2 / S5) ────────
+    // Application Service · Controller · FE 어디도 재정의 금지 — 도메인 단일 진실 소스.
+    public static final int MIN_CONCEPT_COUNT        = 1;
+    public static final int MAX_CONCEPT_COUNT        = 5;
+    public static final int MAX_CONCEPT_VALUE_LENGTH = 100;
+
     // ─── 식별자 ───────────────────────────────────────────
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,8 +40,25 @@ public class LearningFacade {
     @JoinColumn(name = "user_id", nullable = false, updatable = false)
     private UserEntity user;
 
-    @Column(name = "concept", nullable = false, length = 100)
+    /**
+     * 단일 concept 컬럼 (Legacy, Story-LT-E1-S1 이후 deprecated).
+     * <p>NOT NULL 유지 상태이며 컬럼 DROP은 별도 릴리스에서 처리한다.
+     * 도메인은 {@link #concepts} 컬렉션을 진실 소스로 사용하고,
+     * 이 필드는 backfill/backward-compat 용으로 첫 concept 값과 동기화된다.
+     */
+    @Column(name = "concept", nullable = false, length = MAX_CONCEPT_VALUE_LENGTH)
     private String concept;
+
+    // ─── concepts[] 컬렉션 (Story-LT-E1-S2) ────────────────
+    // learning_facade_concept 자식 테이블 매핑. 노출은 getConcepts()의 unmodifiableList로만.
+    @OneToMany(
+            mappedBy      = "facade",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("displayOrder ASC")
+    private final List<LearningFacadeConcept> concepts = new ArrayList<>();
 
     // ─── 세부 축 목록 ─────────────────────────────────────
     // ⚠️ orphanRemoval=false (Fix — Axis↔Deck 완전 통합, SDD §12 Q1 결정):
@@ -72,7 +95,12 @@ public class LearningFacade {
     public static LearningFacade create(UserEntity user, String concept) {
         requireNonNull(user, "user");
         validateConcept(concept);
-        return new LearningFacade(user, concept.trim());
+        LearningFacade facade = new LearningFacade(user, concept.trim());
+        // Story-LT-E1-S2: 단수 concept 생성 시 concepts 컬렉션에도 첫 항목으로 동기 추가한다.
+        // 도메인은 concepts를 진실 소스로 사용하므로 생성 시점에 collection과 legacy 필드가
+        // 언제나 일관된 상태여야 한다.
+        facade.concepts.add(LearningFacadeConcept.of(facade, concept, 1));
+        return facade;
     }
 
     // ─── 행위 ─────────────────────────────────────────────
@@ -89,6 +117,117 @@ public class LearningFacade {
         this.concept = trimmed;
         return ConceptChangeRecord.changed(previous, this.concept);
     }
+
+    // ─── concepts[] 컬렉션 API (Story-LT-E1-S2) ───────────
+
+    /**
+     * 컨셉 1건을 컬렉션 끝에 추가한다.
+     *
+     * <p>규칙:
+     * <ul>
+     *   <li>value는 trim + blank 거부 + 길이 검증 ({@link LearningFacadeConcept#normalizeValue})</li>
+     *   <li>trim 후 값 기준 중복 거부 → {@link ErrorCode#LEARNING_FACADE_CONCEPT_DUPLICATE}</li>
+     *   <li>추가 후 {@code concepts.size() > MAX_CONCEPT_COUNT}이면 거부 → {@link ErrorCode#LEARNING_FACADE_CONCEPTS_SIZE_INVALID}</li>
+     *   <li>displayOrder는 현재 concepts 크기 + 1 (1-based)</li>
+     * </ul>
+     */
+    public LearningFacadeConcept addConcept(String value) {
+        String normalized = LearningFacadeConcept.normalizeValue(value);
+        validateConceptDuplicate(normalized);
+        if (concepts.size() + 1 > MAX_CONCEPT_COUNT) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID,
+                    "현재 " + concepts.size() + "개 상태에서 추가 시 최대(" + MAX_CONCEPT_COUNT + ")를 초과합니다."
+            );
+        }
+        LearningFacadeConcept concept = LearningFacadeConcept.of(this, normalized, concepts.size() + 1);
+        concepts.add(concept);
+        return concept;
+    }
+
+    /**
+     * 컨셉 1건 제거. 최소 개수({@link #MIN_CONCEPT_COUNT}) 미만이 되는 제거는 거부한다.
+     * displayOrder는 제거 후 1-based로 재부여된다.
+     */
+    public void removeConcept(Long conceptId) {
+        if (conceptId == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "conceptId는 null일 수 없습니다."
+            );
+        }
+        if (concepts.size() - 1 < MIN_CONCEPT_COUNT) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID,
+                    "최소 " + MIN_CONCEPT_COUNT + "개는 유지해야 합니다."
+            );
+        }
+        LearningFacadeConcept target = concepts.stream()
+                .filter(c -> conceptId.equals(c.getId()))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(
+                        ErrorCode.INVALID_INPUT,
+                        "conceptId=" + conceptId + " 는 현재 concepts에 존재하지 않습니다."
+                ));
+        concepts.remove(target);
+        // 남은 항목의 displayOrder를 1..N으로 재부여.
+        for (int i = 0; i < concepts.size(); i++) {
+            concepts.get(i).updateDisplayOrder(i + 1);
+        }
+    }
+
+    /**
+     * 컨셉 순서 재배치. 전달된 id 목록이 현재 concepts id 집합과 정확히 일치해야 한다.
+     * 불일치 시 {@link ErrorCode#LEARNING_FACADE_CONCEPTS_REORDER_MISMATCH}.
+     * 빈 리스트는 concepts가 비어있을 때만 정상(no-op).
+     */
+    public void reorderConcepts(List<Long> orderedConceptIds) {
+        if (orderedConceptIds == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "orderedConceptIds는 null일 수 없습니다."
+            );
+        }
+        Set<Long> currentIds  = concepts.stream()
+                                        .map(LearningFacadeConcept::getId)
+                                        .collect(Collectors.toSet());
+        Set<Long> incomingIds = new HashSet<>(orderedConceptIds);
+        if (orderedConceptIds.size() != currentIds.size() || !currentIds.equals(incomingIds)) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPTS_REORDER_MISMATCH,
+                    "전달 id 수=" + orderedConceptIds.size() + " · 현재 concepts 수=" + currentIds.size()
+            );
+        }
+        IntStream.range(0, orderedConceptIds.size()).forEach(i -> {
+            Long id = orderedConceptIds.get(i);
+            LearningFacadeConcept target = concepts.stream()
+                    .filter(c -> id.equals(c.getId()))
+                    .findFirst()
+                    .orElseThrow(); // 위 validation에서 방지됨
+            target.updateDisplayOrder(i + 1);
+        });
+        // 내부 컬렉션도 displayOrder 순으로 정렬해 in-memory 조회 시 순서 일관성 보장.
+        // (@OrderBy는 DB에서 load 시점만 적용되므로 in-memory 변경 후엔 수동 정렬 필요)
+        concepts.sort(java.util.Comparator.comparingInt(LearningFacadeConcept::getDisplayOrder));
+    }
+
+    /**
+     * 현재 concepts를 displayOrder ASC 순으로 반환. 반환된 리스트는 unmodifiable.
+     */
+    public List<LearningFacadeConcept> getConcepts() {
+        return Collections.unmodifiableList(concepts);
+    }
+
+    /**
+     * concepts 컬렉션의 값 문자열만 뽑아 순서대로 반환 (API 응답 편의).
+     */
+    public List<String> getConceptValues() {
+        return concepts.stream()
+                       .map(LearningFacadeConcept::getValue)
+                       .toList();
+    }
+
+    // ─── LearningAxis API ─────────────────────────────────
 
     public LearningAxis addAxis(String name) {
         validateAxisNameDuplicate(name);
@@ -198,6 +337,18 @@ public class LearningFacade {
     }
 
     // ─── 내부 검증 ────────────────────────────────────────
+
+    private void validateConceptDuplicate(String normalizedValue) {
+        // trim된 값 기준 대소문자 정확 매칭으로 중복 판정.
+        boolean duplicated = concepts.stream()
+                                     .anyMatch(c -> c.getValue().equals(normalizedValue));
+        if (duplicated) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE,
+                    "value=" + normalizedValue
+            );
+        }
+    }
 
     private void validateAxisNameDuplicate(String name) {
         if (name == null) return; // null 방어는 LearningAxis.create() 내부 validateName()이 처리

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeConcept.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeConcept.java
@@ -1,0 +1,102 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * LearningFacade 소유의 컨셉 값. `learning_facade_concept` 테이블(V16)에 매핑.
+ *
+ * <p>생성은 정적 팩토리 {@link #of(LearningFacade, String, int)}만 사용 — new 금지.
+ * displayOrder는 1-based (테이블 CHECK는 {@code >= 0} 안전망).
+ * 값은 항상 trim된 상태로 저장되며 blank/길이 초과는 팩토리에서 거부한다.
+ *
+ * <p>Story-LT-E1-S2.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "learning_facade_concept")
+public class LearningFacadeConcept {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "learning_facade_concept_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "learning_facade_id", nullable = false, updatable = false)
+    private LearningFacade facade;
+
+    /** 컨셉 값. V16 컬럼 {@code concept_value}. MySQL 예약어 회피 목적. */
+    @Column(name = "concept_value", nullable = false, length = LearningFacade.MAX_CONCEPT_VALUE_LENGTH)
+    private String value;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LearningFacadeConcept(LearningFacade facade, String value, int displayOrder) {
+        this.facade       = facade;
+        this.value        = value;
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+     * 정적 팩토리. Aggregate Root({@link LearningFacade})의 행위를 통해서만 호출된다.
+     * value는 trim + blank/길이 검증 후 저장. displayOrder는 1-based.
+     */
+    static LearningFacadeConcept of(LearningFacade facade, String value, int displayOrder) {
+        if (facade == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "facade은(는) null일 수 없습니다."
+            );
+        }
+        String normalized = normalizeValue(value);
+        if (displayOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. displayOrder=" + displayOrder
+            );
+        }
+        return new LearningFacadeConcept(facade, normalized, displayOrder);
+    }
+
+    void updateDisplayOrder(int newOrder) {
+        if (newOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. newOrder=" + newOrder
+            );
+        }
+        this.displayOrder = newOrder;
+    }
+
+    /**
+     * 입력 값 정규화 — trim 후 blank/길이 검증. 실패 시 도메인 예외.
+     * package-private: {@link LearningFacade}가 컬렉션 재정렬/치환 시에도 재사용한다.
+     */
+    static String normalizeValue(String value) {
+        if (value == null || value.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_CONCEPT_BLANK);
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > LearningFacade.MAX_CONCEPT_VALUE_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_FACADE_CONCEPT_TOO_LONG,
+                    "value.length=" + trimmed.length()
+            );
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
@@ -41,7 +41,7 @@ public class LearningFacadeController {
             @Valid @RequestBody LearningFacadeRequest.CreateFacade request
     ) {
         return facadeCommandService.createFacade(
-                new LearningFacadeCommand.CreateFacade(user, request.concept()));
+                new LearningFacadeCommand.CreateFacade(user, request.concepts()));
     }
 
     // 2. GET /learning-facade
@@ -53,14 +53,14 @@ public class LearningFacadeController {
                 new LearningFacadeQuery.GetFacade(user.getId()));
     }
 
-    // 3. PATCH /learning-facade/concept
-    @PatchMapping("/concept")
-    public LearningFacadeResponse.UpdateConcept updateConcept(
+    // 3. PATCH /learning-facade/concepts (Story-LT-E1-S4: concepts[] 통째 교체)
+    @PatchMapping("/concepts")
+    public LearningFacadeResponse.UpdateConcepts updateConcepts(
             @AuthenticationPrincipal UserEntity user,
-            @Valid @RequestBody LearningFacadeRequest.UpdateConcept request
+            @Valid @RequestBody LearningFacadeRequest.UpdateConcepts request
     ) {
-        return facadeCommandService.updateConcept(
-                new LearningFacadeCommand.UpdateConcept(user.getId(), request.concept()));
+        return facadeCommandService.updateConcepts(
+                new LearningFacadeCommand.UpdateConcepts(user.getId(), request.concepts()));
     }
 
     // 4. POST /learning-facade/axes

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
@@ -14,11 +14,16 @@ public class LearningFacadeRequest {
 
     /**
      * LearningFacade 생성 요청.
-     * concepts 배열은 필수 · 1~5개 · 각 값은 도메인에서 trim/blank/길이/중복 검증.
+     * concepts 배열은 필수 · 도메인 상수 MIN_CONCEPT_COUNT~MAX_CONCEPT_COUNT 개 ·
+     * 각 값은 도메인에서 trim/blank/길이/중복 검증.
+     * Story-LT-E1-S5: 상수는 도메인({@link com.example.thirdtool.LearningFacade.domain.model.LearningFacade})에서만 정의 —
+     * 여기서 재정의하지 않고 참조.
      */
     public record CreateFacade(
             @NotNull
-            @jakarta.validation.constraints.Size(min = 1, max = 5,
+            @jakarta.validation.constraints.Size(
+                    min = com.example.thirdtool.LearningFacade.domain.model.LearningFacade.MIN_CONCEPT_COUNT,
+                    max = com.example.thirdtool.LearningFacade.domain.model.LearningFacade.MAX_CONCEPT_COUNT,
                     message = "컨셉은 1~5개 이내여야 합니다.")
             List<String> concepts
     ) {}
@@ -26,10 +31,13 @@ public class LearningFacadeRequest {
     /**
      * LearningFacade.concepts 통째 교체 요청.
      * 도메인 {@code updateConcepts()}가 부분성공 불허 · size/blank/중복 검증.
+     * Story-LT-E1-S5: 도메인 상수 참조.
      */
     public record UpdateConcepts(
             @NotNull
-            @jakarta.validation.constraints.Size(min = 1, max = 5,
+            @jakarta.validation.constraints.Size(
+                    min = com.example.thirdtool.LearningFacade.domain.model.LearningFacade.MIN_CONCEPT_COUNT,
+                    max = com.example.thirdtool.LearningFacade.domain.model.LearningFacade.MAX_CONCEPT_COUNT,
                     message = "컨셉은 1~5개 이내여야 합니다.")
             List<String> concepts
     ) {}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
@@ -12,14 +12,26 @@ public class LearningFacadeRequest {
 
     // ─── Facade ───────────────────────────────────────────
 
+    /**
+     * LearningFacade 생성 요청.
+     * concepts 배열은 필수 · 1~5개 · 각 값은 도메인에서 trim/blank/길이/중복 검증.
+     */
     public record CreateFacade(
-            @NotBlank
-            String concept
+            @NotNull
+            @jakarta.validation.constraints.Size(min = 1, max = 5,
+                    message = "컨셉은 1~5개 이내여야 합니다.")
+            List<String> concepts
     ) {}
 
-    public record UpdateConcept(
-            @NotBlank
-            String concept
+    /**
+     * LearningFacade.concepts 통째 교체 요청.
+     * 도메인 {@code updateConcepts()}가 부분성공 불허 · size/blank/중복 검증.
+     */
+    public record UpdateConcepts(
+            @NotNull
+            @jakarta.validation.constraints.Size(min = 1, max = 5,
+                    message = "컨셉은 1~5개 이내여야 합니다.")
+            List<String> concepts
     ) {}
 
     // ─── Axis ─────────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
@@ -185,14 +185,14 @@ public class LearningFacadeResponse {
 
     public record CreateFacade(
             Long facadeId,
-            String concept,
+            List<String> concepts,
             List<AxisItem> axes,
             LocalDateTime createdAt
     ) {
         public static CreateFacade of(LearningFacade facade) {
             return new CreateFacade(
                     facade.getId(),
-                    facade.getConcept(),
+                    facade.getConceptValues(),
                     List.of(),
                     facade.getCreatedAt()
             );
@@ -205,7 +205,7 @@ public class LearningFacadeResponse {
 
     public record FacadeDetail(
             Long facadeId,
-            String concept,
+            List<String> concepts,
             CoverageSummary coverageSummary,
             boolean isAxisCountExceedsRecommended,
             List<AxisItem> axes,
@@ -226,7 +226,7 @@ public class LearningFacadeResponse {
                                       java.util.Map<Long, List<Deck>> linkedDecksByAxis) {
             return new FacadeDetail(
                     facade.getId(),
-                    facade.getConcept(),
+                    facade.getConceptValues(),
                     CoverageSummary.from(facade.getCoverageSummary()),
                     facade.isAxisCountExceedsRecommended(),
                     facade.getAxes().stream()
@@ -245,19 +245,23 @@ public class LearningFacadeResponse {
     // 3. UpdateConcept
     // ──────────────────────────────────────────────────────
 
-    public record UpdateConcept(
+    public record UpdateConcepts(
             Long facadeId,
-            String concept,
-            boolean isConceptChanged,
-            boolean isDrifted,
+            List<String> concepts,
+            List<String> added,
+            List<String> removed,
+            List<String> kept,
+            boolean isChanged,
             LocalDateTime updatedAt
     ) {
-        public static UpdateConcept of(LearningFacade facade, ConceptChangeRecord record) {
-            return new UpdateConcept(
+        public static UpdateConcepts of(LearningFacade facade, ConceptsChangeRecord record) {
+            return new UpdateConcepts(
                     facade.getId(),
-                    facade.getConcept(),
+                    facade.getConceptValues(),
+                    record.getAdded(),
+                    record.getRemoved(),
+                    record.getKept(),
                     record.isChanged(),
-                    record.isDrifted(),
                     facade.getUpdatedAt()
             );
         }

--- a/src/main/resources/db/migration/R17__rollback_learning_facade_concept_backfill.sql
+++ b/src/main/resources/db/migration/R17__rollback_learning_facade_concept_backfill.sql
@@ -1,0 +1,18 @@
+-- =============================================================
+-- R17__rollback_learning_facade_concept_backfill.sql
+-- Story-LT-E1-S3 rollback: V17 백필로 생성된 첫 항목(displayOrder=1)을
+-- concept 값과 일치하는 경우에만 되돌린다.
+--
+-- ⚠️ Story-LT-E1-S3 이후 사용자가 addConcept로 추가한 항목은 삭제하지 않는다 —
+-- concept_value가 단수 concept와 일치하고 displayOrder=1이며,
+-- 해당 facade에 자식 row가 정확히 1개인 경우에만 rollback 대상.
+-- =============================================================
+
+DELETE lfc
+FROM   learning_facade_concept lfc
+JOIN   learning_facade lf ON lf.learning_facade_id = lfc.learning_facade_id
+WHERE  lfc.display_order = 1
+  AND  lfc.concept_value = TRIM(lf.concept)
+  AND  (SELECT COUNT(*)
+        FROM   learning_facade_concept x
+        WHERE  x.learning_facade_id = lfc.learning_facade_id) = 1;

--- a/src/main/resources/db/migration/V17__learning_facade_concept_backfill.sql
+++ b/src/main/resources/db/migration/V17__learning_facade_concept_backfill.sql
@@ -1,0 +1,28 @@
+-- =============================================================
+-- V17__learning_facade_concept_backfill.sql
+-- LT Epic 1 Story 1-3: 단수 learning_facade.concept → learning_facade_concept 백필
+--
+-- 기존 facade의 단수 concept 값을 자식 테이블 첫 항목(displayOrder=1)으로 이전.
+-- - concept IS NULL / TRIM(concept) = '' 는 skip
+-- - 이미 자식 row가 존재하는 facade는 skip (idempotent)
+-- - learning_facade.concept 컬럼은 유지 (컬럼 DROP은 별도 릴리스)
+--
+-- 안전성: 자식 테이블 UNIQUE (learning_facade_id, concept_value)로 재실행 시 실패 없이
+-- 조용히 skip (NOT EXISTS 서브쿼리로 명시적 idempotency).
+--
+-- conventions.md §3.8: 새 V 버전 파일만 추가 — V16 수정 금지.
+-- =============================================================
+
+INSERT INTO learning_facade_concept (learning_facade_id, concept_value, display_order, created_at)
+SELECT lf.learning_facade_id,
+       TRIM(lf.concept),
+       1,
+       CURRENT_TIMESTAMP(6)
+FROM   learning_facade lf
+WHERE  lf.concept IS NOT NULL
+  AND  TRIM(lf.concept) <> ''
+  AND  NOT EXISTS (
+         SELECT 1
+         FROM   learning_facade_concept lfc
+         WHERE  lfc.learning_facade_id = lf.learning_facade_id
+       );

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeConceptsPolicyTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeConceptsPolicyTest.java
@@ -1,0 +1,46 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-LT-E1-S5 · concepts 도메인 상수 · ErrorCode 정합 검증.
+ *
+ * <p>다른 레이어(Application Service / Controller / FE)가 도메인 상수를
+ * 재정의하지 않고 참조하는지 정적 확인 — 여기서는 도메인 상수 자체가 존재하고
+ * ErrorCode 4종이 enum에 등록됐는지만 검증한다.
+ */
+@DisplayName("LearningFacade · concepts 정책 상수 · ErrorCode 정합")
+class LearningFacadeConceptsPolicyTest {
+
+    @Test
+    @DisplayName("도메인_상수_3종_등록")
+    void 도메인_상수_3종_등록() {
+        assertThat(LearningFacade.MIN_CONCEPT_COUNT).isEqualTo(1);
+        assertThat(LearningFacade.MAX_CONCEPT_COUNT).isEqualTo(5);
+        assertThat(LearningFacade.MAX_CONCEPT_VALUE_LENGTH).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("ErrorCode_4종_등록_SIZE_INVALID_DUPLICATE_BLANK_TOO_LONG")
+    void ErrorCode_4종_등록_SIZE_INVALID_DUPLICATE_BLANK_TOO_LONG() {
+        // BLANK는 LF003 (기존 재사용), SIZE_INVALID·DUPLICATE·TOO_LONG는 신규 (LF005~007)
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPT_BLANK.getCode()).isEqualTo("LF003");
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID.getCode()).isEqualTo("LF005");
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE.getCode()).isEqualTo("LF006");
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPT_TOO_LONG.getCode()).isEqualTo("LF007");
+    }
+
+    @Test
+    @DisplayName("ErrorCode_HttpStatus_매핑_정합")
+    void ErrorCode_HttpStatus_매핑_정합() {
+        // BAD_REQUEST → 검증 실패, CONFLICT → 중복
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPT_BLANK.getStatus().value()).isEqualTo(400);
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID.getStatus().value()).isEqualTo(400);
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPT_TOO_LONG.getStatus().value()).isEqualTo(400);
+        assertThat(ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE.getStatus().value()).isEqualTo(409);
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeConceptsTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeConceptsTest.java
@@ -1,0 +1,269 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E1-S2 · concepts[] 컬렉션 API 테스트.
+ * 해피 / 엣지 / 예외 세트 커버.
+ */
+@DisplayName("LearningFacade · concepts[] 컬렉션 API")
+class LearningFacadeConceptsTest {
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    private LearningFacade createFacade() {
+        return LearningFacade.create(user, "백엔드");
+    }
+
+    private static LearningFacadeConcept addConceptWithId(LearningFacade facade, String value, Long id) {
+        LearningFacadeConcept c = facade.addConcept(value);
+        ReflectionTestUtils.setField(c, "id", id);
+        return c;
+    }
+
+    // ─── 생성 (create 팩토리와 concepts 동기화) ─────────────
+
+    @Nested
+    @DisplayName("create — 단수 concept은 concepts[0]으로 동기화")
+    class CreateSync {
+
+        @Test
+        @DisplayName("create_valid_concepts에도_첫_항목으로_추가된다")
+        void create_valid_concepts에도_첫_항목으로_추가된다() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+
+            assertThat(facade.getConcept()).isEqualTo("백엔드");
+            assertThat(facade.getConcepts()).hasSize(1);
+            assertThat(facade.getConcepts().get(0).getValue()).isEqualTo("백엔드");
+            assertThat(facade.getConcepts().get(0).getDisplayOrder()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("create_concept_공백_포함이면_trim된_값으로_concepts에도_저장")
+        void create_concept_공백_포함이면_trim된_값으로_concepts에도_저장() {
+            LearningFacade facade = LearningFacade.create(user, "  백엔드  ");
+            assertThat(facade.getConceptValues()).containsExactly("백엔드");
+        }
+    }
+
+    // ─── addConcept — 해피 ──────────────────────────────────
+
+    @Nested
+    @DisplayName("addConcept — 해피")
+    class AddHappy {
+
+        @Test
+        @DisplayName("addConcept_첫번째_이후_추가_displayOrder는_마지막플러스1")
+        void addConcept_첫번째_이후_추가_displayOrder는_마지막플러스1() {
+            LearningFacade facade = createFacade();
+            LearningFacadeConcept second = facade.addConcept("시스템설계");
+
+            assertThat(facade.getConcepts()).hasSize(2);
+            assertThat(second.getDisplayOrder()).isEqualTo(2);
+            assertThat(facade.getConceptValues()).containsExactly("백엔드", "시스템설계");
+        }
+
+        @Test
+        @DisplayName("addConcept_공백_포함_값은_trim되어_저장")
+        void addConcept_공백_포함_값은_trim되어_저장() {
+            LearningFacade facade = createFacade();
+            facade.addConcept("  분산시스템  ");
+            assertThat(facade.getConceptValues()).containsExactly("백엔드", "분산시스템");
+        }
+
+        @Test
+        @DisplayName("addConcept_5개까지는_정상_허용")
+        void addConcept_5개까지는_정상_허용() {
+            LearningFacade facade = createFacade(); // 1개
+            facade.addConcept("B");
+            facade.addConcept("C");
+            facade.addConcept("D");
+            facade.addConcept("E");
+            assertThat(facade.getConcepts()).hasSize(5);
+        }
+    }
+
+    // ─── addConcept — 엣지·예외 ─────────────────────────────
+
+    @Nested
+    @DisplayName("addConcept — 예외")
+    class AddException {
+
+        @Test
+        @DisplayName("addConcept_blank_예외")
+        void addConcept_blank_예외() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.addConcept("   "))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPT_BLANK);
+        }
+
+        @Test
+        @DisplayName("addConcept_null_예외")
+        void addConcept_null_예외() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.addConcept(null))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPT_BLANK);
+        }
+
+        @Test
+        @DisplayName("addConcept_동일값_trim후_중복_예외")
+        void addConcept_동일값_trim후_중복_예외() {
+            LearningFacade facade = createFacade(); // "백엔드"
+            assertThatThrownBy(() -> facade.addConcept("  백엔드  "))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE);
+        }
+
+        @Test
+        @DisplayName("addConcept_6번째_추가시_SIZE_INVALID_예외")
+        void addConcept_6번째_추가시_SIZE_INVALID_예외() {
+            LearningFacade facade = createFacade(); // 1개
+            facade.addConcept("B");
+            facade.addConcept("C");
+            facade.addConcept("D");
+            facade.addConcept("E"); // 총 5개
+
+            assertThatThrownBy(() -> facade.addConcept("F"))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID);
+        }
+
+        @Test
+        @DisplayName("addConcept_101자_TOO_LONG_예외")
+        void addConcept_101자_TOO_LONG_예외() {
+            LearningFacade facade = createFacade();
+            String longValue = "a".repeat(101);
+            assertThatThrownBy(() -> facade.addConcept(longValue))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPT_TOO_LONG);
+        }
+    }
+
+    // ─── getConcepts unmodifiable ──────────────────────────
+
+    @Nested
+    @DisplayName("getConcepts — 캡슐화")
+    class Encapsulation {
+
+        @Test
+        @DisplayName("getConcepts는_unmodifiable_리스트를_반환_add시_예외")
+        void getConcepts는_unmodifiable_리스트를_반환_add시_예외() {
+            LearningFacade facade = createFacade();
+            List<LearningFacadeConcept> view = facade.getConcepts();
+
+            assertThatThrownBy(() -> view.add(null))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    // ─── removeConcept ─────────────────────────────────────
+
+    @Nested
+    @DisplayName("removeConcept")
+    class Remove {
+
+        @Test
+        @DisplayName("removeConcept_정상_displayOrder_재부여")
+        void removeConcept_정상_displayOrder_재부여() {
+            LearningFacade facade = createFacade();
+            LearningFacadeConcept c2 = addConceptWithId(facade, "B", 20L);
+            LearningFacadeConcept c3 = addConceptWithId(facade, "C", 30L);
+            // c1은 create() 시점에 생성되어 id 없음 — 첫 항목 id 부여 필요
+            ReflectionTestUtils.setField(facade.getConcepts().get(0), "id", 10L);
+
+            facade.removeConcept(20L); // c2 제거
+
+            assertThat(facade.getConcepts()).hasSize(2);
+            assertThat(facade.getConceptValues()).containsExactly("백엔드", "C");
+            assertThat(facade.getConcepts().get(0).getDisplayOrder()).isEqualTo(1);
+            assertThat(facade.getConcepts().get(1).getDisplayOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("removeConcept_마지막1건이면_예외")
+        void removeConcept_마지막1건이면_예외() {
+            LearningFacade facade = createFacade();
+            ReflectionTestUtils.setField(facade.getConcepts().get(0), "id", 10L);
+
+            assertThatThrownBy(() -> facade.removeConcept(10L))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID);
+        }
+
+        @Test
+        @DisplayName("removeConcept_존재하지_않는_id_예외")
+        void removeConcept_존재하지_않는_id_예외() {
+            LearningFacade facade = createFacade();
+            addConceptWithId(facade, "B", 20L);
+            ReflectionTestUtils.setField(facade.getConcepts().get(0), "id", 10L);
+
+            assertThatThrownBy(() -> facade.removeConcept(999L))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    // ─── reorderConcepts ───────────────────────────────────
+
+    @Nested
+    @DisplayName("reorderConcepts")
+    class Reorder {
+
+        @Test
+        @DisplayName("reorderConcepts_정상_displayOrder_재부여")
+        void reorderConcepts_정상_displayOrder_재부여() {
+            LearningFacade facade = createFacade();
+            ReflectionTestUtils.setField(facade.getConcepts().get(0), "id", 10L);
+            addConceptWithId(facade, "B", 20L);
+            addConceptWithId(facade, "C", 30L);
+
+            facade.reorderConcepts(List.of(30L, 10L, 20L));
+
+            assertThat(facade.getConceptValues()).containsExactly("C", "백엔드", "B");
+        }
+
+        @Test
+        @DisplayName("reorderConcepts_id집합_불일치_예외")
+        void reorderConcepts_id집합_불일치_예외() {
+            LearningFacade facade = createFacade();
+            ReflectionTestUtils.setField(facade.getConcepts().get(0), "id", 10L);
+            addConceptWithId(facade, "B", 20L);
+
+            assertThatThrownBy(() -> facade.reorderConcepts(List.of(10L, 99L)))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPTS_REORDER_MISMATCH);
+        }
+
+        @Test
+        @DisplayName("reorderConcepts_길이_불일치_예외")
+        void reorderConcepts_길이_불일치_예외() {
+            LearningFacade facade = createFacade();
+            ReflectionTestUtils.setField(facade.getConcepts().get(0), "id", 10L);
+            addConceptWithId(facade, "B", 20L);
+
+            assertThatThrownBy(() -> facade.reorderConcepts(List.of(10L)))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPTS_REORDER_MISMATCH);
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeTest.java
@@ -90,7 +90,7 @@ class LearningFacadeTest {
         @DisplayName("concept이 null이면 예외가 발생한다")
         void create_concept_null_예외() {
             //when & then
-            assertThatThrownBy(() -> LearningFacade.create(user, null))
+            assertThatThrownBy(() -> LearningFacade.create(user, (String) null))
                     .isInstanceOf(LearningFacadeDomainException.class);
         }
 

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeUpdateConceptsTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeUpdateConceptsTest.java
@@ -1,0 +1,170 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E1-S3 · {@link LearningFacade#updateConcepts(List)} 다건 통째 교체 테스트.
+ */
+@DisplayName("LearningFacade · updateConcepts")
+class LearningFacadeUpdateConceptsTest {
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    private LearningFacade createFacade() {
+        return LearningFacade.create(user, "백엔드"); // concepts=["백엔드"]
+    }
+
+    // ─── 해피 ──────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("해피")
+    class Happy {
+
+        @Test
+        @DisplayName("updateConcepts_새리스트로_통째_교체_added_removed_계산")
+        void updateConcepts_새리스트로_통째_교체_added_removed_계산() {
+            LearningFacade facade = createFacade();
+            facade.addConcept("데이터모델링");
+            // 현재: [백엔드, 데이터모델링]
+
+            ConceptsChangeRecord rec = facade.updateConcepts(List.of("백엔드", "시스템설계", "분산시스템"));
+
+            assertThat(facade.getConceptValues()).containsExactly("백엔드", "시스템설계", "분산시스템");
+            assertThat(rec.getPrevious()).containsExactly("백엔드", "데이터모델링");
+            assertThat(rec.getCurrent()).containsExactly("백엔드", "시스템설계", "분산시스템");
+            assertThat(rec.getAdded()).containsExactly("시스템설계", "분산시스템");
+            assertThat(rec.getRemoved()).containsExactly("데이터모델링");
+            assertThat(rec.getKept()).containsExactly("백엔드");
+            assertThat(rec.isChanged()).isTrue();
+        }
+
+        @Test
+        @DisplayName("updateConcepts_동일리스트_isChanged_false")
+        void updateConcepts_동일리스트_isChanged_false() {
+            LearningFacade facade = createFacade();
+
+            ConceptsChangeRecord rec = facade.updateConcepts(List.of("백엔드"));
+
+            assertThat(rec.isChanged()).isFalse();
+            assertThat(rec.getAdded()).isEmpty();
+            assertThat(rec.getRemoved()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("updateConcepts_순서만_변경도_isChanged_true")
+        void updateConcepts_순서만_변경도_isChanged_true() {
+            LearningFacade facade = createFacade();
+            facade.addConcept("B");
+
+            ConceptsChangeRecord rec = facade.updateConcepts(List.of("B", "백엔드"));
+
+            assertThat(rec.isChanged()).isTrue();
+            assertThat(rec.getAdded()).isEmpty();
+            assertThat(rec.getRemoved()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("updateConcepts_displayOrder_1부터_재부여")
+        void updateConcepts_displayOrder_1부터_재부여() {
+            LearningFacade facade = createFacade();
+
+            facade.updateConcepts(List.of("A", "B", "C"));
+
+            assertThat(facade.getConcepts()).extracting(LearningFacadeConcept::getDisplayOrder)
+                                            .containsExactly(1, 2, 3);
+        }
+
+        @Test
+        @DisplayName("updateConcepts_각_값_trim_처리")
+        void updateConcepts_각_값_trim_처리() {
+            LearningFacade facade = createFacade();
+
+            facade.updateConcepts(List.of("  A  ", "  B  "));
+
+            assertThat(facade.getConceptValues()).containsExactly("A", "B");
+        }
+
+        @Test
+        @DisplayName("updateConcepts_legacy_concept_컬럼도_첫_항목과_동기화")
+        void updateConcepts_legacy_concept_컬럼도_첫_항목과_동기화() {
+            LearningFacade facade = createFacade();
+
+            facade.updateConcepts(List.of("새로운첫번째", "두번째"));
+
+            assertThat(facade.getConcept()).isEqualTo("새로운첫번째");
+        }
+    }
+
+    // ─── 예외 ──────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("예외")
+    class Exceptions {
+
+        @Test
+        @DisplayName("updateConcepts_null_예외")
+        void updateConcepts_null_예외() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.updateConcepts(null))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+
+        @Test
+        @DisplayName("updateConcepts_빈리스트_SIZE_INVALID_예외")
+        void updateConcepts_빈리스트_SIZE_INVALID_예외() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.updateConcepts(List.of()))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID);
+        }
+
+        @Test
+        @DisplayName("updateConcepts_6개_SIZE_INVALID_예외")
+        void updateConcepts_6개_SIZE_INVALID_예외() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.updateConcepts(List.of("A", "B", "C", "D", "E", "F")))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPTS_SIZE_INVALID);
+        }
+
+        @Test
+        @DisplayName("updateConcepts_리스트내_중복_예외_전체_롤백")
+        void updateConcepts_리스트내_중복_trim후_예외() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.updateConcepts(List.of("A", "B", "  A  ")))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE);
+            // 부분성공 불허 — 기존 concepts 상태 유지
+            assertThat(facade.getConceptValues()).containsExactly("백엔드");
+        }
+
+        @Test
+        @DisplayName("updateConcepts_blank_포함_예외_전체_롤백")
+        void updateConcepts_blank_포함_예외_전체_롤백() {
+            LearningFacade facade = createFacade();
+            assertThatThrownBy(() -> facade.updateConcepts(List.of("A", "  ", "B")))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_FACADE_CONCEPT_BLANK);
+            assertThat(facade.getConceptValues()).containsExactly("백엔드");
+        }
+    }
+}


### PR DESCRIPTION
## 개요
`LearningFacade.concept` 단일 String → `concepts: List<String>` 다중화(1~5개). LT Epic 1 완주 (Story LT-E1-S2 ~ S5, 4 Story · 6 SP · 0.0.3v 급행).

## 왜 / 설계 결정
- 사용자 학습 컨셉이 하나로 강제되던 제약을 5개까지 확장 — 백엔드+시스템설계처럼 복합 커리어 표현 지원 (`issue-04-concept-list.md`)
- 새 V17 백필 파일로 처리 (V16 수정 금지 — `conventions.md §3.8`)
- Legacy `learning_facade.concept` NOT NULL 컬럼은 유지, 첫 항목과 동기화. 컬럼 DROP은 별도 릴리스

## 작업 내용
- feat(LT-E1-S2): `LearningFacadeConcept` Entity + `LearningFacade.concepts[]` 컬렉션 API (addConcept/removeConcept/reorderConcepts/getConcepts unmodifiable)
- feat(LT-E1-S3): V17 백필 (NOT EXISTS idempotent) + R17 rollback + `updateConcepts(List<String>)` 다건 통째 교체 + `ConceptsChangeRecord` VO
- feat(LT-E1-S4): API/DTO `concepts: string[]` 스위치 — `PATCH /learning-facade/concept` → `/concepts` 리소스 rename
- refactor(LT-E1-S5): 도메인 상수(`MIN_CONCEPT_COUNT`, `MAX_CONCEPT_COUNT=5`, `MAX_CONCEPT_VALUE_LENGTH=100`) 도메인 단일 진실 소스화. Request DTO @Size가 상수 참조 (재정의 방지)
- ErrorCode 4종 정합: BLANK(LF003 재사용), SIZE_INVALID(LF005), DUPLICATE(LF006), TOO_LONG(LF007), REORDER_MISMATCH(LF008)

## 변경 유형
- [x] feat  - [x] refactor  - [ ] fix  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.*"` → BUILD SUCCESSFUL
- 신규 도메인 테스트 31건:
  - LearningFacadeConceptsTest 17건 (create sync · addConcept happy/edge/exception · unmodifiable · remove · reorder)
  - LearningFacadeUpdateConceptsTest 11건 (added/removed/kept · 순서만 변경도 changed · trim · size/blank/duplicate 예외 롤백)
  - LearningFacadeConceptsPolicyTest 3건 (상수 3종 + ErrorCode 4종 코드/HttpStatus 매핑)
- 전체 `./gradlew test` 통과

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] Flyway V17 + R17 신설, V16 수정 없음 (conventions.md §3.8 준수)
- [x] BC 간 의존 방향 위반 없음
- [x] 5관점 Reviewer 세션 — **rush 정책(0.0.3v 급행)으로 스킵**. 대신 콘솔 요약 + 자체 자가점검만
- [x] 대상 브랜치 = `develop` 확인

## 관련 이슈
- Milestone: `workflow/task/milestones/version/0.0.2v/milestone.md` Tier 1 · Story #2~#5 (0.0.3v 이관 급행)
- SDD: `workflow/task/pes/workspectrum/sdd/in-progress/product-learning-tower.md` Epic 1 Story 1-2 ~ 1-5
- 원안: `workflow/task/fix/brainstorming/version/0.0.2v/issue-04-concept-list.md`