### PR TITLE
feat(learning-facade): LT Epic 2 — Layer 도메인 승격 [Story-LT-E2-S1~S5]

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -84,6 +84,15 @@ public enum ErrorCode {
     LEARNING_FACADE_CONCEPTS_REORDER_MISMATCH("LF008",
             "전달된 concept id 목록이 현재 컨셉 집합과 일치하지 않습니다.",       HttpStatus.BAD_REQUEST),
 
+    // ─── LearningLayer (Story-LT-E2-S1~S5) ────────────────
+    LEARNING_LAYER_NOT_FOUND("LL001",           "Layer를 찾을 수 없습니다.",                                        HttpStatus.NOT_FOUND),
+    LEARNING_LAYER_NAME_BLANK("LL002",          "Layer 이름은 비어 있을 수 없습니다.",                              HttpStatus.BAD_REQUEST),
+    LEARNING_LAYER_DUPLICATE_NAME("LL003",      "동일한 이름의 Layer가 이미 존재합니다.",                          HttpStatus.CONFLICT),
+    LEARNING_LAYER_ALREADY_DELETED("LL004",     "이미 삭제된 Layer입니다.",                                        HttpStatus.BAD_REQUEST),
+    LEARNING_LAYER_HAS_ACTIVE_AXES("LL005",     "활성 축이 있는 Layer는 삭제할 수 없습니다.",                      HttpStatus.CONFLICT),
+    LEARNING_LAYER_REORDER_MISMATCH("LL006",    "전달된 Layer id 목록이 현재 Layer id 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    LEARNING_LAYER_NAME_TOO_LONG("LL007",       "Layer 이름은 100자 이내여야 합니다.",                              HttpStatus.BAD_REQUEST),
+
     // ─── LearningAxis ─────────────────────────────────────
     LEARNING_AXIS_NOT_FOUND("LA001",              "세부 축을 찾을 수 없습니다.",                             HttpStatus.NOT_FOUND),
     LEARNING_AXIS_NAME_BLANK("LA002",             "축 이름은 비어 있을 수 없습니다.",                        HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/dto/LearningFacadeCommand.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/dto/LearningFacadeCommand.java
@@ -53,6 +53,29 @@ public final class LearningFacadeCommand {
             List<Long> orderedAxisIds
     ) {}
 
+    // ─── Layer (Story-LT-E2-S4·S5) ────────────────────────
+
+    public record AddLayer(
+            Long userId,
+            String name
+    ) {}
+
+    public record RenameLayer(
+            Long userId,
+            Long layerId,
+            String name
+    ) {}
+
+    public record RemoveLayer(
+            Long userId,
+            Long layerId
+    ) {}
+
+    public record ReorderLayers(
+            Long userId,
+            List<Long> orderedLayerIds
+    ) {}
+
     public record AddTopic(
             Long userId,
             Long axisId,

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/LearningFacadeCommandService.java
@@ -138,6 +138,44 @@ public class LearningFacadeCommandService {
     }
 
     // ──────────────────────────────────────────────────────
+    // Layer (Story-LT-E2-S4·S5)
+    // ──────────────────────────────────────────────────────
+
+    public AddLayer addLayer(LearningFacadeCommand.AddLayer command) {
+        LearningFacade facade = loadFacade(command.userId());
+        LearningLayer layer = facade.addLayer(command.name());
+        facadeRepository.save(facade);
+        if (layer.getId() == null) {
+            throw new IllegalStateException(
+                    "LearningLayer id가 cascade save 후에도 null입니다. JPA 설정 회귀 가능성.");
+        }
+        return AddLayer.of(layer, facade.isLayerCountExceedsRecommended());
+    }
+
+    public RenameLayer renameLayer(LearningFacadeCommand.RenameLayer command) {
+        LearningFacade facade = loadFacade(command.userId());
+        boolean changed = facade.renameLayer(command.layerId(), command.name());
+        if (changed) {
+            facadeRepository.save(facade);
+        }
+        LearningLayer layer = facade.findLayer(command.layerId());
+        return RenameLayer.of(layer, changed);
+    }
+
+    public void removeLayer(LearningFacadeCommand.RemoveLayer command) {
+        LearningFacade facade = loadFacade(command.userId());
+        facade.removeLayer(command.layerId());
+        facadeRepository.save(facade);
+    }
+
+    public ReorderLayers reorderLayers(LearningFacadeCommand.ReorderLayers command) {
+        LearningFacade facade = loadFacade(command.userId());
+        facade.reorderLayers(command.orderedLayerIds());
+        facadeRepository.save(facade);
+        return ReorderLayers.of(facade.getLayers());
+    }
+
+    // ──────────────────────────────────────────────────────
     // 사용자가 명시적으로 Deck을 생성하는 경로는 폐기되었다.
     // (Fix — Axis↔Deck 완전 통합, BE-Story 2, 2026-07-01)
     // Deck은 이제 LearningAxisCreatedEventHandler가 Axis 생성 이벤트에 반응해 자동으로만 생성한다.

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -54,6 +54,17 @@ public class LearningAxis {
     @JoinColumn(name = "learning_facade_id", nullable = false, updatable = false)
     private LearningFacade facade;
 
+    // ─── Layer FK (Story-LT-E2-S2) ────────────────────────
+    //
+    // Layer 도입에 따른 상위 그룹핑 참조. 3-phase 마이그레이션 (V19)의 안전한 전이 기간 동안
+    // nullable로 유지되며 Story-LT-E2-S3 백필 완료 후 이관 릴리스에서 NOT NULL로 전환된다.
+    //
+    // <p>도메인 진입점: {@link LearningLayer#addAxis} (blessed) 또는
+    // {@link LearningFacade#addAxis(String)} (legacy — 내부적으로 default layer 라우팅)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "learning_layer_id", nullable = true, updatable = true)
+    private LearningLayer layer;
+
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
@@ -81,12 +92,18 @@ public class LearningAxis {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    private LearningAxis(LearningFacade facade, String name, int displayOrder) {
+    private LearningAxis(LearningFacade facade, LearningLayer layer, String name, int displayOrder) {
         this.facade       = facade;
+        this.layer        = layer;
         this.name         = name;
         this.displayOrder = displayOrder;
     }
 
+    /**
+     * Legacy 팩토리 (Layer 없이 생성) — {@link LearningFacade#addAxis(String)} 경로용.
+     * <p>Layer는 {@code null}로 두고, LearningFacade가 default Uncategorized layer를 확보한 뒤
+     * {@link #assignLayer(LearningLayer)}로 주입한다. 3-phase 마이그레이션 종료 후 제거 예정.
+     */
     static LearningAxis create(LearningFacade facade, String name, int displayOrder) {
         requireNonNull(facade, "facade");
         validateName(name);
@@ -97,7 +114,34 @@ public class LearningAxis {
                     "displayOrder는 1 이상이어야 합니다. displayOrder=" + displayOrder
             );
         }
-        return new LearningAxis(facade, name.trim(), displayOrder);
+        return new LearningAxis(facade, null, name.trim(), displayOrder);
+    }
+
+    /**
+     * Layer 소속 axis 생성 (Story-LT-E2-S2 blessed 경로).
+     * {@link LearningLayer#addAxis(String)}가 호출한다.
+     */
+    static LearningAxis createInLayer(LearningFacade facade, LearningLayer layer, String name, int displayOrder) {
+        requireNonNull(facade, "facade");
+        requireNonNull(layer, "layer");
+        validateName(name);
+        if (displayOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. displayOrder=" + displayOrder
+            );
+        }
+        return new LearningAxis(facade, layer, name.trim(), displayOrder);
+    }
+
+    /**
+     * Layer 소속을 사후 주입 (Story-LT-E2-S3 default layer 라우팅).
+     * 기존에 layer가 없던 axis에만 사용 — 이미 layer가 지정됐다면 no-op.
+     */
+    void assignLayer(LearningLayer layer) {
+        if (this.layer == null) {
+            this.layer = layer;
+        }
     }
 
     public void updateName(String newName) {

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -60,6 +60,17 @@ public class LearningFacade {
     @OrderBy("displayOrder ASC")
     private final List<LearningFacadeConcept> concepts = new ArrayList<>();
 
+    // ─── Layer 목록 (Story-LT-E2-S1/S2) ────────────────────
+    // learning_layer 자식 테이블 매핑. 소프트 삭제된 layer는 @SQLRestriction으로 자동 제외.
+    @OneToMany(
+            mappedBy      = "facade",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = false,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("displayOrder ASC")
+    private final List<LearningLayer> layers = new ArrayList<>();
+
     // ─── 세부 축 목록 ─────────────────────────────────────
     // ⚠️ orphanRemoval=false (Fix — Axis↔Deck 완전 통합, SDD §12 Q1 결정):
     //   LearningAxis는 Soft Delete 정책 (deleted_at). removeAxis()는 axes.remove()가 아닌
@@ -100,6 +111,8 @@ public class LearningFacade {
         // 도메인은 concepts를 진실 소스로 사용하므로 생성 시점에 collection과 legacy 필드가
         // 언제나 일관된 상태여야 한다.
         facade.concepts.add(LearningFacadeConcept.of(facade, concept, 1));
+        // Story-LT-E2-S3: 신규 Facade에 default Uncategorized Layer 1건 자동 생성.
+        facade.layers.add(LearningLayer.of(facade, LearningLayer.DEFAULT_LAYER_NAME, 1));
         return facade;
     }
 
@@ -136,6 +149,8 @@ public class LearningFacade {
         for (int i = 0; i < normalized.size(); i++) {
             facade.concepts.add(LearningFacadeConcept.of(facade, normalized.get(i), i + 1));
         }
+        // Story-LT-E2-S3: 신규 Facade에 default Uncategorized Layer 1건 자동 생성.
+        facade.layers.add(LearningLayer.of(facade, LearningLayer.DEFAULT_LAYER_NAME, 1));
         return facade;
     }
 
@@ -330,12 +345,58 @@ public class LearningFacade {
     public LearningAxis addAxis(String name) {
         validateAxisNameDuplicate(name);
 
-        // Fix — Axis↔Deck 완전 통합: displayOrder는 활성 축 기준으로 부여한다.
-        // 소프트 삭제된 축은 in-memory 컬렉션에 남아 있으나 사용자 관점의 "N번째 축"에서는 제외.
-        int nextOrder = (int) axes.stream().filter(a -> !a.isDeleted()).count() + 1;
-        LearningAxis axis = LearningAxis.create(this, name, nextOrder);
+        // Story-LT-E2-S3: axis는 default Uncategorized Layer 소속으로 자동 라우팅.
+        // Layer 도메인 승격 이전 코드 경로(레거시 addAxis)는 여전히 사용되므로,
+        // 사용자가 명시적 layer를 지정하지 않으면 default로 흡수한다.
+        LearningLayer target = getDefaultLayer();
+        LearningAxis axis = target.addAxis(name);
+        // facade-level bidirectional 동기화 — @OneToMany(mappedBy) 매핑 상 조회 편의.
         axes.add(axis);
         return axis;
+    }
+
+    /**
+     * 지정된 Layer 하위에 axis 추가 (Story-LT-E2-S5 blessed 경로).
+     * facade-level 이름 중복 검사 후 layer에 위임.
+     */
+    public LearningAxis addAxisInLayer(Long layerId, String name) {
+        validateAxisNameDuplicate(name);
+        LearningLayer target = findLayer(layerId);
+        LearningAxis axis = target.addAxis(name);
+        axes.add(axis);
+        return axis;
+    }
+
+    /**
+     * default Uncategorized Layer를 반환. 없으면 도메인 예외 (백필 누락 시그널).
+     */
+    public LearningLayer getDefaultLayer() {
+        return layers.stream()
+                .filter(l -> !l.isDeleted())
+                .filter(LearningLayer::isDefault)
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(
+                        ErrorCode.LEARNING_LAYER_NOT_FOUND,
+                        "default Uncategorized layer가 없습니다. facadeId=" + this.id
+                ));
+    }
+
+    LearningLayer findLayer(Long layerId) {
+        return layers.stream()
+                .filter(l -> !l.isDeleted())
+                .filter(l -> l.getId() != null && l.getId().equals(layerId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(
+                        ErrorCode.LEARNING_LAYER_NOT_FOUND,
+                        "layerId=" + layerId
+                ));
+    }
+
+    /** 활성 Layer 목록 반환 (soft-deleted 제외, displayOrder 정렬은 @OrderBy로 로드 시점 처리). */
+    public List<LearningLayer> getLayers() {
+        return layers.stream()
+                .filter(l -> !l.isDeleted())
+                .toList();
     }
 
     /**

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacade.java
@@ -29,6 +29,9 @@ public class LearningFacade {
     public static final int MAX_CONCEPT_COUNT        = 5;
     public static final int MAX_CONCEPT_VALUE_LENGTH = 100;
 
+    // ─── Layer 정책 상수 (Story-LT-E2-S5) ───────────────────
+    public static final int RECOMMENDED_LAYER_COUNT_LIMIT = 5;
+
     // ─── 식별자 ───────────────────────────────────────────
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -381,7 +384,7 @@ public class LearningFacade {
                 ));
     }
 
-    LearningLayer findLayer(Long layerId) {
+    public LearningLayer findLayer(Long layerId) {
         return layers.stream()
                 .filter(l -> !l.isDeleted())
                 .filter(l -> l.getId() != null && l.getId().equals(layerId))
@@ -397,6 +400,90 @@ public class LearningFacade {
         return layers.stream()
                 .filter(l -> !l.isDeleted())
                 .toList();
+    }
+
+    /**
+     * Facade에 신규 Layer 추가 (Story-LT-E2-S5).
+     * 이름은 trim/blank/길이 검증(팩토리)에 이어 facade 내 활성 layer 이름 중복 거부.
+     * displayOrder는 활성 layer 기준 max + 1 (1-based).
+     */
+    public LearningLayer addLayer(String name) {
+        String normalized = LearningLayer.normalizeName(name);
+        validateLayerNameDuplicate(normalized, /*excludeId*/ null);
+        int nextOrder = (int) layers.stream().filter(l -> !l.isDeleted()).count() + 1;
+        LearningLayer layer = LearningLayer.of(this, normalized, nextOrder);
+        layers.add(layer);
+        return layer;
+    }
+
+    /**
+     * Layer 이름 변경 (Story-LT-E2-S5).
+     * 동일 layer id를 제외한 나머지 활성 layer의 이름과 중복 여부 검사.
+     *
+     * @return 실제 변경이 발생했는지 여부
+     */
+    public boolean renameLayer(Long layerId, String newName) {
+        LearningLayer target = findLayer(layerId);
+        String normalized = LearningLayer.normalizeName(newName);
+        if (target.getName().equals(normalized)) {
+            return false;
+        }
+        validateLayerNameDuplicate(normalized, layerId);
+        return target.updateName(newName);
+    }
+
+    /**
+     * Layer 순서 재배치 (Story-LT-E2-S5). 전달 id 목록이 활성 layer id 집합과 정확히 일치해야 함.
+     */
+    public void reorderLayers(List<Long> orderedLayerIds) {
+        if (orderedLayerIds == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "orderedLayerIds는 null일 수 없습니다."
+            );
+        }
+        Set<Long> currentIds = layers.stream()
+                                      .filter(l -> !l.isDeleted())
+                                      .map(LearningLayer::getId)
+                                      .collect(Collectors.toSet());
+        Set<Long> incoming = new HashSet<>(orderedLayerIds);
+        if (currentIds.size() != orderedLayerIds.size() || !currentIds.equals(incoming)) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_LAYER_REORDER_MISMATCH,
+                    "전달 id 수=" + orderedLayerIds.size() + " · 활성 layer 수=" + currentIds.size()
+            );
+        }
+        IntStream.range(0, orderedLayerIds.size()).forEach(i -> {
+            Long id = orderedLayerIds.get(i);
+            LearningLayer target = layers.stream()
+                    .filter(l -> id.equals(l.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            target.updateDisplayOrder(i + 1);
+        });
+        // in-memory 정렬 일관성 유지 (@OrderBy는 DB load 시점만 적용).
+        layers.sort(java.util.Comparator.comparingInt(LearningLayer::getDisplayOrder));
+    }
+
+    /** 활성 Layer 개수가 권장 상한을 초과하는지. */
+    public boolean isLayerCountExceedsRecommended() {
+        return getLayers().size() > RECOMMENDED_LAYER_COUNT_LIMIT;
+    }
+
+    /**
+     * Layer softDelete 진입점 (Story-LT-E2-S4).
+     * default Uncategorized Layer는 삭제 금지 — 백필/자동 라우팅의 필수 앵커.
+     * 활성 axis 존재·재삭제 가드는 {@link LearningLayer#softDelete()}가 처리.
+     */
+    public void removeLayer(Long layerId) {
+        LearningLayer target = findLayer(layerId);
+        if (target.isDefault()) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_LAYER_HAS_ACTIVE_AXES,
+                    "default Uncategorized Layer는 삭제할 수 없습니다."
+            );
+        }
+        target.softDelete();
     }
 
     /**
@@ -505,6 +592,23 @@ public class LearningFacade {
             throw LearningFacadeDomainException.of(
                     ErrorCode.LEARNING_FACADE_CONCEPT_DUPLICATE,
                     "value=" + normalizedValue
+            );
+        }
+    }
+
+    /**
+     * 활성 Layer 이름 중복 검증.
+     * excludeId가 있으면 그 layer는 검증 대상에서 제외 (rename 시나리오).
+     */
+    void validateLayerNameDuplicate(String normalizedName, Long excludeId) {
+        boolean duplicated = layers.stream()
+                .filter(l -> !l.isDeleted())
+                .filter(l -> excludeId == null || !excludeId.equals(l.getId()))
+                .anyMatch(l -> l.getName().equals(normalizedName));
+        if (duplicated) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_LAYER_DUPLICATE_NAME,
+                    "name=" + normalizedName
             );
         }
     }

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayer.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayer.java
@@ -1,0 +1,241 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * LearningFacade 하위, LearningAxis 상위 그룹핑 계층 (Story-LT-E2-S1).
+ *
+ * <p>사용자 자산성 도메인 → Soft Delete 적용 ({@code @SQLRestriction} + {@code @SQLDelete}).
+ * default Layer 이름 "Uncategorized"는 {@link LearningFacade#create}에서 자동 생성되며,
+ * 마이그레이션 V19의 backfill이 기존 axis를 이 layer로 이관한다.
+ *
+ * <p>{@code softDelete()}는 활성 axis가 존재하면 {@link ErrorCode#LEARNING_LAYER_HAS_ACTIVE_AXES}를 던진다
+ * — 자동 연쇄 삭제 대신 사용자에게 명시적 이동/삭제를 요구 (Epic 2 기술 결정).
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "learning_layer",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_learning_layer_facade_name_deleted",
+                columnNames = {"learning_facade_id", "name", "deleted_at"}
+        )
+)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE learning_layer SET deleted_at = CURRENT_TIMESTAMP(6) WHERE learning_layer_id = ?")
+public class LearningLayer {
+
+    /** default Layer 이름 — 마이그레이션·자동생성·조회에 재사용. */
+    public static final String DEFAULT_LAYER_NAME = "Uncategorized";
+
+    public static final int MAX_LAYER_NAME_LENGTH = 100;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "learning_layer_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "learning_facade_id", nullable = false, updatable = false)
+    private LearningFacade facade;
+
+    @Column(name = "name", nullable = false, length = MAX_LAYER_NAME_LENGTH)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    /**
+     * Layer 소속 활성 axis 목록.
+     * {@link LearningAxis} 도메인이 개별 {@code @SQLRestriction("deleted_at IS NULL")}을 갖고 있어
+     * 조회 시점에 자동 필터된다.
+     */
+    @OneToMany(
+            mappedBy      = "layer",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = false,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("displayOrder ASC")
+    private final List<LearningAxis> axes = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    private LearningLayer(LearningFacade facade, String name, int displayOrder) {
+        this.facade       = facade;
+        this.name         = name;
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+     * 정적 팩토리. Aggregate Root({@link LearningFacade})의 addLayer 경로에서만 호출된다.
+     * name은 trim + blank 거부 + 길이 검증. displayOrder는 1-based.
+     */
+    static LearningLayer of(LearningFacade facade, String name, int displayOrder) {
+        if (facade == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "facade는 null일 수 없습니다."
+            );
+        }
+        String normalized = normalizeName(name);
+        if (displayOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. displayOrder=" + displayOrder
+            );
+        }
+        return new LearningLayer(facade, normalized, displayOrder);
+    }
+
+    static String normalizeName(String name) {
+        if (name == null || name.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_LAYER_NAME_BLANK);
+        }
+        String trimmed = name.trim();
+        if (trimmed.length() > MAX_LAYER_NAME_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_LAYER_NAME_TOO_LONG,
+                    "length=" + trimmed.length()
+            );
+        }
+        return trimmed;
+    }
+
+    void updateDisplayOrder(int newOrder) {
+        if (newOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. newOrder=" + newOrder
+            );
+        }
+        this.displayOrder = newOrder;
+    }
+
+    // ─── 소프트 삭제 ─────────────────────────────────────
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    /**
+     * Layer softDelete (Story-LT-E2-S4).
+     *
+     * <p>정책:
+     * <ul>
+     *   <li>이미 삭제 상태에서 재호출 → {@link ErrorCode#LEARNING_LAYER_ALREADY_DELETED}</li>
+     *   <li>활성 자식 axis가 존재 → {@link ErrorCode#LEARNING_LAYER_HAS_ACTIVE_AXES} (자동 연쇄 X)</li>
+     *   <li>실제 반영은 {@code @SQLDelete}가 UPDATE로 처리 — 여기서는 in-memory 상태만 갱신</li>
+     * </ul>
+     */
+    public void softDelete() {
+        if (isDeleted()) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_LAYER_ALREADY_DELETED);
+        }
+        if (axes.stream().anyMatch(a -> !a.isDeleted())) {
+            throw LearningFacadeDomainException.of(ErrorCode.LEARNING_LAYER_HAS_ACTIVE_AXES);
+        }
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    /** default Uncategorized Layer 여부. */
+    public boolean isDefault() {
+        return DEFAULT_LAYER_NAME.equals(this.name);
+    }
+
+    // ─── name 갱신 ───────────────────────────────────────
+
+    /**
+     * Layer 이름 변경 (Story-LT-E2-S5).
+     * 동일 값(trim 후) 입력이면 no-op.
+     * Facade 내 다른 활성 Layer와 중복 여부는 {@link LearningFacade#validateLayerNameDuplicate}가 검증.
+     *
+     * @return 실제 변경이 발생했는지 여부
+     */
+    boolean updateName(String newName) {
+        String normalized = normalizeName(newName);
+        if (this.name.equals(normalized)) {
+            return false;
+        }
+        this.name = normalized;
+        return true;
+    }
+
+    // ─── axis 목록 관리 ───────────────────────────────────
+
+    /**
+     * Layer 소속 axis 추가. 이름 정규화·displayOrder 부여·중복 검증은 Facade에서 사전 확인 후 호출한다.
+     * displayOrder는 이 Layer 내부의 활성 axis 중 max + 1 (전역 아님).
+     */
+    LearningAxis addAxis(String name) {
+        int nextOrder = (int) axes.stream().filter(a -> !a.isDeleted()).count() + 1;
+        LearningAxis axis = LearningAxis.createInLayer(this.facade, this, name, nextOrder);
+        axes.add(axis);
+        return axis;
+    }
+
+    /** Layer 내 활성 axis만 반환 (읽기 편의). */
+    public List<LearningAxis> getAxes() {
+        return axes.stream()
+                   .filter(a -> !a.isDeleted())
+                   .toList();
+    }
+
+    /**
+     * Layer 내 axis 순서 재배치. 전달 id 목록이 이 layer의 axis id 집합과 정확히 일치해야 함.
+     */
+    void reorderAxes(List<Long> orderedAxisIds) {
+        if (orderedAxisIds == null) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "orderedAxisIds는 null일 수 없습니다."
+            );
+        }
+        Set<Long> currentIds = getAxes().stream()
+                                        .map(LearningAxis::getId)
+                                        .collect(Collectors.toSet());
+        Set<Long> incoming = new HashSet<>(orderedAxisIds);
+        if (currentIds.size() != orderedAxisIds.size() || !currentIds.equals(incoming)) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.LEARNING_AXIS_REORDER_MISMATCH,
+                    "layer id=" + this.id
+            );
+        }
+        IntStream.range(0, orderedAxisIds.size()).forEach(i -> {
+            Long id = orderedAxisIds.get(i);
+            LearningAxis target = axes.stream()
+                    .filter(a -> id.equals(a.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            target.updateDisplayOrder(i + 1);
+        });
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/LearningFacadeController.java
@@ -106,6 +106,51 @@ public class LearningFacadeController {
                 new LearningFacadeCommand.ReorderAxes(user.getId(), request.orderedAxisIds()));
     }
 
+    // ─── Layer 엔드포인트 (Story-LT-E2-S4·S5) ──────────────
+
+    // POST /learning-facade/layers
+    @PostMapping("/layers")
+    @ResponseStatus(HttpStatus.CREATED)
+    public LearningFacadeResponse.AddLayer addLayer(
+            @AuthenticationPrincipal UserEntity user,
+            @Valid @RequestBody LearningFacadeRequest.AddLayer request
+    ) {
+        return facadeCommandService.addLayer(
+                new LearningFacadeCommand.AddLayer(user.getId(), request.name()));
+    }
+
+    // PATCH /learning-facade/layers/{layerId}
+    @PatchMapping("/layers/{layerId}")
+    public LearningFacadeResponse.RenameLayer renameLayer(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long layerId,
+            @Valid @RequestBody LearningFacadeRequest.RenameLayer request
+    ) {
+        return facadeCommandService.renameLayer(
+                new LearningFacadeCommand.RenameLayer(user.getId(), layerId, request.name()));
+    }
+
+    // DELETE /learning-facade/layers/{layerId}
+    @DeleteMapping("/layers/{layerId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeLayer(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long layerId
+    ) {
+        facadeCommandService.removeLayer(
+                new LearningFacadeCommand.RemoveLayer(user.getId(), layerId));
+    }
+
+    // PUT /learning-facade/layers/order
+    @PutMapping("/layers/order")
+    public LearningFacadeResponse.ReorderLayers reorderLayers(
+            @AuthenticationPrincipal UserEntity user,
+            @Valid @RequestBody LearningFacadeRequest.ReorderLayers request
+    ) {
+        return facadeCommandService.reorderLayers(
+                new LearningFacadeCommand.ReorderLayers(user.getId(), request.orderedLayerIds()));
+    }
+
     // POST /learning-facade/axes/{axisId}/decks (Fix-Story 2에서 신설)는 폐기되었다.
     // (Fix — Axis↔Deck 완전 통합, BE-Story 2, 2026-07-01)
     // 축 생성 시 이벤트로 자동 Deck을 만들도록 통일 — 사용자가 명시적으로 덱을 만들 진입점은 없다.

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeRequest.java
@@ -59,6 +59,23 @@ public class LearningFacadeRequest {
             List<Long> orderedAxisIds
     ) {}
 
+    // ─── Layer (Story-LT-E2-S5) ──────────────────────────
+
+    public record AddLayer(
+            @NotBlank
+            String name
+    ) {}
+
+    public record RenameLayer(
+            @NotBlank
+            String name
+    ) {}
+
+    public record ReorderLayers(
+            @NotNull
+            List<Long> orderedLayerIds
+    ) {}
+
     // CreateAxisDeck 폐기: Fix — Axis↔Deck 완전 통합 (BE-Story 2, 2026-07-01).
     // 수동 축 스코프 Deck 생성 경로가 사라지면서 관련 Request record도 제거됨.
 

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/LearningFacadeResponse.java
@@ -328,6 +328,64 @@ public class LearningFacadeResponse {
     }
 
     // ──────────────────────────────────────────────────────
+    // Layer (Story-LT-E2-S4·S5)
+    // ──────────────────────────────────────────────────────
+
+    public record LayerItem(
+            Long layerId,
+            String name,
+            int displayOrder,
+            boolean isDefault,
+            int axisCount
+    ) {
+        public static LayerItem of(LearningLayer layer) {
+            return new LayerItem(
+                    layer.getId(),
+                    layer.getName(),
+                    layer.getDisplayOrder(),
+                    layer.isDefault(),
+                    layer.getAxes().size()
+            );
+        }
+    }
+
+    public record AddLayer(
+            Long layerId,
+            String name,
+            int displayOrder,
+            boolean isLayerCountExceedsRecommended
+    ) {
+        public static AddLayer of(LearningLayer layer, boolean isLayerCountExceedsRecommended) {
+            return new AddLayer(
+                    layer.getId(),
+                    layer.getName(),
+                    layer.getDisplayOrder(),
+                    isLayerCountExceedsRecommended
+            );
+        }
+    }
+
+    public record RenameLayer(
+            Long layerId,
+            String name,
+            boolean isChanged
+    ) {
+        public static RenameLayer of(LearningLayer layer, boolean isChanged) {
+            return new RenameLayer(layer.getId(), layer.getName(), isChanged);
+        }
+    }
+
+    public record ReorderLayers(
+            List<LayerItem> layers
+    ) {
+        public static ReorderLayers of(List<LearningLayer> layers) {
+            return new ReorderLayers(
+                    layers.stream().map(LayerItem::of).collect(Collectors.toList())
+            );
+        }
+    }
+
+    // ──────────────────────────────────────────────────────
     // 8. AddTopic (Story-004-2: 자료 추가 유도 + 기존 자료 연결 후보)
     // ──────────────────────────────────────────────────────
 

--- a/src/main/resources/db/migration/R18__rollback_learning_layer.sql
+++ b/src/main/resources/db/migration/R18__rollback_learning_layer.sql
@@ -1,0 +1,9 @@
+-- =============================================================
+-- R18__rollback_learning_layer.sql
+-- Story-LT-E2-S1 rollback: learning_layer 테이블 폐기.
+--
+-- ⚠️ V19에서 learning_axis.learning_layer_id FK가 추가되면
+-- 이 rollback을 실행하기 전에 V19의 R19를 먼저 실행해야 한다 (FK 무결성).
+-- =============================================================
+
+DROP TABLE IF EXISTS learning_layer;

--- a/src/main/resources/db/migration/R19__rollback_learning_axis_layer_fk.sql
+++ b/src/main/resources/db/migration/R19__rollback_learning_axis_layer_fk.sql
@@ -1,0 +1,19 @@
+-- =============================================================
+-- R19__rollback_learning_axis_layer_fk.sql
+-- Story-LT-E2-S2/S3 rollback.
+--
+-- ⚠️ 순서 준수: index 삭제 → FK 삭제 → NOT NULL 되돌리기 → 컬럼 삭제.
+-- 백필된 Uncategorized layer 는 R18(learning_layer 폐기)에서 처리하지 않고 남긴다 —
+-- 데이터 손실 방지. 필요 시 별도 스크립트로 정리.
+-- =============================================================
+
+DROP INDEX idx_learning_axis_layer ON learning_axis;
+
+ALTER TABLE learning_axis
+    DROP FOREIGN KEY fk_learning_axis_layer;
+
+ALTER TABLE learning_axis
+    MODIFY COLUMN learning_layer_id BIGINT NULL;
+
+ALTER TABLE learning_axis
+    DROP COLUMN learning_layer_id;

--- a/src/main/resources/db/migration/V18__learning_layer.sql
+++ b/src/main/resources/db/migration/V18__learning_layer.sql
@@ -1,0 +1,36 @@
+-- =============================================================
+-- V18__learning_layer.sql
+-- LT Epic 2 Story 2-1: learning_layer 테이블 신설 + LearningLayer Aggregate 기반 스키마
+--
+-- Layer 정책 (ADR003 v2 확장 · ADR021 관행 · issue-05):
+--   · Layer는 사용자 자산성 도메인 → Soft Delete 적용 (deleted_at 컬럼)
+--   · 동일 Facade 내 활성 Layer 이름 유일 → UNIQUE (facade_id, name, deleted_at)
+--     MySQL은 NULL을 서로 다른 값으로 취급하므로 활성 대상에서만 유일성 강제,
+--     softDeleted Layer의 이름 재사용은 허용.
+--   · display_order는 도메인은 1-based, DB CHECK는 ≥ 0 안전망.
+--   · FK ON DELETE 미지정 (기본 RESTRICT) — LearningFacade는 soft delete 도메인이라
+--     하드 삭제 경로 없음.
+-- =============================================================
+
+CREATE TABLE learning_layer
+(
+    learning_layer_id  BIGINT       NOT NULL AUTO_INCREMENT,
+    learning_facade_id BIGINT       NOT NULL,
+    name               VARCHAR(100) NOT NULL,
+    display_order      INT          NOT NULL,
+    created_at         DATETIME(6)  NOT NULL,
+    updated_at         DATETIME(6)  NOT NULL,
+    deleted_at         DATETIME(6)  NULL,
+
+    PRIMARY KEY (learning_layer_id),
+    CONSTRAINT uk_learning_layer_facade_name_deleted
+        UNIQUE (learning_facade_id, name, deleted_at),
+    CONSTRAINT fk_learning_layer_facade
+        FOREIGN KEY (learning_facade_id) REFERENCES learning_facade (learning_facade_id),
+    CONSTRAINT chk_learning_layer_order
+        CHECK (display_order >= 0),
+    INDEX idx_learning_layer_facade_order (learning_facade_id, display_order),
+    INDEX idx_learning_layer_deleted (deleted_at)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V19__learning_axis_layer_fk.sql
+++ b/src/main/resources/db/migration/V19__learning_axis_layer_fk.sql
@@ -1,0 +1,56 @@
+-- =============================================================
+-- V19__learning_axis_layer_fk.sql
+-- LT Epic 2 Story 2-2/2-3: learning_axis.facade_id → learning_axis.learning_layer_id 재배선
+--
+-- 3-phase 마이그레이션 (conventions.md §3.8 준수):
+--   1) ADD COLUMN nullable
+--   2) 기존 axis 백필: facade별 Uncategorized layer 생성 → axis.learning_layer_id 매핑
+--   3) NOT NULL 승격 + FK 제약 (ON DELETE RESTRICT — Layer softDelete 시 활성 axis 존재 검증은
+--      도메인 LearningLayer.softDelete가 담당하며, DB 제약은 이중 안전망)
+--
+-- 컬럼 유지: learning_axis.learning_facade_id 는 삭제하지 않는다 (backward compat + 3-phase 원칙).
+-- 별도 릴리스에서 facade FK 제거 검토.
+-- =============================================================
+
+-- ── Phase 1 ─────────────────────────────────────────────
+ALTER TABLE learning_axis
+    ADD COLUMN learning_layer_id BIGINT NULL;
+
+-- ── Phase 2-a: facade별 default Uncategorized layer 생성 (idempotent) ──
+INSERT INTO learning_layer (learning_facade_id, name, display_order, created_at, updated_at)
+SELECT lf.learning_facade_id,
+       'Uncategorized',
+       1,
+       CURRENT_TIMESTAMP(6),
+       CURRENT_TIMESTAMP(6)
+FROM   learning_facade lf
+WHERE  lf.deleted_at IS NULL
+  AND  NOT EXISTS (
+         SELECT 1
+         FROM   learning_layer ll
+         WHERE  ll.learning_facade_id = lf.learning_facade_id
+           AND  ll.name = 'Uncategorized'
+           AND  ll.deleted_at IS NULL
+       );
+
+-- ── Phase 2-b: 기존 axis 를 Uncategorized layer 로 매핑 (idempotent) ──
+UPDATE learning_axis la
+JOIN   learning_layer ll
+       ON ll.learning_facade_id = la.learning_facade_id
+      AND ll.name = 'Uncategorized'
+      AND ll.deleted_at IS NULL
+SET    la.learning_layer_id = ll.learning_layer_id
+WHERE  la.learning_layer_id IS NULL;
+
+-- ── Phase 3-a: NOT NULL 승격 ─────────────────────────────
+ALTER TABLE learning_axis
+    MODIFY COLUMN learning_layer_id BIGINT NOT NULL;
+
+-- ── Phase 3-b: FK 제약 ──────────────────────────────────
+ALTER TABLE learning_axis
+    ADD CONSTRAINT fk_learning_axis_layer
+        FOREIGN KEY (learning_layer_id) REFERENCES learning_layer (learning_layer_id)
+        ON DELETE RESTRICT;
+
+-- ── Phase 3-c: 조회 인덱스 ──────────────────────────────
+CREATE INDEX idx_learning_axis_layer ON learning_axis (learning_layer_id);

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeLayersTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeLayersTest.java
@@ -82,6 +82,144 @@ class LearningFacadeLayersTest {
         }
     }
 
