### PR TITLE
feat(ai-suggestion): AS Epic 1 — 4-Port 인터페이스 스켈레톤 [Story-AS-E1]

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/LayerSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/LayerSuggestion.java
@@ -1,0 +1,21 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+/**
+ * AI 제안 Layer 후보 (Story-AS-E1).
+ *
+ * <p>{@code name}은 사용자에게 노출될 Layer 이름(필수, trim 후 저장).
+ * {@code rationale}은 "왜 이 Layer를 제안했는지" 설명(선택 — LLM이 안정적으로 생성한다는 보장이 없어 null 허용).</p>
+ */
+public record LayerSuggestion(String name, String rationale) {
+
+    public LayerSuggestion {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name은 blank일 수 없습니다.");
+        }
+        name = name.trim();
+        if (rationale != null) {
+            String trimmed = rationale.trim();
+            rationale = trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/LayerSuggestionContext.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/LayerSuggestionContext.java
@@ -1,0 +1,40 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * Layer 후보 제안에 전달되는 입력 컨텍스트 (Story-AS-E1).
+ *
+ * <p>{@code facadeId}는 소유 사용자 식별용 (Static Adapter에서는 fallback 카탈로그 조회 hint).
+ * {@code concepts}는 LearningFacade.concepts[] 스냅샷 (trim 정규화 완료 상태 기대).
+ * {@code role}은 concept로부터 파생된 역할 카테고리 hint (nullable — RoleDetector 미도입 상태에서는 null 허용).
+ *
+ * <p>도메인 레이어는 본 VO를 import하지 않는다 — Application Service만 참조.</p>
+ */
+public record LayerSuggestionContext(
+        Long facadeId,
+        List<String> concepts,
+        String role
+) {
+
+    public LayerSuggestionContext {
+        if (facadeId == null) {
+            throw new IllegalArgumentException("facadeId는 null일 수 없습니다.");
+        }
+        if (concepts == null || concepts.isEmpty()) {
+            throw new IllegalArgumentException("concepts는 최소 1개 이상이어야 합니다.");
+        }
+        concepts = concepts.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        throw new IllegalArgumentException("concepts의 각 원소는 blank일 수 없습니다.");
+                    }
+                    return value.trim();
+                })
+                .toList();
+        if (role != null) {
+            String trimmed = role.trim();
+            role = trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/LayerSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/LayerSuggestionPort.java
@@ -1,0 +1,34 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * AI 제안 — LearningLayer 후보 생성 outbound Port (Story-AS-E1).
+ *
+ * <p>구현체는 Static(코드 상수 기반 카탈로그) / LLM(Vertex AI Gemini) 등으로 교체 가능.
+ * 도메인 레이어는 본 Port를 import하지 않는다 — Application Service만 호출.</p>
+ *
+ * <p><b>Port 계약 (구현체 공통)</b>:</p>
+ * <ul>
+ *   <li>{@code existingLayerNames}의 각 원소는 trim 후 비교한다 (conventions.md §1.1 입력 정규화).</li>
+ *   <li>{@code existingLayerNames}가 null이거나 빈 리스트면 중복 제거 없이 후보 전체에서 limit만큼 반환.</li>
+ *   <li>{@code existingLayerNames}의 null 원소는 무시한다 (예외 미발생).</li>
+ *   <li>{@code limit <= 0}이면 빈 목록을 반환하고 예외를 던지지 않는다.</li>
+ *   <li>구현체는 입력 List를 변경해선 안 된다 (read-only contract).</li>
+ * </ul>
+ *
+ * @see AxisSuggestionPort
+ */
+public interface LayerSuggestionPort {
+
+    /**
+     * 사용자의 concept context + 기존 Layer 이름 목록을 입력으로 Layer 후보를 반환한다.
+     *
+     * <p>구현체는 {@code existingLayerNames}와 중복되는 후보를 제거하고 최대 {@code limit}개까지 반환한다.
+     * 호출 실패 시(타임아웃 / 파싱 실패 / 인증 실패)는 구현체별 예외로 던지며, 상위 Service가
+     * 빈 목록 + {@code suggestionsAvailable: false}로 변환한다(Fallback 정책).</p>
+     */
+    List<LayerSuggestion> suggest(LayerSuggestionContext context,
+                                   List<String> existingLayerNames,
+                                   int limit);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/RoadmapSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/RoadmapSuggestion.java
@@ -1,0 +1,31 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * AI 제안 Axis Roadmap (Story-AS-E1).
+ *
+ * <p>ADR023(예정) 용어 기준 Roadmap = 헌법. Axis 안에서의 학습 순서 청사진 (챕터 순서).
+ * <p>{@code outline}은 챕터 title 순서 리스트 (최소 1개).
+ * {@code rationale}은 이 로드맵을 제안한 이유(선택 — LLM 안정 생성 보장 없어 null 허용).</p>
+ */
+public record RoadmapSuggestion(List<String> outline, String rationale) {
+
+    public RoadmapSuggestion {
+        if (outline == null || outline.isEmpty()) {
+            throw new IllegalArgumentException("outline은 최소 1개 이상이어야 합니다.");
+        }
+        outline = outline.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        throw new IllegalArgumentException("outline의 각 원소는 blank일 수 없습니다.");
+                    }
+                    return value.trim();
+                })
+                .toList();
+        if (rationale != null) {
+            String trimmed = rationale.trim();
+            rationale = trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/RoadmapSuggestionContext.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/RoadmapSuggestionContext.java
@@ -1,0 +1,54 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * Axis별 Roadmap(헌법 — 학습 순서 청사진) 제안에 전달되는 입력 컨텍스트 (Story-AS-E1).
+ *
+ * <p>Roadmap은 특정 Axis 안에서 "무엇을 · 어떤 순서로 학습할지" 뼈대를 정의한다.
+ * ADR023(예정) 용어 기준: Roadmap = 헌법, Selection = 판례.
+ *
+ * <p>{@code layerName}은 옵셔널 힌트 (LLM 컨텍스트 풍부화). {@code role}은 RoleDetector 미도입 상태에서 null.</p>
+ */
+public record RoadmapSuggestionContext(
+        Long facadeId,
+        Long layerId,
+        Long axisId,
+        String axisName,
+        String layerName,
+        List<String> concepts,
+        String role
+) {
+
+    public RoadmapSuggestionContext {
+        if (facadeId == null) {
+            throw new IllegalArgumentException("facadeId는 null일 수 없습니다.");
+        }
+        if (axisId == null) {
+            throw new IllegalArgumentException("axisId는 null일 수 없습니다.");
+        }
+        if (axisName == null || axisName.isBlank()) {
+            throw new IllegalArgumentException("axisName은 blank일 수 없습니다.");
+        }
+        axisName = axisName.trim();
+        if (layerName != null) {
+            String trimmed = layerName.trim();
+            layerName = trimmed.isEmpty() ? null : trimmed;
+        }
+        if (concepts == null || concepts.isEmpty()) {
+            throw new IllegalArgumentException("concepts는 최소 1개 이상이어야 합니다.");
+        }
+        concepts = concepts.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        throw new IllegalArgumentException("concepts의 각 원소는 blank일 수 없습니다.");
+                    }
+                    return value.trim();
+                })
+                .toList();
+        if (role != null) {
+            String trimmed = role.trim();
+            role = trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/RoadmapSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/RoadmapSuggestionPort.java
@@ -1,0 +1,25 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+/**
+ * AI 제안 — Axis Roadmap(헌법) 생성 outbound Port (Story-AS-E1).
+ *
+ * <p>Axis 하나에 대해 학습 순서 청사진(챕터 리스트)을 반환한다.
+ * ADR023(예정) 용어 기준: Roadmap = 헌법(구조적 청사진).
+ *
+ * <p>구현체는 Static / LLM 등으로 교체 가능. 도메인 레이어는 본 Port를 import하지 않는다.</p>
+ *
+ * <p><b>Port 계약 (구현체 공통)</b>:</p>
+ * <ul>
+ *   <li>{@code context.concepts}는 사전에 trim 정규화된 상태로 전달된다.</li>
+ *   <li>실패 시(타임아웃 / 파싱 실패 / 인증 실패)는 구현체별 예외로 던지며, 상위 Service가
+ *       {@code roadmapAvailable: false} + 빈 outline 응답으로 변환.</li>
+ *   <li>구현체는 입력 context를 변경해선 안 된다 (read-only contract).</li>
+ * </ul>
+ */
+public interface RoadmapSuggestionPort {
+
+    /**
+     * 지정 Axis에 대해 Roadmap outline을 반환한다.
+     */
+    RoadmapSuggestion suggest(RoadmapSuggestionContext context);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SelectionsSuggestion.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SelectionsSuggestion.java
@@ -1,0 +1,31 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * AI 제안 Axis Selections (Story-AS-E1).
+ *
+ * <p>ADR023(예정) 용어 기준 Selection = 판례. Axis 학습 과정에서 활용할 구체 사례·문제·응용 리스트.
+ * <p>{@code selections}는 사례 리스트 (최소 1개).
+ * {@code rationale}은 판례 선택 이유(선택 — LLM 안정 생성 보장 없어 null 허용).</p>
+ */
+public record SelectionsSuggestion(List<String> selections, String rationale) {
+
+    public SelectionsSuggestion {
+        if (selections == null || selections.isEmpty()) {
+            throw new IllegalArgumentException("selections는 최소 1개 이상이어야 합니다.");
+        }
+        selections = selections.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        throw new IllegalArgumentException("selections의 각 원소는 blank일 수 없습니다.");
+                    }
+                    return value.trim();
+                })
+                .toList();
+        if (rationale != null) {
+            String trimmed = rationale.trim();
+            rationale = trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SelectionsSuggestionContext.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SelectionsSuggestionContext.java
@@ -1,0 +1,58 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import java.util.List;
+
+/**
+ * Axis별 Selections(판례 — 구체 사례·응용) 제안에 전달되는 입력 컨텍스트 (Story-AS-E1).
+ *
+ * <p>Selections는 Roadmap의 각 챕터에 대응되는 구체 사례·문제·응용 예시 리스트.
+ * ADR023(예정) 용어 기준: Selection = 판례.
+ *
+ * <p>{@code roadmapOutline}은 Roadmap 결과의 outline 순서 리스트를 참고용으로 전달 (LLM이 챕터별로
+ * 관련 판례를 생성할 때 컨텍스트).</p>
+ */
+public record SelectionsSuggestionContext(
+        Long facadeId,
+        Long layerId,
+        Long axisId,
+        String axisName,
+        List<String> concepts,
+        List<String> roadmapOutline,
+        String role
+) {
+
+    public SelectionsSuggestionContext {
+        if (facadeId == null) {
+            throw new IllegalArgumentException("facadeId는 null일 수 없습니다.");
+        }
+        if (axisId == null) {
+            throw new IllegalArgumentException("axisId는 null일 수 없습니다.");
+        }
+        if (axisName == null || axisName.isBlank()) {
+            throw new IllegalArgumentException("axisName은 blank일 수 없습니다.");
+        }
+        axisName = axisName.trim();
+        if (concepts == null || concepts.isEmpty()) {
+            throw new IllegalArgumentException("concepts는 최소 1개 이상이어야 합니다.");
+        }
+        concepts = concepts.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        throw new IllegalArgumentException("concepts의 각 원소는 blank일 수 없습니다.");
+                    }
+                    return value.trim();
+                })
+                .toList();
+        // roadmapOutline은 nullable — Roadmap 미생성 상태에서도 Selections 단독 호출 가능.
+        if (roadmapOutline != null) {
+            roadmapOutline = roadmapOutline.stream()
+                    .map(v -> v == null ? null : v.trim())
+                    .filter(v -> v != null && !v.isEmpty())
+                    .toList();
+        }
+        if (role != null) {
+            String trimmed = role.trim();
+            role = trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SelectionsSuggestionPort.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SelectionsSuggestionPort.java
@@ -1,0 +1,23 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+/**
+ * AI 제안 — Axis Selections(판례) 생성 outbound Port (Story-AS-E1).
+ *
+ * <p>Axis 하나에 대해 학습 과정에서 활용할 구체 사례·응용 판례 리스트를 반환한다.
+ * ADR023(예정) 용어 기준: Selection = 판례(구체 사례).
+ *
+ * <p><b>Port 계약 (구현체 공통)</b>:</p>
+ * <ul>
+ *   <li>{@code context.roadmapOutline}이 제공되면 챕터별로 관련성 있는 판례를 생성.</li>
+ *   <li>실패 시(타임아웃 / 파싱 실패 / 인증 실패)는 구현체별 예외로 던지며, 상위 Service가
+ *       빈 selections + {@code selectionsAvailable: false}로 변환.</li>
+ *   <li>구현체는 입력 context를 변경해선 안 된다 (read-only contract).</li>
+ * </ul>
+ */
+public interface SelectionsSuggestionPort {
+
+    /**
+     * 지정 Axis에 대해 판례(구체 사례) 리스트를 반환한다.
+     */
+    SelectionsSuggestion suggest(SelectionsSuggestionContext context);
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionPortsContractTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/port/out/suggestion/SuggestionPortsContractTest.java
@@ -1,0 +1,177 @@
+package com.example.thirdtool.LearningFacade.application.port.out.suggestion;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-AS-E1 · 3 Port(Layer/Roadmap/Selections) 인터페이스 + record 컴파일 · 계약 검증.
+ * 임의 stub Adapter로 시그니처 확정 실험.
+ */
+@DisplayName("AS Epic 1 · 4-Port 스켈레톤 계약")
+class SuggestionPortsContractTest {
+
+    // ─── 임의 Adapter stub (컴파일 실험) ───────────────────
+
+    private static class LayerStub implements LayerSuggestionPort {
+        @Override
+        public List<LayerSuggestion> suggest(LayerSuggestionContext context,
+                                             List<String> existingLayerNames,
+                                             int limit) {
+            return List.of(new LayerSuggestion("UI", "화면 계층"));
+        }
+    }
+
+    private static class RoadmapStub implements RoadmapSuggestionPort {
+        @Override
+        public RoadmapSuggestion suggest(RoadmapSuggestionContext context) {
+            return new RoadmapSuggestion(List.of("Ch1", "Ch2"), null);
+        }
+    }
+
+    private static class SelectionsStub implements SelectionsSuggestionPort {
+        @Override
+        public SelectionsSuggestion suggest(SelectionsSuggestionContext context) {
+            return new SelectionsSuggestion(List.of("사례1", "사례2"), "핵심 판례");
+        }
+    }
+
+    // ─── Layer ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("LayerSuggestion / Context / Port")
+    class Layer {
+
+        @Test
+        @DisplayName("LayerSuggestion_유효값_trim_저장")
+        void LayerSuggestion_유효값_trim_저장() {
+            LayerSuggestion s = new LayerSuggestion("  UI  ", "  화면 계층  ");
+            assertThat(s.name()).isEqualTo("UI");
+            assertThat(s.rationale()).isEqualTo("화면 계층");
+        }
+
+        @Test
+        @DisplayName("LayerSuggestion_name_blank_예외")
+        void LayerSuggestion_name_blank_예외() {
+            assertThatThrownBy(() -> new LayerSuggestion("  ", null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("LayerSuggestionContext_concepts_blank_예외")
+        void LayerSuggestionContext_concepts_blank_예외() {
+            assertThatThrownBy(() -> new LayerSuggestionContext(1L, List.of("  "), null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("LayerSuggestionContext_facadeId_null_예외")
+        void LayerSuggestionContext_facadeId_null_예외() {
+            assertThatThrownBy(() -> new LayerSuggestionContext(null, List.of("A"), null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("Port_stub_구현_시그니처_확정")
+        void Port_stub_구현_시그니처_확정() {
+            LayerSuggestionPort port = new LayerStub();
+            List<LayerSuggestion> result = port.suggest(
+                    new LayerSuggestionContext(1L, List.of("백엔드"), null),
+                    List.of(),
+                    5
+            );
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).name()).isEqualTo("UI");
+        }
+    }
+
+    // ─── Roadmap ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("RoadmapSuggestion / Context / Port")
+    class Roadmap {
+
+        @Test
+        @DisplayName("RoadmapSuggestion_outline_각_원소_trim")
+        void RoadmapSuggestion_outline_각_원소_trim() {
+            RoadmapSuggestion s = new RoadmapSuggestion(List.of("  Ch1  ", "  Ch2  "), "설계 이유");
+            assertThat(s.outline()).containsExactly("Ch1", "Ch2");
+        }
+
+        @Test
+        @DisplayName("RoadmapSuggestion_outline_빈_리스트_예외")
+        void RoadmapSuggestion_outline_빈_리스트_예외() {
+            assertThatThrownBy(() -> new RoadmapSuggestion(List.of(), null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("RoadmapContext_axisId_null_예외")
+        void RoadmapContext_axisId_null_예외() {
+            assertThatThrownBy(() -> new RoadmapSuggestionContext(1L, null, null,
+                    "API 설계", null, List.of("백엔드"), null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("Port_stub_구현_시그니처_확정")
+        void Port_stub_구현_시그니처_확정() {
+            RoadmapSuggestionPort port = new RoadmapStub();
+            RoadmapSuggestion result = port.suggest(new RoadmapSuggestionContext(
+                    1L, 10L, 100L, "API 설계", "백엔드 계층", List.of("Spring", "JPA"), "backend-developer"));
+            assertThat(result.outline()).containsExactly("Ch1", "Ch2");
+        }
+    }
+
+    // ─── Selections ────────────────────────────────────────
+
+    @Nested
+    @DisplayName("SelectionsSuggestion / Context / Port")
+    class Selections {
+
+        @Test
+        @DisplayName("SelectionsSuggestion_selections_trim_저장")
+        void SelectionsSuggestion_selections_trim_저장() {
+            SelectionsSuggestion s = new SelectionsSuggestion(List.of("  사례1  "), null);
+            assertThat(s.selections()).containsExactly("사례1");
+        }
+
+        @Test
+        @DisplayName("SelectionsSuggestion_selections_빈리스트_예외")
+        void SelectionsSuggestion_selections_빈리스트_예외() {
+            assertThatThrownBy(() -> new SelectionsSuggestion(List.of(), null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("SelectionsContext_roadmapOutline_nullable_허용")
+        void SelectionsContext_roadmapOutline_nullable_허용() {
+            SelectionsSuggestionContext ctx = new SelectionsSuggestionContext(
+                    1L, 10L, 100L, "API 설계", List.of("Spring"), null, null);
+            assertThat(ctx.roadmapOutline()).isNull();
+        }
+
+        @Test
+        @DisplayName("SelectionsContext_facadeId_null_예외")
+        void SelectionsContext_facadeId_null_예외() {
+            assertThatThrownBy(() -> new SelectionsSuggestionContext(
+                    null, 10L, 100L, "A", List.of("B"), null, null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("Port_stub_구현_시그니처_확정")
+        void Port_stub_구현_시그니처_확정() {
+            SelectionsSuggestionPort port = new SelectionsStub();
+            SelectionsSuggestion result = port.suggest(new SelectionsSuggestionContext(
+                    1L, 10L, 100L, "API 설계", List.of("Spring"),
+                    List.of("Ch1", "Ch2"), "backend-developer"));
+            assertThat(result.selections()).containsExactly("사례1", "사례2");
+        }
+    }
+}


### PR DESCRIPTION
## 개요
기존 AxisSuggestionPort에 이어 Layer/Roadmap/Selections 3 Port를 추가해 4-Port 스켈레톤을 완성. Adapter 구현은 별도 Story (Epic 3+ Static Adapter, Epic 4+ LLM Adapter).

## 왜 / 설계 결정
- LT Epic 1·2로 concepts[]·Layer 도메인이 착지 → AI 제안이 참조할 도메인 개념 확정
- Adapter 구현체 착수 전 시그니처 잠금 → 이후 Static/LLM Adapter 병렬 진입 가능 (milestone 근거)
- 6-Port 재편은 이슈 #17로 M4에서 진입 (product-ai-suggestion.md SDD의 SUPERSEDED 표기)
- ADR023(예정) 용어 정합: Roadmap=헌법, Selection=판례 — record javadoc에 언급

## 작업 내용
- feat(LayerSuggestionPort + LayerSuggestion + LayerSuggestionContext): 화면 계층 후보 제안 시그니처
- feat(RoadmapSuggestionPort + RoadmapSuggestion + RoadmapSuggestionContext): Axis별 학습 순서 청사진 (outline: List<String>)
- feat(SelectionsSuggestionPort + SelectionsSuggestion + SelectionsSuggestionContext): Axis별 구체 사례 리스트, roadmapOutline 컨텍스트 참고
- 각 record는 생성자 검증 (facadeId non-null · concepts min 1 · trim / blank / null 정규화) — SuggestionConceptContext 패턴 계승
- 컨트랙트 테스트 15건 (Layer/Roadmap/Selections 각 5건: 정규화 · 예외 · stub Adapter 구현 컴파일 확정)

## 변경 유형
- [x] feat  - [x] test  - [ ] fix  - [ ] refactor  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.application.port.out.suggestion.SuggestionPortsContractTest"` → BUILD SUCCESSFUL (15/15)

## 체크리스트
- [x] 4 Port + Context/VO record 컴파일 통과
- [x] 임의 stub Adapter 시그니처 확정 실험 통과 (LayerStub/RoadmapStub/SelectionsStub)
- [x] BC 간 의존 방향 위반 없음 (Port는 LearningFacade BC application/port/out/suggestion에 배치)
- [x] 5관점 Reviewer 세션 — rush 정책(0.0.3v 급행)으로 스킵
- [x] 대상 브랜치 = `develop` 확인

## 관련 이슈
- Milestone: `workflow/task/milestones/version/0.0.2v/milestone.md` Tier 1 · Story #11
- SDD: `workflow/task/pes/workspectrum/sdd/in-progress/product-ai-suggestion.md` Epic 1 (4-Port 정의 · 6-Port SUPERSEDED 표기)
- 원안: `workflow/task/fix/brainstorming/version/0.0.2v/issue-09-ai-4-port.md`