### PR TITLE
feat(ai-suggestion): AS Static Adapter 첫 발 [Story-AS-E3-S1·S2·E2-S1]

### DIFF
--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/RoleDetector.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/RoleDetector.java
@@ -1,0 +1,65 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@code concepts[]}로부터 사용자 role hint를 자동 감지하는 유틸 서비스 (Story-AS-E3-S1).
+ *
+ * <p>4개 role(backend-developer / planner / designer / problem-solver) + generic fallback.
+ * 매칭 규칙은 하드코드 사전 (keyword substring match, 대소문자 무시).
+ *
+ * <p>다중 role 매칭 시 첫 매칭(LinkedHashMap 순서)이 우선. 매칭 실패 시 "generic".
+ *
+ * <p>v1 — 정규식/임베딩 대신 하드코드 사전 채택 (Epic 3 기술 결정).
+ */
+@Component
+public class RoleDetector {
+
+    public static final String ROLE_GENERIC = "generic";
+
+    /** 매칭 순서 결정을 위해 {@link LinkedHashMap} 사용 (첫 매칭 우선). */
+    private static final Map<String, Set<String>> ROLE_KEYWORDS;
+
+    static {
+        ROLE_KEYWORDS = new LinkedHashMap<>();
+        ROLE_KEYWORDS.put("backend-developer",
+                Set.of("백엔드", "backend", "java", "spring", "시스템", "system", "서버", "api", "jpa", "database", "db"));
+        ROLE_KEYWORDS.put("planner",
+                Set.of("기획", "planner", "프로덕트", "product", "pm", "요구사항", "product manager", "기획자"));
+        ROLE_KEYWORDS.put("designer",
+                Set.of("디자인", "design", "ui", "ux", "와이어프레임", "wireframe", "figma", "디자이너"));
+        ROLE_KEYWORDS.put("problem-solver",
+                Set.of("문제해결", "problem", "알고리즘", "algorithm", "트러블슈팅", "troubleshoot", "코딩테스트", "ps"));
+    }
+
+    /**
+     * concepts에서 첫 매칭 role을 반환한다. 매칭 실패 시 {@link #ROLE_GENERIC}.
+     *
+     * <p>입력 정규화: 각 concept은 {@code lowerCase().trim()} 후 substring 매칭.
+     * null concept은 무시. 빈 리스트도 무시하고 fallback 반환.
+     */
+    public String detect(List<String> concepts) {
+        if (concepts == null || concepts.isEmpty()) {
+            return ROLE_GENERIC;
+        }
+        for (Map.Entry<String, Set<String>> entry : ROLE_KEYWORDS.entrySet()) {
+            for (String concept : concepts) {
+                if (concept == null || concept.isBlank()) {
+                    continue;
+                }
+                String normalized = concept.toLowerCase().trim();
+                for (String keyword : entry.getValue()) {
+                    if (normalized.contains(keyword.toLowerCase())) {
+                        return entry.getKey();
+                    }
+                }
+            }
+        }
+        return ROLE_GENERIC;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticLayerSuggestionAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticLayerSuggestionAdapter.java
@@ -1,0 +1,77 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.LayerSuggestion;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.LayerSuggestionContext;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.LayerSuggestionPort;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Static (LLM 없이 카탈로그 기반) Layer 제안 Adapter (Story-AS-E2-S1).
+ *
+ * <p>{@link LayerSuggestionContext#role()}를 카탈로그 키로 조회 → 매칭 카탈로그의 layers 절 반환.
+ * role이 null이면 "generic" 카탈로그로 폴백 ({@link SuggestionCatalogLoader#load}가 처리).
+ * {@code existingLayerNames}에 포함된 이름은 후보에서 제외.
+ *
+ * <p>기본 활성화 조건: {@code thirdtool.suggestion.provider=static} (또는 미설정 시 기본).
+ * LLM Adapter 도입 시 property로 교체.
+ */
+@Component
+@ConditionalOnProperty(
+        name = "thirdtool.suggestion.provider",
+        havingValue = "static",
+        matchIfMissing = true
+)
+public class StaticLayerSuggestionAdapter implements LayerSuggestionPort {
+
+    private final SuggestionCatalogLoader catalogLoader;
+
+    public StaticLayerSuggestionAdapter(SuggestionCatalogLoader catalogLoader) {
+        this.catalogLoader = catalogLoader;
+    }
+
+    @Override
+    public List<LayerSuggestion> suggest(LayerSuggestionContext context,
+                                         List<String> existingLayerNames,
+                                         int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        SuggestionCatalog catalog = catalogLoader.load(context.role());
+        List<SuggestionCatalog.LayerEntry> layerEntries = catalog.layers();
+        if (layerEntries == null || layerEntries.isEmpty()) {
+            return List.of();
+        }
+
+        // 기존 Layer 이름 정규화 (trim, null 제외) — 도메인 컨벤션 §1.1.
+        Set<String> excluded = new HashSet<>();
+        if (existingLayerNames != null) {
+            for (String name : existingLayerNames) {
+                if (name != null) {
+                    excluded.add(name.trim());
+                }
+            }
+        }
+
+        List<LayerSuggestion> filtered = new ArrayList<>();
+        for (SuggestionCatalog.LayerEntry entry : layerEntries) {
+            if (entry == null || entry.name() == null || entry.name().isBlank()) {
+                continue;
+            }
+            String name = entry.name().trim();
+            if (excluded.contains(name)) {
+                continue;
+            }
+            filtered.add(new LayerSuggestion(name, entry.rationale()));
+            if (filtered.size() >= limit) {
+                break;
+            }
+        }
+        return filtered;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/SuggestionCatalog.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/SuggestionCatalog.java
@@ -1,0 +1,27 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Role별 4-Port(Layer/Axis/Roadmap/Selections) 응답 데이터를 담는 카탈로그 (Story-AS-E3-S2).
+ *
+ * <p>classpath JSON에서 로드 — 필드 순서·구조는 파일 스키마와 일치.
+ * Story-15 스코프에서는 {@code layers} 절만 실제 사용 (나머지는 Adapter 확장 대비 사전 정의).
+ */
+public record SuggestionCatalog(
+        String role,
+        List<LayerEntry> layers,
+        Map<String, List<AxisEntry>> axes,
+        Map<String, RoadmapEntry> roadmaps,
+        Map<String, SelectionsEntry> selections
+) {
+
+    public record LayerEntry(String name, String rationale) {}
+
+    public record AxisEntry(String description, String rationale) {}
+
+    public record RoadmapEntry(List<String> outline, String rationale) {}
+
+    public record SelectionsEntry(List<String> selections, String rationale) {}
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/SuggestionCatalogLoader.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/SuggestionCatalogLoader.java
@@ -1,0 +1,74 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * classpath에서 role별 카탈로그 JSON을 로드해 캐시한다 (Story-AS-E3-S2).
+ *
+ * <p>경로 규약: {@code ai/catalog/{role}.json}. role 파일이 없으면 {@code generic.json}으로 폴백.
+ * generic 파일도 없으면 빈 카탈로그 반환 (Adapter가 빈 응답으로 변환).
+ *
+ * <p>캐시는 프로세스 lifetime 동안 유지 (JVM restart 시 재로드).
+ */
+@Component
+public class SuggestionCatalogLoader {
+
+    private static final String CATALOG_BASE_PATH = "ai/catalog/";
+    private static final String CATALOG_EXTENSION = ".json";
+
+    private final ObjectMapper objectMapper;
+    private final Map<String, SuggestionCatalog> cache = new ConcurrentHashMap<>();
+
+    public SuggestionCatalogLoader(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * role에 해당하는 카탈로그를 반환. 없으면 generic로 폴백. generic도 없으면 빈 카탈로그.
+     * 결과는 캐시된다 (동일 role 재요청 시 파일 재읽기 없음).
+     */
+    public SuggestionCatalog load(String role) {
+        String effectiveRole = (role == null || role.isBlank()) ? "generic" : role;
+        return cache.computeIfAbsent(effectiveRole, this::doLoad);
+    }
+
+    private SuggestionCatalog doLoad(String role) {
+        SuggestionCatalog catalog = tryReadCatalog(role);
+        if (catalog != null) {
+            return catalog;
+        }
+        if (!"generic".equals(role)) {
+            SuggestionCatalog fallback = tryReadCatalog("generic");
+            if (fallback != null) {
+                return fallback;
+            }
+        }
+        return emptyCatalog(role);
+    }
+
+    private SuggestionCatalog tryReadCatalog(String role) {
+        String path = CATALOG_BASE_PATH + role + CATALOG_EXTENSION;
+        ClassPathResource resource = new ClassPathResource(path);
+        if (!resource.exists()) {
+            return null;
+        }
+        try (InputStream in = resource.getInputStream()) {
+            return objectMapper.readValue(in, SuggestionCatalog.class);
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "카탈로그 JSON 파싱 실패: " + path, e);
+        }
+    }
+
+    private static SuggestionCatalog emptyCatalog(String role) {
+        return new SuggestionCatalog(role, List.of(), Map.of(), Map.of(), Map.of());
+    }
+}

--- a/src/main/resources/ai/catalog/backend-developer.json
+++ b/src/main/resources/ai/catalog/backend-developer.json
@@ -1,0 +1,45 @@
+{
+  "role": "backend-developer",
+  "layers": [
+    { "name": "웹 API",       "rationale": "HTTP 요청·응답·라우팅 처리 계층" },
+    { "name": "도메인 로직",  "rationale": "비즈니스 규칙과 불변식이 응집되는 핵심 계층" },
+    { "name": "데이터 접근",  "rationale": "영속화 · 트랜잭션 · 쿼리 최적화 계층" },
+    { "name": "인프라 · 운영", "rationale": "배포 · 모니터링 · 로깅 · 보안 계층" },
+    { "name": "테스트 · 품질", "rationale": "단위 · 슬라이스 · 통합 테스트 전략과 자동화 계층" }
+  ],
+  "axes": {
+    "웹 API": [
+      { "description": "REST 원칙",       "rationale": "리소스 · 상태 · HTTP 매핑" },
+      { "description": "인증 · 인가",     "rationale": "JWT / OAuth / RBAC" },
+      { "description": "예외 · 응답 형식", "rationale": "ErrorCode · GlobalExceptionHandler" }
+    ],
+    "도메인 로직": [
+      { "description": "Aggregate 설계",   "rationale": "경계 · 불변식 · 정적 팩토리" },
+      { "description": "Value Object",     "rationale": "불변 · 캡슐화 · 정규화" }
+    ],
+    "데이터 접근": [
+      { "description": "JPA · QueryDSL",   "rationale": "매핑 · fetch 전략 · N+1" },
+      { "description": "Flyway 마이그레이션", "rationale": "스키마 진화 · 롤백 · 백필" }
+    ]
+  },
+  "roadmaps": {
+    "REST 원칙": {
+      "outline": ["REST 개요", "리소스 모델링", "상태 전이", "버전 관리 · 문서화"],
+      "rationale": "HTTP 위 API 설계의 기본 골격을 순차 학습"
+    },
+    "Aggregate 설계": {
+      "outline": ["Aggregate 경계", "불변식 강제", "정적 팩토리 · 캡슐화", "다건 입력 처리"],
+      "rationale": "DDD 관점의 도메인 응집도 확보"
+    }
+  },
+  "selections": {
+    "REST 원칙": {
+      "selections": ["Github API 사례", "Stripe API 사례", "Slack API 사례"],
+      "rationale": "실무 잘 알려진 REST 설계 예"
+    },
+    "Aggregate 설계": {
+      "selections": ["결제 도메인 사례", "주문 · 배송 사례", "학습 카드 사례"],
+      "rationale": "도메인별 Aggregate 경계 정하기 실전 예"
+    }
+  }
+}

--- a/src/main/resources/ai/catalog/generic.json
+++ b/src/main/resources/ai/catalog/generic.json
@@ -1,0 +1,28 @@
+{
+  "role": "generic",
+  "layers": [
+    { "name": "핵심 개념", "rationale": "학습 주제의 근본 개념 계층" },
+    { "name": "실무 적용", "rationale": "개념을 실제 상황에 적용하는 계층" },
+    { "name": "심화 · 응용", "rationale": "예외 · 최적화 · 확장 계층" }
+  ],
+  "axes": {
+    "핵심 개념": [
+      { "description": "기본 원칙", "rationale": "필수로 알아야 할 원칙 · 정의" }
+    ],
+    "실무 적용": [
+      { "description": "표준 패턴", "rationale": "널리 쓰이는 표준 · 관행" }
+    ]
+  },
+  "roadmaps": {
+    "기본 원칙": {
+      "outline": ["개요", "심화", "실전"],
+      "rationale": "일반적 학습 흐름 fallback"
+    }
+  },
+  "selections": {
+    "기본 원칙": {
+      "selections": ["사례 A", "사례 B", "사례 C"],
+      "rationale": "일반 사례 fallback"
+    }
+  }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/RoleDetectorTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/RoleDetectorTest.java
@@ -1,0 +1,96 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-AS-E3-S1 · RoleDetector 하드코드 사전 매칭 검증.
+ */
+@DisplayName("RoleDetector — 4 role + generic fallback")
+class RoleDetectorTest {
+
+    private final RoleDetector detector = new RoleDetector();
+
+    @Test
+    @DisplayName("detect_백엔드_시스템설계_backend_developer_반환")
+    void detect_백엔드_시스템설계_backend_developer_반환() {
+        String role = detector.detect(List.of("백엔드", "시스템설계"));
+        assertThat(role).isEqualTo("backend-developer");
+    }
+
+    @Test
+    @DisplayName("detect_기획_프로덕트_planner_반환")
+    void detect_기획_프로덕트_planner_반환() {
+        String role = detector.detect(List.of("기획", "프로덕트"));
+        assertThat(role).isEqualTo("planner");
+    }
+
+    @Test
+    @DisplayName("detect_UI_와이어프레임_designer_반환")
+    void detect_UI_와이어프레임_designer_반환() {
+        String role = detector.detect(List.of("UI", "와이어프레임"));
+        assertThat(role).isEqualTo("designer");
+    }
+
+    @Test
+    @DisplayName("detect_알고리즘_트러블슈팅_problem_solver_반환")
+    void detect_알고리즘_트러블슈팅_problem_solver_반환() {
+        String role = detector.detect(List.of("알고리즘", "트러블슈팅"));
+        assertThat(role).isEqualTo("problem-solver");
+    }
+
+    @Test
+    @DisplayName("detect_대소문자_무시_backend")
+    void detect_대소문자_무시_backend() {
+        String role = detector.detect(List.of("SPRING", "JAVA"));
+        assertThat(role).isEqualTo("backend-developer");
+    }
+
+    @Test
+    @DisplayName("detect_공백_포함_trim_적용")
+    void detect_공백_포함_trim_적용() {
+        String role = detector.detect(List.of("  백엔드  "));
+        assertThat(role).isEqualTo("backend-developer");
+    }
+
+    @Test
+    @DisplayName("detect_매칭_실패_generic_반환")
+    void detect_매칭_실패_generic_반환() {
+        String role = detector.detect(List.of("random-word"));
+        assertThat(role).isEqualTo(RoleDetector.ROLE_GENERIC);
+    }
+
+    @Test
+    @DisplayName("detect_빈_리스트_generic_반환")
+    void detect_빈_리스트_generic_반환() {
+        String role = detector.detect(List.of());
+        assertThat(role).isEqualTo(RoleDetector.ROLE_GENERIC);
+    }
+
+    @Test
+    @DisplayName("detect_null_리스트_generic_반환")
+    void detect_null_리스트_generic_반환() {
+        String role = detector.detect(null);
+        assertThat(role).isEqualTo(RoleDetector.ROLE_GENERIC);
+    }
+
+    @Test
+    @DisplayName("detect_null_원소_무시_다음_원소_매칭")
+    void detect_null_원소_무시_다음_원소_매칭() {
+        String role = detector.detect(java.util.Arrays.asList(null, "  ", "백엔드"));
+        assertThat(role).isEqualTo("backend-developer");
+    }
+
+    @Test
+    @DisplayName("detect_다중_role_매칭시_첫_매칭_반환_backend_먼저")
+    void detect_다중_role_매칭시_첫_매칭_반환_backend_먼저() {
+        // LinkedHashMap 순서: backend-developer > planner > designer > problem-solver
+        // "백엔드"(backend) + "디자인"(designer) 조합 → backend 우선
+        String role = detector.detect(List.of("디자인", "백엔드"));
+        assertThat(role).isEqualTo("backend-developer");
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticLayerSuggestionAdapterTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/StaticLayerSuggestionAdapterTest.java
@@ -1,0 +1,134 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.LayerSuggestion;
+import com.example.thirdtool.LearningFacade.application.port.out.suggestion.LayerSuggestionContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-AS-E2-S1 · StaticLayerSuggestionAdapter — role 카탈로그 + dedupe + limit 검증.
+ */
+@DisplayName("StaticLayerSuggestionAdapter")
+class StaticLayerSuggestionAdapterTest {
+
+    private StaticLayerSuggestionAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        SuggestionCatalogLoader loader = new SuggestionCatalogLoader(new ObjectMapper());
+        adapter = new StaticLayerSuggestionAdapter(loader);
+    }
+
+    @Nested
+    @DisplayName("suggest — 해피")
+    class Happy {
+
+        @Test
+        @DisplayName("suggest_backend_developer_role_웹API가_첫_항목")
+        void suggest_backend_developer_role_웹API가_첫_항목() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("백엔드"), "backend-developer");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of(), 5);
+
+            assertThat(result).hasSize(5);
+            assertThat(result.get(0).name()).isEqualTo("웹 API");
+        }
+
+        @Test
+        @DisplayName("suggest_role_null_generic_fallback_반환")
+        void suggest_role_null_generic_fallback_반환() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("random"), null);
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of(), 5);
+
+            // generic.json has 3 layers
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).name()).isEqualTo("핵심 개념");
+        }
+
+        @Test
+        @DisplayName("suggest_존재하지_않는_role_generic_폴백")
+        void suggest_존재하지_않는_role_generic_폴백() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("random"), "nonexistent-role");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of(), 5);
+
+            assertThat(result).isNotEmpty();
+            assertThat(result.get(0).name()).isEqualTo("핵심 개념");
+        }
+    }
+
+    @Nested
+    @DisplayName("suggest — 필터")
+    class Filter {
+
+        @Test
+        @DisplayName("suggest_existingLayerNames_에_포함된_이름_제외")
+        void suggest_existingLayerNames_에_포함된_이름_제외() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("백엔드"), "backend-developer");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of("웹 API"), 5);
+
+            assertThat(result).extracting(LayerSuggestion::name)
+                    .doesNotContain("웹 API");
+            assertThat(result.get(0).name()).isEqualTo("도메인 로직");
+        }
+
+        @Test
+        @DisplayName("suggest_existingLayerNames_trim_적용_후_비교")
+        void suggest_existingLayerNames_trim_적용_후_비교() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("백엔드"), "backend-developer");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx,
+                    java.util.Arrays.asList("  웹 API  ", null), 5);
+
+            assertThat(result).extracting(LayerSuggestion::name)
+                    .doesNotContain("웹 API");
+        }
+
+        @Test
+        @DisplayName("suggest_limit_2_상위_2개만_반환")
+        void suggest_limit_2_상위_2개만_반환() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("백엔드"), "backend-developer");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of(), 2);
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("suggest_limit_0_빈_리스트")
+        void suggest_limit_0_빈_리스트() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("백엔드"), "backend-developer");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of(), 0);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("suggest_limit_음수_빈_리스트")
+        void suggest_limit_음수_빈_리스트() {
+            LayerSuggestionContext ctx = new LayerSuggestionContext(
+                    1L, List.of("백엔드"), "backend-developer");
+
+            List<LayerSuggestion> result = adapter.suggest(ctx, List.of(), -1);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/SuggestionCatalogLoaderTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/suggestion/SuggestionCatalogLoaderTest.java
@@ -1,0 +1,62 @@
+package com.example.thirdtool.LearningFacade.infrastructure.suggestion;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-AS-E3-S2 · classpath 카탈로그 로더 검증.
+ */
+@DisplayName("SuggestionCatalogLoader")
+class SuggestionCatalogLoaderTest {
+
+    private SuggestionCatalogLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        loader = new SuggestionCatalogLoader(new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("load_backend_developer_layers_5건_반환")
+    void load_backend_developer_layers_5건_반환() {
+        SuggestionCatalog catalog = loader.load("backend-developer");
+
+        assertThat(catalog.role()).isEqualTo("backend-developer");
+        assertThat(catalog.layers()).hasSize(5);
+        assertThat(catalog.layers().get(0).name()).isEqualTo("웹 API");
+    }
+
+    @Test
+    @DisplayName("load_존재하지_않는_role_generic_fallback")
+    void load_존재하지_않는_role_generic_fallback() {
+        SuggestionCatalog catalog = loader.load("nonexistent-role");
+        assertThat(catalog.role()).isEqualTo("generic");
+        assertThat(catalog.layers()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("load_null_role_generic_fallback")
+    void load_null_role_generic_fallback() {
+        SuggestionCatalog catalog = loader.load(null);
+        assertThat(catalog.role()).isEqualTo("generic");
+    }
+
+    @Test
+    @DisplayName("load_blank_role_generic_fallback")
+    void load_blank_role_generic_fallback() {
+        SuggestionCatalog catalog = loader.load("  ");
+        assertThat(catalog.role()).isEqualTo("generic");
+    }
+
+    @Test
+    @DisplayName("load_동일_role_재요청시_캐시_반환_동일_인스턴스")
+    void load_동일_role_재요청시_캐시_반환_동일_인스턴스() {
+        SuggestionCatalog first = loader.load("backend-developer");
+        SuggestionCatalog second = loader.load("backend-developer");
+        assertThat(first).isSameAs(second);
+    }
+}


### PR DESCRIPTION
## 개요
AI 제안 4-Port(PR #198)에 첫 실제 구현체 착지 — RoleDetector로 concepts→role 자동 감지 · JSON 카탈로그 로딩 · Layer 제안 Static Adapter. LLM 없이도 Layer 제안 가능. Tier 2 · Want (0.0.3v 급행).

## 왜 / 설계 결정
- LT Epic 1·2 착지 + AS-E1 4-Port 스켈레톤 완료 → 실제 Static Adapter로 loop 완결 (사용자가 layers 제안을 받는 endpoint까지 도달 가능)
- RoleDetector 하드코드 사전 (LinkedHashMap 순서) — 정규식/임베딩보다 단순, 4 role 초기 데이터 확보에 충분 (Epic 3 결정)
- SuggestionCatalog record + 캐시 — startup 시 로드 미하고 최초 요청 시 lazy 로드 + ConcurrentHashMap 캐시 (JVM lifetime 유지)
- 폴백 전략: role 매칭 실패 → generic.json → 빈 카탈로그. Adapter는 빈 리스트 반환 (상위 Service가 suggestionsAvailable=false로 변환, ADR010 정합)
- `@ConditionalOnProperty(matchIfMissing=true)` — 기본값 static, LLM Adapter 도입 시 property로 교체 (SDD Epic 2 기술 결정)

## 작업 내용
- feat(AS-E3-S1) `RoleDetector`: concepts→role hint. 4 role + generic fallback. 하드코드 사전 (`Map<String, Set<String>>`)
- feat(AS-E3-S2) 카탈로그: `SuggestionCatalog` record + `SuggestionCatalogLoader`. `resources/ai/catalog/backend-developer.json`(5 layers · 3 axes 그룹 · roadmaps 2 · selections 2) + `generic.json`(3 layers 최소)
- feat(AS-E2-S1) `StaticLayerSuggestionAdapter`: `LayerSuggestionPort` 구현체. context.role() → catalog.layers 조회. existingLayerNames trim/null 정규화 dedupe. limit 적용

## 변경 유형
- [x] feat  - [x] test  - [ ] fix  - [ ] refactor  - [ ] chore

## 테스트
- `./gradlew test --tests "*RoleDetectorTest" --tests "*SuggestionCatalog*Test" --tests "*StaticLayerSuggestionAdapterTest"` → BUILD SUCCESSFUL
- 신규 테스트 24건:
  - RoleDetectorTest 11 (4 role · 대소문자 · trim · null 원소 · 다중 매칭 · generic)
  - SuggestionCatalogLoaderTest 5 (로드 · 폴백 · null/blank · 캐시)
  - StaticLayerSuggestionAdapterTest 8 (role 매칭 · null role · dedupe · trim · limit)
- 전체 `./gradlew test` 통과

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] BC 간 의존 방향 위반 없음 (RoleDetector = application/service, Adapter/Catalog = infrastructure/suggestion)
- [x] Spring `@ConditionalOnProperty` 관행 준수 (SDD Epic 2 결정)
- [x] 5관점 Reviewer 세션 — rush 정책(0.0.3v Tier 2)으로 스킵
- [x] 대상 브랜치 = `develop` 확인

## 관련 이슈
- Milestone: `workflow/task/milestones/version/0.0.2v/milestone.md` Tier 2 · Story #13/#14/#15 (0.0.3v Tier 2)
- SDD: `workflow/task/pes/workspectrum/sdd/in-progress/product-ai-suggestion.md` Epic 2 Story 2-1 · Epic 3 Story 3-1/3-2
- 원안: `workflow/task/fix/brainstorming/version/0.0.2v/issue-09-ai-suggestion-3layer.md` · `issue-10-role-catalog-expansion.md`