+    // ─── addLayer / reorderLayers / removeLayer (Story-S4·S5) ─
+
+    @Nested
+    @DisplayName("addLayer / renameLayer")
+    class LayerLifecycle {
+
+        @Test
+        @DisplayName("addLayer_default이후_displayOrder는_max_plus_1")
+        void addLayer_default이후_displayOrder는_max_plus_1() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+
+            LearningLayer added = facade.addLayer("UI");
+
+            assertThat(added.getDisplayOrder()).isEqualTo(2);
+            assertThat(facade.getLayers()).extracting(LearningLayer::getName)
+                    .containsExactly("Uncategorized", "UI");
+        }
+
+        @Test
+        @DisplayName("addLayer_동일이름_중복_예외")
+        void addLayer_동일이름_중복_예외() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            facade.addLayer("UI");
+
+            assertThatThrownBy(() -> facade.addLayer("UI"))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_DUPLICATE_NAME);
+        }
+
+        @Test
+        @DisplayName("addLayer_5개_초과시_권장_한도_플래그_true")
+        void addLayer_5개_초과시_권장_한도_플래그_true() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            facade.addLayer("L2");
+            facade.addLayer("L3");
+            facade.addLayer("L4");
+            facade.addLayer("L5"); // 총 5개 (default 포함)
+
+            assertThat(facade.isLayerCountExceedsRecommended()).isFalse();
+
+            facade.addLayer("L6"); // 6개
+
+            assertThat(facade.isLayerCountExceedsRecommended()).isTrue();
+        }
+
+        @Test
+        @DisplayName("renameLayer_동일값_no_op_false")
+        void renameLayer_동일값_no_op_false() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer layer = facade.addLayer("UI");
+            ReflectionTestUtils.setField(layer, "id", 20L);
+
+            boolean changed = facade.renameLayer(20L, "UI");
+
+            assertThat(changed).isFalse();
+        }
+
+        @Test
+        @DisplayName("renameLayer_다른_활성layer와_중복_예외")
+        void renameLayer_다른_활성layer와_중복_예외() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer ui = facade.addLayer("UI");
+            LearningLayer view = facade.addLayer("View");
+            ReflectionTestUtils.setField(ui, "id", 20L);
+            ReflectionTestUtils.setField(view, "id", 30L);
+
+            assertThatThrownBy(() -> facade.renameLayer(30L, "UI"))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_DUPLICATE_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("removeLayer — default 보호")
+    class RemoveLayer {
+
+        @Test
+        @DisplayName("removeLayer_default_Uncategorized_삭제_시도_예외")
+        void removeLayer_default_Uncategorized_삭제_시도_예외() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer defaultLayer = facade.getDefaultLayer();
+            ReflectionTestUtils.setField(defaultLayer, "id", 10L);
+
+            assertThatThrownBy(() -> facade.removeLayer(10L))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_HAS_ACTIVE_AXES);
+        }
+
+        @Test
+        @DisplayName("removeLayer_non_default_활성_axis_없음_성공")
+        void removeLayer_non_default_활성_axis_없음_성공() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer ui = facade.addLayer("UI");
+            ReflectionTestUtils.setField(ui, "id", 20L);
+
+            facade.removeLayer(20L);
+
+            assertThat(ui.isDeleted()).isTrue();
+            assertThat(facade.getLayers()).hasSize(1); // default만 남음
+        }
+    }
+
+    @Nested
+    @DisplayName("reorderLayers")
+    class Reorder {
+
+        @Test
+        @DisplayName("reorderLayers_정상_displayOrder_재부여")
+        void reorderLayers_정상_displayOrder_재부여() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer defaultLayer = facade.getDefaultLayer();
+            ReflectionTestUtils.setField(defaultLayer, "id", 10L);
+            LearningLayer ui = facade.addLayer("UI");
+            LearningLayer view = facade.addLayer("View");
+            ReflectionTestUtils.setField(ui, "id", 20L);
+            ReflectionTestUtils.setField(view, "id", 30L);
+
+            facade.reorderLayers(java.util.List.of(30L, 10L, 20L));
+
+            assertThat(facade.getLayers()).extracting(LearningLayer::getName)
+                    .containsExactly("View", "Uncategorized", "UI");
+        }
+
+        @Test
+        @DisplayName("reorderLayers_id_집합_불일치_예외")
+        void reorderLayers_id_집합_불일치_예외() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer defaultLayer = facade.getDefaultLayer();
+            ReflectionTestUtils.setField(defaultLayer, "id", 10L);
+            LearningLayer ui = facade.addLayer("UI");
+            ReflectionTestUtils.setField(ui, "id", 20L);
+
+            assertThatThrownBy(() -> facade.reorderLayers(java.util.List.of(10L, 99L)))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_REORDER_MISMATCH);
+        }
+    }
+
     @Nested
     @DisplayName("findLayer / getLayers")
     class Query {

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeLayersTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningFacadeLayersTest.java
@@ -1,0 +1,110 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E2-S2/S3 · LearningFacade.layers 컬렉션 & default Uncategorized 라우팅 검증.
+ */
+@DisplayName("LearningFacade · layers 자동 default")
+class LearningFacadeLayersTest {
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("create — default Uncategorized 자동 생성")
+    class CreateAutoLayer {
+
+        @Test
+        @DisplayName("create_단수_concept_default_Uncategorized_layer_1건_자동_생성")
+        void create_단수_concept_default_Uncategorized_layer_1건_자동_생성() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+
+            assertThat(facade.getLayers()).hasSize(1);
+            LearningLayer defaultLayer = facade.getDefaultLayer();
+            assertThat(defaultLayer.isDefault()).isTrue();
+            assertThat(defaultLayer.getName()).isEqualTo(LearningLayer.DEFAULT_LAYER_NAME);
+            assertThat(defaultLayer.getDisplayOrder()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("create_concepts_리스트_default_Uncategorized_layer_1건_자동_생성")
+        void create_concepts_리스트_default_Uncategorized_layer_1건_자동_생성() {
+            LearningFacade facade = LearningFacade.create(user,
+                    java.util.List.of("A", "B", "C"));
+
+            assertThat(facade.getLayers()).hasSize(1);
+            assertThat(facade.getDefaultLayer().isDefault()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("addAxis — default layer 자동 라우팅")
+    class AddAxisRouting {
+
+        @Test
+        @DisplayName("addAxis_axis에_default_layer_할당됨")
+        void addAxis_axis에_default_layer_할당됨() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+
+            LearningAxis axis = facade.addAxis("API 설계");
+
+            LearningLayer defaultLayer = facade.getDefaultLayer();
+            assertThat(axis.getLayer()).isSameAs(defaultLayer);
+            assertThat(defaultLayer.getAxes()).contains(axis);
+            assertThat(facade.getAxes()).contains(axis);
+        }
+
+        @Test
+        @DisplayName("addAxis_facade_이름_중복_거부")
+        void addAxis_facade_이름_중복_거부() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            facade.addAxis("API");
+
+            assertThatThrownBy(() -> facade.addAxis("API"))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_AXIS_DUPLICATE_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("findLayer / getLayers")
+    class Query {
+
+        @Test
+        @DisplayName("findLayer_존재하지_않는_id_예외")
+        void findLayer_존재하지_않는_id_예외() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+
+            assertThatThrownBy(() -> facade.findLayer(999L))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("getLayers_softDeleted_제외")
+        void getLayers_softDeleted_제외() {
+            LearningFacade facade = LearningFacade.create(user, "백엔드");
+            LearningLayer target = facade.getDefaultLayer();
+            // softDelete는 활성 axis 없어야 성공
+            target.softDelete();
+
+            assertThat(facade.getLayers()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayerTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayerTest.java
@@ -1,0 +1,162 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E2-S1 · LearningLayer 도메인 단위 테스트.
+ * 팩토리·정규화·softDelete 가드·isDefault 판정.
+ */
+@DisplayName("LearningLayer")
+class LearningLayerTest {
+
+    private UserEntity user;
+    private LearningFacade facade;
+
+    @BeforeEach
+    void setUp() {
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        facade = LearningFacade.create(user, "백엔드");
+        ReflectionTestUtils.setField(facade, "id", 100L);
+    }
+
+    // ─── 팩토리 ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("of — 팩토리")
+    class Of {
+
+        @Test
+        @DisplayName("of_유효값_생성")
+        void of_유효값_생성() {
+            LearningLayer layer = LearningLayer.of(facade, "UI", 1);
+
+            assertThat(layer.getFacade()).isSameAs(facade);
+            assertThat(layer.getName()).isEqualTo("UI");
+            assertThat(layer.getDisplayOrder()).isEqualTo(1);
+            assertThat(layer.isDeleted()).isFalse();
+            assertThat(layer.isDefault()).isFalse();
+        }
+
+        @Test
+        @DisplayName("of_공백_trim_처리")
+        void of_공백_trim_처리() {
+            LearningLayer layer = LearningLayer.of(facade, "  UI  ", 1);
+            assertThat(layer.getName()).isEqualTo("UI");
+        }
+
+        @Test
+        @DisplayName("of_default_이름은_isDefault_true")
+        void of_default_이름은_isDefault_true() {
+            LearningLayer layer = LearningLayer.of(facade, "Uncategorized", 1);
+            assertThat(layer.isDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("of_name_blank_예외")
+        void of_name_blank_예외() {
+            assertThatThrownBy(() -> LearningLayer.of(facade, "  ", 1))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_NAME_BLANK);
+        }
+
+        @Test
+        @DisplayName("of_name_null_예외")
+        void of_name_null_예외() {
+            assertThatThrownBy(() -> LearningLayer.of(facade, null, 1))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_NAME_BLANK);
+        }
+
+        @Test
+        @DisplayName("of_name_101자_TOO_LONG_예외")
+        void of_name_101자_TOO_LONG_예외() {
+            assertThatThrownBy(() -> LearningLayer.of(facade, "a".repeat(101), 1))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_NAME_TOO_LONG);
+        }
+
+        @Test
+        @DisplayName("of_facade_null_예외")
+        void of_facade_null_예외() {
+            assertThatThrownBy(() -> LearningLayer.of(null, "UI", 1))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+
+        @Test
+        @DisplayName("of_displayOrder_0_이하_예외")
+        void of_displayOrder_0_이하_예외() {
+            assertThatThrownBy(() -> LearningLayer.of(facade, "UI", 0))
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    // ─── softDelete ─────────────────────────────────────
+
+    @Nested
+    @DisplayName("softDelete — 활성 axis 가드")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("softDelete_axis_0건_성공_deletedAt_설정")
+        void softDelete_axis_0건_성공_deletedAt_설정() {
+            LearningLayer layer = LearningLayer.of(facade, "UI", 1);
+
+            layer.softDelete();
+
+            assertThat(layer.isDeleted()).isTrue();
+            assertThat(layer.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("softDelete_이미_삭제된_상태_ALREADY_DELETED_예외")
+        void softDelete_이미_삭제된_상태_ALREADY_DELETED_예외() {
+            LearningLayer layer = LearningLayer.of(facade, "UI", 1);
+            layer.softDelete();
+
+            assertThatThrownBy(layer::softDelete)
+                    .isInstanceOf(LearningFacadeDomainException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_LAYER_ALREADY_DELETED);
+        }
+    }
+
+    // ─── updateName ──────────────────────────────────────
+
+    @Nested
+    @DisplayName("updateName")
+    class UpdateName {
+
+        @Test
+        @DisplayName("updateName_동일값_no_op_false_반환")
+        void updateName_동일값_no_op_false_반환() {
+            LearningLayer layer = LearningLayer.of(facade, "UI", 1);
+
+            boolean changed = layer.updateName("UI");
+
+            assertThat(changed).isFalse();
+        }
+
+        @Test
+        @DisplayName("updateName_새값_true_반환_변경")
+        void updateName_새값_true_반환_변경() {
+            LearningLayer layer = LearningLayer.of(facade, "UI", 1);
+
+            boolean changed = layer.updateName("View");
+
+            assertThat(changed).isTrue();
+            assertThat(layer.getName()).isEqualTo("View");
+        }
+    }
+}


### PR DESCRIPTION
## 개요
Axis 상위 그룹핑 계층인 `LearningLayer` Aggregate 를 신설해 축 그룹핑·Layer 스코프 리뷰의 지지대를 확보. LT Epic 2 완주 (Story LT-E2-S1 ~ S5, 5 Story · 9 SP · 0.0.3v 급행).

## 왜 / 설계 결정
- 하나의 Facade 안에서 여러 축을 "백엔드 계열 축 3개"처럼 그룹핑할 수단이 없음 (`issue-05-layer-server-domain.md`)
- 백필 안전성: V19를 3-phase (ADD NULL → 백필 → NOT NULL + FK) — conventions.md §3.8 준수
- default Layer 정책: `LearningFacade.create()`가 항상 "Uncategorized" Layer 자동 생성 → 신규 facade와 백필 결과가 일관
- Layer softDelete cascade 금지 (자동 연쇄 대신 사용자에게 명시적 이동/삭제 요구, HAS_ACTIVE_AXES 409) — Epic 2 기술 결정
- default Uncategorized 는 삭제 금지 (자동 라우팅 앵커)
- SDD의 "facade.axes 컴파일 오류" AC는 backward compat 이유로 미충족 — legacy accessor 유지, 별도 릴리스에서 제거 검토

## 작업 내용
- feat(LT-E2-S1): V18 (+R18) learning_layer 테이블 + `LearningLayer` Aggregate (@SQLRestriction + @SQLDelete + softDelete 활성 axis 가드) + LearningAxis.layer FK 필드
- feat(LT-E2-S2·S3): V19 (+R19) 3-phase Axis FK 재배선 + Uncategorized 백필 (idempotent) + LearningFacade.layers 컬렉션 + create() 자동 default + addAxis 자동 라우팅 + addAxisInLayer/getDefaultLayer/findLayer/getLayers API
- feat(LT-E2-S4): LearningFacade.removeLayer + Service.removeLayer + default 보호 + Controller DELETE /layers/{id}
- feat(LT-E2-S5): 도메인 상수 RECOMMENDED_LAYER_COUNT_LIMIT=5 · addLayer/renameLayer/reorderLayers/isLayerCountExceedsRecommended + Request/Response DTO 세트 + Controller 4엔드포인트 (POST/PATCH/DELETE/PUT)
- ErrorCode 7종: LL001~LL007 (NOT_FOUND, NAME_BLANK, DUPLICATE_NAME, ALREADY_DELETED, HAS_ACTIVE_AXES, REORDER_MISMATCH, NAME_TOO_LONG)

## 변경 유형
- [x] feat  - [x] test  - [ ] fix  - [ ] refactor  - [ ] docs  - [ ] chore

## 테스트
- `./gradlew test` → BUILD SUCCESSFUL (전체 통과)
- 신규 도메인 테스트 27건:
  - LearningLayerTest 12건 (팩토리·정규화·softDelete·updateName)
  - LearningFacadeLayersTest 15건 (create 자동 default 2 · addAxis 라우팅 2 · addLayer/renameLayer 5 · removeLayer 2 · reorderLayers 2 · Query 2)

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] Flyway V18 + V19 (+R18/R19), V16/V17 수정 없음
- [x] BC 간 의존 방향 위반 없음 (Layer는 LearningFacade BC 내부 배치 — Epic 2 결정)
- [x] 5관점 Reviewer 세션 — rush 정책(0.0.3v 급행)으로 스킵. 대신 콘솔 요약 + 자체 자가점검만
- [x] 대상 브랜치 = `develop` 확인

## 관련 이슈
- Milestone: `workflow/task/milestones/version/0.0.2v/milestone.md` Tier 1 · Story #6~#10 (0.0.3v 이관 급행)
- SDD: `workflow/task/pes/workspectrum/sdd/in-progress/product-learning-tower.md` Epic 2 Story 2-1~2-5
- 원안: `workflow/task/fix/brainstorming/version/0.0.2v/issue-05-layer-server-domain.md`