### PR TITLE
feat(learning-facade): Roadmap 노드 first-class 스키마·도메인·API [Story-LT-E3-S3-6~8]

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -105,6 +105,13 @@ public enum ErrorCode {
     LEARNING_AXIS_TOPIC_NAME_BLANK("LT002",       "주제 이름은 비어 있을 수 없습니다.",                      HttpStatus.BAD_REQUEST),
     LEARNING_AXIS_TOPIC_REORDER_MISMATCH("LT003", "전달된 주제 id 목록이 현재 주제 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
+    // ─── AxisRoadmapNode (Story-LT-E3-S3-6~S3-8, 이슈 #15) ─
+    // 이슈 #6의 axis_roadmap.content TEXT 통짜 SUPERSEDED — 챕터 노드 first-class로 재편.
+    ROADMAP_NODE_NOT_FOUND("RN001",       "Roadmap 노드를 찾을 수 없습니다.",                              HttpStatus.NOT_FOUND),
+    ROADMAP_NODE_TITLE_BLANK("RN002",     "Roadmap 노드 title은 비어 있을 수 없습니다.",                    HttpStatus.BAD_REQUEST),
+    ROADMAP_NODE_BODY_BLANK("RN003",      "Roadmap 노드 body는 비어 있을 수 없습니다.",                     HttpStatus.BAD_REQUEST),
+    ROADMAP_NODE_ORDER_MISMATCH("RN004",  "전달된 Roadmap 노드 id 목록이 현재 노드 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+
     // ─── LearningMaterial ─────────────────────────────────
     LEARNING_MATERIAL_NOT_FOUND("LM001",                          "학습 자료를 찾을 수 없습니다.",                                  HttpStatus.NOT_FOUND),
     LEARNING_MATERIAL_PROFICIENCY_UNRATED_NOT_ALLOWED("LM002",    "숙련도는 UNRATED로 되돌릴 수 없습니다.",                         HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/dto/AxisRoadmapNodeCommand.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/dto/AxisRoadmapNodeCommand.java
@@ -1,0 +1,44 @@
+package com.example.thirdtool.LearningFacade.application.dto;
+
+import java.util.List;
+
+/**
+ * Roadmap 노드 Command DTO (Story-LT-E3-S3-8).
+ * 사용자 요청을 Application Service로 전달하는 record 셋트.
+ */
+public final class AxisRoadmapNodeCommand {
+
+    private AxisRoadmapNodeCommand() {}
+
+    /** POST /api/v1/axes/{axisId}/roadmap-nodes */
+    public record Add(
+            Long userId,
+            Long axisId,
+            String title,
+            String rationale,
+            String body
+    ) {}
+
+    /**
+     * PATCH /api/v1/roadmap-nodes/{nodeId} — 부분 필드 업데이트.
+     * 각 필드는 "미제공(null)"과 "빈문자열/blank"를 구분해서 처리:
+     *   · title/body — null이면 미제공(no-op), blank이면 예외
+     *   · rationale — null이면 미제공, blank이면 null로 정규화
+     */
+    public record Update(
+            Long userId,
+            Long nodeId,
+            String title,       // null = 미제공
+            String rationale,   // null = 미제공, blank = null로 정규화
+            String body,        // null = 미제공
+            boolean titlePresent,
+            boolean rationalePresent,
+            boolean bodyPresent
+    ) {}
+
+    /** DELETE /api/v1/roadmap-nodes/{nodeId} */
+    public record Remove(Long userId, Long nodeId) {}
+
+    /** PUT /api/v1/axes/{axisId}/roadmap-nodes/order */
+    public record Reorder(Long userId, Long axisId, List<Long> orderedNodeIds) {}
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisRoadmapNodeCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisRoadmapNodeCommandService.java
@@ -1,0 +1,107 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.application.dto.AxisRoadmapNodeCommand;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.AxisRoadmapNodeRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisRoadmapNodeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Roadmap 노드 Command Application Service (Story-LT-E3-S3-8).
+ *
+ * <p>모든 커맨드는 소유권 검증 (loadFacadeByUser → facade가 axis를 소유하는지 → axis가 node를 소유하는지).
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AxisRoadmapNodeCommandService {
+
+    private final LearningFacadeRepository facadeRepository;
+    private final AxisRoadmapNodeRepository nodeRepository;
+
+    public AxisRoadmapNodeResponse.NodeDetail add(AxisRoadmapNodeCommand.Add command) {
+        LearningFacade facade = loadFacade(command.userId());
+        LearningAxis axis = findAxis(facade, command.axisId());
+
+        AxisRoadmapNode node = axis.addRoadmapNode(command.title(), command.rationale(), command.body());
+        facadeRepository.save(facade);
+
+        if (node.getId() == null) {
+            throw new IllegalStateException(
+                    "AxisRoadmapNode id가 cascade save 후에도 null입니다. JPA 설정 회귀 가능성.");
+        }
+        return AxisRoadmapNodeResponse.NodeDetail.of(node);
+    }
+
+    public AxisRoadmapNodeResponse.NodeDetail update(AxisRoadmapNodeCommand.Update command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisRoadmapNode node = loadNodeOwnedBy(facade, command.nodeId());
+
+        if (command.titlePresent()) {
+            node.updateTitle(command.title());
+        }
+        if (command.rationalePresent()) {
+            node.updateRationale(command.rationale());
+        }
+        if (command.bodyPresent()) {
+            node.updateBody(command.body());
+        }
+        // JPA dirty checking으로 flush 시점에 UPDATE.
+        return AxisRoadmapNodeResponse.NodeDetail.of(node);
+    }
+
+    public void remove(AxisRoadmapNodeCommand.Remove command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisRoadmapNode node = loadNodeOwnedBy(facade, command.nodeId());
+
+        // 도메인 API 통과 (LearningAxis.removeRoadmapNode) — 자식 컬렉션에 대한 캡슐화 유지.
+        LearningAxis axis = node.getAxis();
+        axis.removeRoadmapNode(command.nodeId());
+        facadeRepository.save(facade);
+    }
+
+    public AxisRoadmapNodeResponse.Reordered reorder(AxisRoadmapNodeCommand.Reorder command) {
+        LearningFacade facade = loadFacade(command.userId());
+        LearningAxis axis = findAxis(facade, command.axisId());
+
+        axis.reorderRoadmapNodes(command.orderedNodeIds());
+        facadeRepository.save(facade);
+        return AxisRoadmapNodeResponse.Reordered.of(axis.getRoadmapNodes());
+    }
+
+    private LearningFacade loadFacade(Long userId) {
+        return facadeRepository.findByUserId(userId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND));
+    }
+
+    private LearningAxis findAxis(LearningFacade facade, Long axisId) {
+        return facade.getAxes().stream()
+                .filter(a -> a.getId() != null && a.getId().equals(axisId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_NOT_FOUND));
+    }
+
+    /**
+     * 노드 로드 + 소유권 검증 통합. facade → axis → node 체인.
+     */
+    private AxisRoadmapNode loadNodeOwnedBy(LearningFacade facade, Long nodeId) {
+        AxisRoadmapNode node = nodeRepository.findById(nodeId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.ROADMAP_NODE_NOT_FOUND));
+
+        // node.axis.facade == facade 여야 함 (userId 소유자 검증).
+        LearningAxis axis = node.getAxis();
+        if (axis == null || axis.getFacade() == null
+                || !axis.getFacade().getId().equals(facade.getId())) {
+            // 소유자 mismatch도 NOT_FOUND로 통일 (정보 노출 방지).
+            throw LearningFacadeDomainException.of(ErrorCode.ROADMAP_NODE_NOT_FOUND);
+        }
+        return node;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisRoadmapNodeQueryService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisRoadmapNodeQueryService.java
@@ -1,0 +1,40 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.AxisRoadmapNodeRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisRoadmapNodeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Roadmap 노드 Query Application Service (Story-LT-E3-S3-8).
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AxisRoadmapNodeQueryService {
+
+    private final LearningFacadeRepository facadeRepository;
+    private final AxisRoadmapNodeRepository nodeRepository;
+
+    /**
+     * axisId 하위 활성 노드 리스트 (display_order ASC).
+     * 소유권 검증: axis가 user의 facade에 속하는지.
+     */
+    public AxisRoadmapNodeResponse.NodeList list(Long userId, Long axisId) {
+        LearningFacade facade = facadeRepository.findByUserId(userId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND));
+        LearningAxis axis = facade.getAxes().stream()
+                .filter(a -> a.getId() != null && a.getId().equals(axisId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_NOT_FOUND));
+
+        return AxisRoadmapNodeResponse.NodeList.of(
+                nodeRepository.findByAxisIdOrderByDisplayOrderAsc(axis.getId()));
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisRoadmapNode.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisRoadmapNode.java
@@ -51,7 +51,7 @@ public class AxisRoadmapNode {
     @Column(name = "rationale", length = RATIONALE_MAX_LENGTH)
     private String rationale;
 
-    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "body", nullable = false, columnDefinition = "MEDIUMTEXT")
     private String body;
 
     @CreationTimestamp

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisRoadmapNode.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisRoadmapNode.java
@@ -1,0 +1,168 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Roadmap 챕터 노드 (Story-LT-E3-S3-6, 이슈 #15).
+ *
+ * <p>이슈 #6의 {@code axis_roadmap.content TEXT} 통짜 저장 방식은 SUPERSEDED.
+ * 챕터 단위 first-class Entity로 승격되어 각 챕터가 독립적으로 저장·조회·순서변경·재생성 가능.
+ *
+ * <p>body에는 챕터 subtree (`├── 1-1. 정의와 본질\n...` 형태 ASCII 통짜)를 저장한다.
+ * 편집·diff는 사용자 텍스트 편집으로 자연스럽게 성립.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "axis_roadmap_node")
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE axis_roadmap_node SET deleted_at = NOW(6) WHERE id = ?")
+public class AxisRoadmapNode {
+
+    public static final int TITLE_MAX_LENGTH = 200;
+    public static final int RATIONALE_MAX_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "axis_id", nullable = false, updatable = false)
+    private LearningAxis axis;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(name = "title", nullable = false, length = TITLE_MAX_LENGTH)
+    private String title;
+
+    @Column(name = "rationale", length = RATIONALE_MAX_LENGTH)
+    private String rationale;
+
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    private AxisRoadmapNode(LearningAxis axis, int displayOrder, String title, String rationale, String body) {
+        this.axis = axis;
+        this.displayOrder = displayOrder;
+        this.title = title;
+        this.rationale = rationale;
+        this.body = body;
+    }
+
+    /**
+     * 정적 팩토리. {@link LearningAxis#addRoadmapNode}에서만 호출된다.
+     *
+     * <p>trim + blank 검증은 이 팩토리에서 담당한다 — Application Service가 정규화하지 않는다.
+     */
+    static AxisRoadmapNode create(LearningAxis axis, int displayOrder, String title, String rationale, String body) {
+        if (axis == null) {
+            throw LearningFacadeDomainException.of(ErrorCode.INVALID_INPUT, "axis는 null일 수 없습니다.");
+        }
+        if (displayOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. displayOrder=" + displayOrder);
+        }
+        String normalizedTitle = validateAndTrimTitle(title);
+        String normalizedBody = validateAndTrimBody(body);
+        String normalizedRationale = normalizeRationale(rationale);
+
+        return new AxisRoadmapNode(axis, displayOrder, normalizedTitle, normalizedRationale, normalizedBody);
+    }
+
+    public void updateTitle(String newTitle) {
+        this.title = validateAndTrimTitle(newTitle);
+    }
+
+    /**
+     * rationale는 nullable. blank/null 입력 시 null로 정규화한다 (선택 필드 컨벤션).
+     */
+    public void updateRationale(String newRationale) {
+        this.rationale = normalizeRationale(newRationale);
+    }
+
+    public void updateBody(String newBody) {
+        this.body = validateAndTrimBody(newBody);
+    }
+
+    /**
+     * Roadmap 노드 자체 논리 삭제.
+     * {@code @SQLDelete}에 의해 UPDATE로 변환되어 {@code deleted_at}이 설정된다.
+     */
+    public void softDelete() {
+        if (this.deletedAt != null) {
+            return; // 멱등 (재삭제 no-op)
+        }
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    void updateDisplayOrder(int newOrder) {
+        if (newOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. newOrder=" + newOrder);
+        }
+        this.displayOrder = newOrder;
+    }
+
+    private static String validateAndTrimTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.ROADMAP_NODE_TITLE_BLANK);
+        }
+        String trimmed = title.trim();
+        if (trimmed.length() > TITLE_MAX_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "title은 " + TITLE_MAX_LENGTH + "자 이내여야 합니다. length=" + trimmed.length());
+        }
+        return trimmed;
+    }
+
+    private static String validateAndTrimBody(String body) {
+        if (body == null || body.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.ROADMAP_NODE_BODY_BLANK);
+        }
+        return body.trim();
+    }
+
+    private static String normalizeRationale(String rationale) {
+        if (rationale == null || rationale.isBlank()) {
+            return null;
+        }
+        String trimmed = rationale.trim();
+        if (trimmed.length() > RATIONALE_MAX_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "rationale은 " + RATIONALE_MAX_LENGTH + "자 이내여야 합니다. length=" + trimmed.length());
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -80,6 +80,20 @@ public class LearningAxis {
     @OrderBy("displayOrder ASC")
     private final List<AxisTopic> topics = new ArrayList<>();
 
+    /**
+     * Roadmap 챕터 노드 (Story-LT-E3-S3-6, 이슈 #15).
+     * 각 노드가 챕터 하나 (title + rationale + body ASCII 통짜).
+     * {@code orphanRemoval=false} — 노드 자체가 {@code @SQLDelete}로 소프트 삭제되므로 hard delete 발생하지 않는다.
+     */
+    @OneToMany(
+            mappedBy      = "axis",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = false,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("displayOrder ASC")
+    private final List<AxisRoadmapNode> roadmapNodes = new ArrayList<>();
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -304,6 +318,80 @@ public class LearningAxis {
     public record TopicCommand(String name, String description) {
         public static TopicCommand of(String name, String description) {
             return new TopicCommand(name, description);
+        }
+    }
+
+    // ─── Roadmap 노드 도메인 API (Story-LT-E3-S3-6, 이슈 #15) ─────────
+
+    /**
+     * Roadmap 챕터 노드 추가. display_order는 (활성 노드 max) + 1.
+     *
+     * @return 신규 노드 (id는 flush 후 부여)
+     */
+    public AxisRoadmapNode addRoadmapNode(String title, String rationale, String body) {
+        int nextOrder = roadmapNodes.size() + 1;
+        AxisRoadmapNode node = AxisRoadmapNode.create(this, nextOrder, title, rationale, body);
+        roadmapNodes.add(node);
+        return node;
+    }
+
+    /**
+     * Roadmap 노드 순서 재부여. 전달된 id 순서대로 displayOrder를 1-based로 재부여한다.
+     * 전달된 id 집합이 현재 활성 roadmapNodes와 불일치하면 예외.
+     */
+    public void reorderRoadmapNodes(List<Long> orderedNodeIds) {
+        validateRoadmapNodeReorderIds(orderedNodeIds);
+        IntStream.range(0, orderedNodeIds.size()).forEach(i -> {
+            AxisRoadmapNode node = findRoadmapNode(orderedNodeIds.get(i));
+            node.updateDisplayOrder(i + 1);
+        });
+    }
+
+    /**
+     * Roadmap 노드 소프트 삭제. 노드 자체 {@link AxisRoadmapNode#softDelete()} 호출.
+     * 재삭제는 no-op (멱등).
+     */
+    public void removeRoadmapNode(Long nodeId) {
+        AxisRoadmapNode target = findRoadmapNode(nodeId);
+        target.softDelete();
+    }
+
+    public AxisRoadmapNode findRoadmapNode(Long nodeId) {
+        return roadmapNodes.stream()
+                .filter(n -> n.getId() != null && n.getId().equals(nodeId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(
+                        ErrorCode.ROADMAP_NODE_NOT_FOUND,
+                        "nodeId=" + nodeId));
+    }
+
+    /**
+     * 활성 Roadmap 노드 목록 (soft delete된 노드는 {@code @SQLRestriction}에 의해 자동 제외).
+     */
+    public List<AxisRoadmapNode> getRoadmapNodes() {
+        return Collections.unmodifiableList(roadmapNodes);
+    }
+
+    private void validateRoadmapNodeReorderIds(List<Long> orderedNodeIds) {
+        if (orderedNodeIds == null) {
+            throw LearningFacadeDomainException.of(ErrorCode.ROADMAP_NODE_ORDER_MISMATCH);
+        }
+        Set<Long> currentIds = roadmapNodes.stream()
+                .map(AxisRoadmapNode::getId)
+                .collect(Collectors.toSet());
+
+        if (orderedNodeIds.size() != currentIds.size()) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.ROADMAP_NODE_ORDER_MISMATCH,
+                    "전달된 노드 id 수(" + orderedNodeIds.size()
+                            + ")가 현재 노드 수(" + currentIds.size() + ")와 다릅니다.");
+        }
+
+        Set<Long> incomingIds = new HashSet<>(orderedNodeIds);
+        if (!currentIds.equals(incomingIds)) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.ROADMAP_NODE_ORDER_MISMATCH,
+                    "전달된 노드 id 목록이 현재 노드 id 집합과 일치하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeJpaRepository.java
@@ -1,0 +1,11 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AxisRoadmapNodeJpaRepository extends JpaRepository<AxisRoadmapNode, Long> {
+
+    List<AxisRoadmapNode> findByAxisIdOrderByDisplayOrderAsc(Long axisId);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeRepository.java
@@ -1,0 +1,18 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Roadmap 노드 Repository Port (Story-LT-E3-S3-8).
+ */
+public interface AxisRoadmapNodeRepository {
+
+    Optional<AxisRoadmapNode> findById(Long nodeId);
+
+    List<AxisRoadmapNode> findByAxisIdOrderByDisplayOrderAsc(Long axisId);
+
+    AxisRoadmapNode save(AxisRoadmapNode node);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AxisRoadmapNodeRepositoryAdapter implements AxisRoadmapNodeRepository {
+
+    private final AxisRoadmapNodeJpaRepository jpa;
+
+    @Override
+    public Optional<AxisRoadmapNode> findById(Long nodeId) {
+        return jpa.findById(nodeId);
+    }
+
+    @Override
+    public List<AxisRoadmapNode> findByAxisIdOrderByDisplayOrderAsc(Long axisId) {
+        return jpa.findByAxisIdOrderByDisplayOrderAsc(axisId);
+    }
+
+    @Override
+    public AxisRoadmapNode save(AxisRoadmapNode node) {
+        return jpa.save(node);
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/AxisRoadmapNodeController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/AxisRoadmapNodeController.java
@@ -1,0 +1,98 @@
+package com.example.thirdtool.LearningFacade.presentation;
+
+import com.example.thirdtool.LearningFacade.application.dto.AxisRoadmapNodeCommand;
+import com.example.thirdtool.LearningFacade.application.service.AxisRoadmapNodeCommandService;
+import com.example.thirdtool.LearningFacade.application.service.AxisRoadmapNodeQueryService;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisRoadmapNodeRequest;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisRoadmapNodeResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * Roadmap 노드 REST Controller (Story-LT-E3-S3-8, 이슈 #15).
+ *
+ * <p>SDD (`product-learning-tower.md` line 1434~1438) 명세 대로 top-level `/api/v1/axes/{axisId}/roadmap-nodes`
+ * 리소스로 노출. 기존 `PUT /api/v1/axes/{axisId}/roadmap {content}` 엔드포인트는 존재한 적 없어 410 Gone 처리 불필요.
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AxisRoadmapNodeController {
+
+    private final AxisRoadmapNodeCommandService commandService;
+    private final AxisRoadmapNodeQueryService queryService;
+
+    // POST /api/v1/axes/{axisId}/roadmap-nodes
+    @PostMapping("/axes/{axisId}/roadmap-nodes")
+    public ResponseEntity<AxisRoadmapNodeResponse.NodeDetail> add(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId,
+            @Valid @RequestBody AxisRoadmapNodeRequest.Add request
+    ) {
+        AxisRoadmapNodeResponse.NodeDetail detail = commandService.add(
+                new AxisRoadmapNodeCommand.Add(
+                        user.getId(), axisId, request.title(), request.rationale(), request.body()));
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/v1/roadmap-nodes/{nodeId}")
+                .buildAndExpand(detail.nodeId())
+                .toUri();
+        return ResponseEntity.created(location).body(detail);
+    }
+
+    // GET /api/v1/axes/{axisId}/roadmap-nodes
+    @GetMapping("/axes/{axisId}/roadmap-nodes")
+    public AxisRoadmapNodeResponse.NodeList list(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId
+    ) {
+        return queryService.list(user.getId(), axisId);
+    }
+
+    // PATCH /api/v1/roadmap-nodes/{nodeId}
+    @PatchMapping("/roadmap-nodes/{nodeId}")
+    public AxisRoadmapNodeResponse.NodeDetail update(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long nodeId,
+            @Valid @RequestBody AxisRoadmapNodeRequest.Update request
+    ) {
+        return commandService.update(new AxisRoadmapNodeCommand.Update(
+                user.getId(),
+                nodeId,
+                request.title(),
+                request.rationale(),
+                request.body(),
+                request.title() != null,
+                request.rationale() != null,
+                request.body() != null
+        ));
+    }
+
+    // DELETE /api/v1/roadmap-nodes/{nodeId}
+    @DeleteMapping("/roadmap-nodes/{nodeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void remove(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long nodeId
+    ) {
+        commandService.remove(new AxisRoadmapNodeCommand.Remove(user.getId(), nodeId));
+    }
+
+    // PUT /api/v1/axes/{axisId}/roadmap-nodes/order
+    @PutMapping("/axes/{axisId}/roadmap-nodes/order")
+    public AxisRoadmapNodeResponse.Reordered reorder(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId,
+            @Valid @RequestBody AxisRoadmapNodeRequest.Reorder request
+    ) {
+        return commandService.reorder(new AxisRoadmapNodeCommand.Reorder(
+                user.getId(), axisId, request.orderedNodeIds()));
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisRoadmapNodeRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisRoadmapNodeRequest.java
@@ -1,0 +1,47 @@
+package com.example.thirdtool.LearningFacade.presentation.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Roadmap 노드 Request DTO 셋트 (Story-LT-E3-S3-8).
+ * 검증 어노테이션은 여기서만 (도메인 검증은 별도 · 이중 방어).
+ */
+public final class AxisRoadmapNodeRequest {
+
+    private AxisRoadmapNodeRequest() {}
+
+    public record Add(
+            @NotNull
+            @Size(max = 200, message = "title은 200자 이내여야 합니다.")
+            String title,
+
+            @Size(max = 500, message = "rationale은 500자 이내여야 합니다.")
+            String rationale,
+
+            @NotNull
+            String body
+    ) {}
+
+    /**
+     * PATCH — 필드 미제공(null)과 blank 구분.
+     * rationale은 blank 전달 시 null로 정규화됨.
+     */
+    public record Update(
+            @Size(max = 200)
+            String title,
+
+            @Size(max = 500)
+            String rationale,
+
+            String body
+    ) {}
+
+    public record Reorder(
+            @NotEmpty
+            List<@NotNull Long> orderedNodeIds
+    ) {}
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisRoadmapNodeRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisRoadmapNodeRequest.java
@@ -1,5 +1,6 @@
 package com.example.thirdtool.LearningFacade.presentation.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -15,14 +16,14 @@ public final class AxisRoadmapNodeRequest {
     private AxisRoadmapNodeRequest() {}
 
     public record Add(
-            @NotNull
+            @NotBlank(message = "title은 비어 있을 수 없습니다.")
             @Size(max = 200, message = "title은 200자 이내여야 합니다.")
             String title,
 
             @Size(max = 500, message = "rationale은 500자 이내여야 합니다.")
             String rationale,
 
-            @NotNull
+            @NotBlank(message = "body는 비어 있을 수 없습니다.")
             String body
     ) {}
 

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisRoadmapNodeResponse.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisRoadmapNodeResponse.java
@@ -1,0 +1,49 @@
+package com.example.thirdtool.LearningFacade.presentation.dto;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Roadmap 노드 Response DTO (Story-LT-E3-S3-8).
+ */
+public final class AxisRoadmapNodeResponse {
+
+    private AxisRoadmapNodeResponse() {}
+
+    public record NodeDetail(
+            Long nodeId,
+            Long axisId,
+            int displayOrder,
+            String title,
+            String rationale,
+            String body,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        public static NodeDetail of(AxisRoadmapNode node) {
+            return new NodeDetail(
+                    node.getId(),
+                    node.getAxis() != null ? node.getAxis().getId() : null,
+                    node.getDisplayOrder(),
+                    node.getTitle(),
+                    node.getRationale(),
+                    node.getBody(),
+                    node.getCreatedAt(),
+                    node.getUpdatedAt());
+        }
+    }
+
+    public record NodeList(List<NodeDetail> nodes) {
+        public static NodeList of(List<AxisRoadmapNode> nodes) {
+            return new NodeList(nodes.stream().map(NodeDetail::of).toList());
+        }
+    }
+
+    public record Reordered(List<NodeDetail> nodes) {
+        public static Reordered of(List<AxisRoadmapNode> nodes) {
+            return new Reordered(nodes.stream().map(NodeDetail::of).toList());
+        }
+    }
+}

--- a/src/main/resources/db/migration/R20__rollback_axis_roadmap_node.sql
+++ b/src/main/resources/db/migration/R20__rollback_axis_roadmap_node.sql
@@ -1,0 +1,6 @@
+-- =============================================================
+-- R20__rollback_axis_roadmap_node.sql
+-- V20 롤백: axis_roadmap_node 테이블 제거.
+-- =============================================================
+
+DROP TABLE IF EXISTS axis_roadmap_node;

--- a/src/main/resources/db/migration/V20__axis_roadmap_node.sql
+++ b/src/main/resources/db/migration/V20__axis_roadmap_node.sql
@@ -24,7 +24,7 @@ CREATE TABLE axis_roadmap_node
     display_order  INT          NOT NULL,
     title          VARCHAR(200) NOT NULL,
     rationale      VARCHAR(500) NULL,
-    body           TEXT         NOT NULL,
+    body           MEDIUMTEXT   NOT NULL,       -- ASCII subtree 통짜 저장. TEXT 64KB 상한 회피 (up to 16MB)
     created_at     DATETIME(6)  NOT NULL,
     updated_at     DATETIME(6)  NOT NULL,
     deleted_at     DATETIME(6)  NULL,

--- a/src/main/resources/db/migration/V20__axis_roadmap_node.sql
+++ b/src/main/resources/db/migration/V20__axis_roadmap_node.sql
@@ -1,0 +1,41 @@
+-- =============================================================
+-- V20__axis_roadmap_node.sql
+-- LT Epic 3 Story 3-7: axis_roadmap_node 테이블 신설
+--
+-- Roadmap 챕터 노드 (이슈 #15, 2026-07-02 개정):
+--   · 이슈 #6의 axis_roadmap.content TEXT 통짜 방식 SUPERSEDED
+--   · 챕터 first-class Entity로 승격 → 챕터별 저장·조회·순서변경·재생성 가능
+--   · body에는 챕터 subtree(1-1~1-N + 리프 본문) ASCII 통짜 저장
+--
+-- 정책:
+--   · Soft Delete 적용 (deleted_at) — 노드 개별 복원 가능
+--   · display_order 도메인은 1-based, DB CHECK ≥ 1 (Layer가 ≥ 0인 것과 다름)
+--   · title/body는 필수. rationale은 선택
+--   · FK ON DELETE CASCADE — axis가 하드 삭제되면 노드도 함께
+--     (실제 axis는 soft delete가 표준. hard delete는 개발/테스트 초기화 상황용)
+--
+-- 이전(#6)의 axis_roadmap 테이블은 어느 릴리스에도 존재한 적 없어 아카이브 대상 없음.
+-- =============================================================
+
+CREATE TABLE axis_roadmap_node
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    axis_id        BIGINT       NOT NULL,
+    display_order  INT          NOT NULL,
+    title          VARCHAR(200) NOT NULL,
+    rationale      VARCHAR(500) NULL,
+    body           TEXT         NOT NULL,
+    created_at     DATETIME(6)  NOT NULL,
+    updated_at     DATETIME(6)  NOT NULL,
+    deleted_at     DATETIME(6)  NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_axis_roadmap_node_axis
+        FOREIGN KEY (axis_id) REFERENCES learning_axis (learning_axis_id) ON DELETE CASCADE,
+    CONSTRAINT chk_axis_roadmap_node_order
+        CHECK (display_order >= 1),
+    INDEX idx_axis_roadmap_node_axis_order (axis_id, display_order),
+    INDEX idx_axis_roadmap_node_deleted (deleted_at)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/AxisRoadmapNodeCommandServiceTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/AxisRoadmapNodeCommandServiceTest.java
@@ -1,0 +1,181 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.application.dto.AxisRoadmapNodeCommand;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.AxisRoadmapNodeRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisRoadmapNodeResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Story-LT-E3-S3-8 · AxisRoadmapNodeCommandService 단위 테스트.
+ * Repository는 Mock, 도메인은 실제 객체 (Classist).
+ */
+@DisplayName("AxisRoadmapNodeCommandService (Story-LT-E3-S3-8)")
+class AxisRoadmapNodeCommandServiceTest {
+
+    private LearningFacadeRepository facadeRepository;
+    private AxisRoadmapNodeRepository nodeRepository;
+    private AxisRoadmapNodeCommandService service;
+
+    private UserEntity user;
+    private LearningFacade facade;
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        facadeRepository = mock(LearningFacadeRepository.class);
+        nodeRepository = mock(AxisRoadmapNodeRepository.class);
+        service = new AxisRoadmapNodeCommandService(facadeRepository, nodeRepository);
+
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        facade = LearningFacade.create(user, "백엔드");
+        ReflectionTestUtils.setField(facade, "id", 50L);
+        axis = facade.addAxis("하네스 엔지니어링");
+        ReflectionTestUtils.setField(axis, "id", 10L);
+
+        when(facadeRepository.findByUserId(1L)).thenReturn(Optional.of(facade));
+        when(facadeRepository.save(facade)).thenAnswer(inv -> {
+            LearningFacade saved = inv.getArgument(0);
+            var nodes = saved.getAxes().get(0).getRoadmapNodes();
+            for (int i = 0; i < nodes.size(); i++) {
+                AxisRoadmapNode n = nodes.get(i);
+                if (n.getId() == null) ReflectionTestUtils.setField(n, "id", 500L + i);
+            }
+            return saved;
+        });
+    }
+
+    @Test
+    @DisplayName("[해피] add: 노드 저장 + Response 반환")
+    void add_savesAndReturns() {
+        AxisRoadmapNodeResponse.NodeDetail detail = service.add(
+                new AxisRoadmapNodeCommand.Add(1L, 10L, "1. 기초", "근거", "├── 1-1. ..."));
+
+        assertThat(detail.title()).isEqualTo("1. 기초");
+        assertThat(detail.rationale()).isEqualTo("근거");
+        assertThat(detail.displayOrder()).isEqualTo(1);
+        assertThat(detail.axisId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("[예외] add: 존재하지 않는 axisId → LEARNING_AXIS_NOT_FOUND")
+    void add_axisNotFound_throws() {
+        assertThatThrownBy(() -> service.add(
+                new AxisRoadmapNodeCommand.Add(1L, 999L, "제목", null, "body")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_AXIS_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[해피] update: title/rationale/body 부분 업데이트")
+    void update_partialFields() {
+        AxisRoadmapNode node = axis.addRoadmapNode("1. 기초", null, "b1");
+        ReflectionTestUtils.setField(node, "id", 500L);
+        ReflectionTestUtils.setField(node, "axis", axis);
+        when(nodeRepository.findById(500L)).thenReturn(Optional.of(node));
+
+        AxisRoadmapNodeResponse.NodeDetail updated = service.update(
+                new AxisRoadmapNodeCommand.Update(1L, 500L, "1. 새 제목", null, null,
+                        true, false, false));
+
+        assertThat(updated.title()).isEqualTo("1. 새 제목");
+        assertThat(updated.body()).isEqualTo("b1");
+    }
+
+    @Test
+    @DisplayName("[예외] update: 다른 유저의 노드는 ROADMAP_NODE_NOT_FOUND (정보 노출 방지)")
+    void update_otherUserNode_notFound() {
+        // 다른 facade의 axis에 붙은 노드
+        UserEntity otherUser = UserEntity.ofLocal("other", "pw", "닉2", "o@t.com");
+        ReflectionTestUtils.setField(otherUser, "id", 2L);
+        LearningFacade otherFacade = LearningFacade.create(otherUser, "다른컨셉");
+        ReflectionTestUtils.setField(otherFacade, "id", 99L);
+        LearningAxis otherAxis = otherFacade.addAxis("다른 축");
+        ReflectionTestUtils.setField(otherAxis, "id", 20L);
+        AxisRoadmapNode otherNode = otherAxis.addRoadmapNode("1. 다른", null, "b");
+        ReflectionTestUtils.setField(otherNode, "id", 600L);
+        ReflectionTestUtils.setField(otherNode, "axis", otherAxis);
+        when(nodeRepository.findById(600L)).thenReturn(Optional.of(otherNode));
+
+        assertThatThrownBy(() -> service.update(
+                new AxisRoadmapNodeCommand.Update(1L, 600L, "새 제목", null, null,
+                        true, false, false)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ROADMAP_NODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[해피] remove: 노드 소프트 삭제")
+    void remove_softDeletes() {
+        AxisRoadmapNode node = axis.addRoadmapNode("1. 기초", null, "b1");
+        ReflectionTestUtils.setField(node, "id", 500L);
+        ReflectionTestUtils.setField(node, "axis", axis);
+        when(nodeRepository.findById(500L)).thenReturn(Optional.of(node));
+
+        service.remove(new AxisRoadmapNodeCommand.Remove(1L, 500L));
+
+        assertThat(node.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[해피] reorder: 노드 순서 재부여")
+    void reorder_reassignsOrder() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫", null, "b1");
+        AxisRoadmapNode n2 = axis.addRoadmapNode("2. 둘", null, "b2");
+        AxisRoadmapNode n3 = axis.addRoadmapNode("3. 셋", null, "b3");
+        ReflectionTestUtils.setField(n1, "id", 500L);
+        ReflectionTestUtils.setField(n2, "id", 501L);
+        ReflectionTestUtils.setField(n3, "id", 502L);
+
+        AxisRoadmapNodeResponse.Reordered result = service.reorder(
+                new AxisRoadmapNodeCommand.Reorder(1L, 10L, List.of(502L, 500L, 501L)));
+
+        assertThat(n3.getDisplayOrder()).isEqualTo(1);
+        assertThat(n1.getDisplayOrder()).isEqualTo(2);
+        assertThat(n2.getDisplayOrder()).isEqualTo(3);
+        assertThat(result.nodes()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("[예외] reorder: id 집합 불일치 → ROADMAP_NODE_ORDER_MISMATCH")
+    void reorder_idMismatch_throws() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫", null, "b1");
+        ReflectionTestUtils.setField(n1, "id", 500L);
+
+        assertThatThrownBy(() -> service.reorder(
+                new AxisRoadmapNodeCommand.Reorder(1L, 10L, List.of(999L))))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ROADMAP_NODE_ORDER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("[예외] update: 없는 nodeId → ROADMAP_NODE_NOT_FOUND")
+    void update_nodeNotFound_throws() {
+        when(nodeRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update(
+                new AxisRoadmapNodeCommand.Update(1L, 999L, "새 제목", null, null,
+                        true, false, false)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ROADMAP_NODE_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisRoadmapNodeTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisRoadmapNodeTest.java
@@ -1,0 +1,133 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E3-S3-6 · AxisRoadmapNode 도메인 단위 테스트.
+ */
+@DisplayName("AxisRoadmapNode 도메인 단위 테스트 (Story-LT-E3-S3-6)")
+class AxisRoadmapNodeTest {
+
+    private static final String SAMPLE_TITLE = "1. 하네스 엔지니어링 기초";
+    private static final String SAMPLE_RATIONALE = "AI 에이전트 기본 프레임";
+    private static final String SAMPLE_BODY = "├── 1-1. 정의와 본질\n│       모델 + 하네스 — ...";
+
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        UserEntity user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        axis = facade.addAxis("하네스 엔지니어링");
+    }
+
+    @Test
+    @DisplayName("[해피] axis에 첫 노드 추가 시 displayOrder=1")
+    void addRoadmapNode_first_displayOrder1() {
+        AxisRoadmapNode node = axis.addRoadmapNode(SAMPLE_TITLE, SAMPLE_RATIONALE, SAMPLE_BODY);
+
+        assertThat(node.getDisplayOrder()).isEqualTo(1);
+        assertThat(node.getTitle()).isEqualTo(SAMPLE_TITLE);
+        assertThat(node.getRationale()).isEqualTo(SAMPLE_RATIONALE);
+        assertThat(node.getBody()).isEqualTo(SAMPLE_BODY);
+        assertThat(axis.getRoadmapNodes()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("[해피] 3번째 노드 추가 시 displayOrder=3")
+    void addRoadmapNode_third_displayOrder3() {
+        axis.addRoadmapNode("1. 첫 챕터", null, "body 1");
+        axis.addRoadmapNode("2. 둘째 챕터", null, "body 2");
+
+        AxisRoadmapNode third = axis.addRoadmapNode("3. 셋째 챕터", null, "body 3");
+
+        assertThat(third.getDisplayOrder()).isEqualTo(3);
+        assertThat(axis.getRoadmapNodes()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("[엣지] title trim + rationale blank → null 정규화")
+    void addRoadmapNode_normalize_trim_blankRationaleToNull() {
+        AxisRoadmapNode node = axis.addRoadmapNode("  1. 챕터  ", "   ", "  body  ");
+
+        assertThat(node.getTitle()).isEqualTo("1. 챕터");
+        assertThat(node.getRationale()).isNull();
+        assertThat(node.getBody()).isEqualTo("body");
+    }
+
+    @Test
+    @DisplayName("[예외] title blank이면 ROADMAP_NODE_TITLE_BLANK")
+    void addRoadmapNode_blankTitle_throws() {
+        assertThatThrownBy(() -> axis.addRoadmapNode("   ", null, SAMPLE_BODY))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROADMAP_NODE_TITLE_BLANK);
+    }
+
+    @Test
+    @DisplayName("[예외] body blank이면 ROADMAP_NODE_BODY_BLANK")
+    void addRoadmapNode_blankBody_throws() {
+        assertThatThrownBy(() -> axis.addRoadmapNode(SAMPLE_TITLE, null, "  "))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROADMAP_NODE_BODY_BLANK);
+    }
+
+    @Test
+    @DisplayName("[해피] updateTitle / updateRationale / updateBody 반영")
+    void updateFields() {
+        AxisRoadmapNode node = axis.addRoadmapNode(SAMPLE_TITLE, SAMPLE_RATIONALE, SAMPLE_BODY);
+
+        node.updateTitle("1. 새 챕터");
+        node.updateRationale("새 근거");
+        node.updateBody("새 body");
+
+        assertThat(node.getTitle()).isEqualTo("1. 새 챕터");
+        assertThat(node.getRationale()).isEqualTo("새 근거");
+        assertThat(node.getBody()).isEqualTo("새 body");
+    }
+
+    @Test
+    @DisplayName("[엣지] updateRationale에 blank 전달 시 null로 정규화")
+    void updateRationale_blank_normalizesToNull() {
+        AxisRoadmapNode node = axis.addRoadmapNode(SAMPLE_TITLE, SAMPLE_RATIONALE, SAMPLE_BODY);
+
+        node.updateRationale("   ");
+
+        assertThat(node.getRationale()).isNull();
+    }
+
+    @Test
+    @DisplayName("[엣지] softDelete 재호출은 no-op (멱등)")
+    void softDelete_idempotent() {
+        AxisRoadmapNode node = axis.addRoadmapNode(SAMPLE_TITLE, null, SAMPLE_BODY);
+
+        node.softDelete();
+        var firstDeletedAt = node.getDeletedAt();
+        node.softDelete();
+
+        assertThat(node.isDeleted()).isTrue();
+        assertThat(node.getDeletedAt()).isEqualTo(firstDeletedAt);
+    }
+
+    @Test
+    @DisplayName("[예외] title 200자 초과 시 INVALID_INPUT")
+    void addRoadmapNode_titleTooLong_throws() {
+        String tooLong = "x".repeat(AxisRoadmapNode.TITLE_MAX_LENGTH + 1);
+
+        assertThatThrownBy(() -> axis.addRoadmapNode(tooLong, null, SAMPLE_BODY))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxisRoadmapNodesTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxisRoadmapNodesTest.java
@@ -1,0 +1,137 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E3-S3-6 · LearningAxis.roadmapNodes 컬렉션 확장 검증.
+ * (id 부여가 필요한 reorder/find/remove 케이스는 ReflectionTestUtils로 id 주입 후 검증)
+ */
+@DisplayName("LearningAxis · roadmapNodes 컬렉션 (Story-LT-E3-S3-6)")
+class LearningAxisRoadmapNodesTest {
+
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        UserEntity user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        axis = facade.addAxis("하네스 엔지니어링");
+    }
+
+    @Test
+    @DisplayName("[해피] findRoadmapNode: id로 노드 조회")
+    void findRoadmapNode_by_id() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫 챕터", null, "body 1");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+
+        AxisRoadmapNode found = axis.findRoadmapNode(100L);
+
+        assertThat(found).isSameAs(n1);
+    }
+
+    @Test
+    @DisplayName("[예외] findRoadmapNode: 없는 id → ROADMAP_NODE_NOT_FOUND")
+    void findRoadmapNode_notFound_throws() {
+        assertThatThrownBy(() -> axis.findRoadmapNode(999L))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROADMAP_NODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[해피] reorderRoadmapNodes: id 순서대로 displayOrder 재부여")
+    void reorderRoadmapNodes_reassignsDisplayOrder() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫", null, "b1");
+        AxisRoadmapNode n2 = axis.addRoadmapNode("2. 둘", null, "b2");
+        AxisRoadmapNode n3 = axis.addRoadmapNode("3. 셋", null, "b3");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+        ReflectionTestUtils.setField(n2, "id", 200L);
+        ReflectionTestUtils.setField(n3, "id", 300L);
+
+        axis.reorderRoadmapNodes(List.of(300L, 100L, 200L));
+
+        assertThat(n3.getDisplayOrder()).isEqualTo(1);
+        assertThat(n1.getDisplayOrder()).isEqualTo(2);
+        assertThat(n2.getDisplayOrder()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("[예외] reorderRoadmapNodes: id 집합 불일치 → ROADMAP_NODE_ORDER_MISMATCH")
+    void reorderRoadmapNodes_idMismatch_throws() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫", null, "b1");
+        AxisRoadmapNode n2 = axis.addRoadmapNode("2. 둘", null, "b2");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+        ReflectionTestUtils.setField(n2, "id", 200L);
+
+        // 유령 id 999 포함
+        assertThatThrownBy(() -> axis.reorderRoadmapNodes(List.of(100L, 999L)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROADMAP_NODE_ORDER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("[예외] reorderRoadmapNodes: 사이즈 다름 → ROADMAP_NODE_ORDER_MISMATCH")
+    void reorderRoadmapNodes_sizeMismatch_throws() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫", null, "b1");
+        AxisRoadmapNode n2 = axis.addRoadmapNode("2. 둘", null, "b2");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+        ReflectionTestUtils.setField(n2, "id", 200L);
+
+        assertThatThrownBy(() -> axis.reorderRoadmapNodes(List.of(100L)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROADMAP_NODE_ORDER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("[예외] reorderRoadmapNodes: null 전달 → ROADMAP_NODE_ORDER_MISMATCH")
+    void reorderRoadmapNodes_null_throws() {
+        assertThatThrownBy(() -> axis.reorderRoadmapNodes(null))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROADMAP_NODE_ORDER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("[해피] removeRoadmapNode: 노드 소프트 삭제")
+    void removeRoadmapNode_softDeletes() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 첫", null, "b1");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+
+        axis.removeRoadmapNode(100L);
+
+        assertThat(n1.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[해피] getRoadmapNodes: unmodifiable 반환")
+    void getRoadmapNodes_isUnmodifiable() {
+        axis.addRoadmapNode("1. 첫", null, "b1");
+
+        List<AxisRoadmapNode> nodes = axis.getRoadmapNodes();
+
+        assertThatThrownBy(() -> nodes.add(null))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("[엣지] reorderRoadmapNodes: 빈 리스트 + 빈 컬렉션 → 정상")
+    void reorderRoadmapNodes_emptyList_noop() {
+        axis.reorderRoadmapNodes(List.of());
+        // 예외 발생 없으면 통과
+        assertThat(axis.getRoadmapNodes()).isEmpty();
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeRepositoryTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisRoadmapNodeRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisRoadmapNode;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-LT-E3-S3-8 · AxisRoadmapNode Repository Slice.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AxisRoadmapNodeRepositoryAdapter.class, QuerydslTestConfig.class})
+@DisplayName("AxisRoadmapNodeRepository slice (Story-LT-E3-S3-8)")
+class AxisRoadmapNodeRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    AxisRoadmapNodeRepositoryAdapter repository;
+
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        UserEntity user = UserEntity.ofLocal(
+                "tester-1", "encoded-pw", "닉네임-1", "tester1@example.com");
+        em.persist(user);
+
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        em.persist(facade);
+        axis = facade.addAxis("하네스 엔지니어링");
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("axisId로 조회하면 displayOrder 오름차순으로 반환")
+    void findByAxisIdOrderByDisplayOrderAsc() {
+        axis.addRoadmapNode("1. 기초", null, "├── 1-1. ...");
+        axis.addRoadmapNode("2. 심화", null, "├── 2-1. ...");
+        axis.addRoadmapNode("3. 실전", null, "├── 3-1. ...");
+        em.flush();
+        em.clear();
+
+        List<AxisRoadmapNode> result = repository.findByAxisIdOrderByDisplayOrderAsc(axis.getId());
+
+        assertThat(result)
+                .extracting(AxisRoadmapNode::getTitle)
+                .containsExactly("1. 기초", "2. 심화", "3. 실전");
+        assertThat(result)
+                .extracting(AxisRoadmapNode::getDisplayOrder)
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("softDelete된 노드는 @SQLRestriction으로 자동 제외")
+    void softDeleted_filteredOut() {
+        AxisRoadmapNode n1 = axis.addRoadmapNode("1. 기초", null, "b1");
+        AxisRoadmapNode n2 = axis.addRoadmapNode("2. 심화", null, "b2");
+        em.flush();
+        Long deletedId = n1.getId();
+        Long remainingId = n2.getId();
+
+        n1.softDelete();
+        em.flush();
+        em.clear();
+
+        List<AxisRoadmapNode> result = repository.findByAxisIdOrderByDisplayOrderAsc(axis.getId());
+        assertThat(result).extracting(AxisRoadmapNode::getId).containsExactly(remainingId);
+        assertThat(repository.findById(deletedId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("save 시 audit 자동 기록 (created_at + updated_at)")
+    void save_setsAuditColumns() {
+        AxisRoadmapNode node = axis.addRoadmapNode("1. 기초", "근거", "├── 1-1. ...");
+        em.flush();
+        em.clear();
+
+        AxisRoadmapNode found = repository.findById(node.getId()).orElseThrow();
+        assertThat(found.getCreatedAt()).isNotNull();
+        assertThat(found.getUpdatedAt()).isNotNull();
+        assertThat(found.getDeletedAt()).isNull();
+        assertThat(found.getRationale()).isEqualTo("근거");
+    }
+}


### PR DESCRIPTION
## 개요

M3 / 0.0.3v Epic PR#3. Roadmap을 axis당 content TEXT 통짜 저장 방식(이슈 #6)에서 **챕터 노드 first-class** 스키마로 승격한다 (이슈 #15). AI 초안이 챕터 단위로 저장·조회·순서변경·재생성 가능한 인프라 확립.

**SUPERSEDES**: 이슈 #6 (`axis_roadmap.content TEXT` 통짜 방식)

## 왜 / 설계 결정

- **트리 방대 문제**: 이슈 #6의 axis당 1건 통짜 저장은 사용자가 부분 수정 어렵고, AI 초안 소화 부담.
- **챕터 노드 first-class**: 챕터별 CRUD + 순서변경 자연스러움. Body는 여전히 ASCII 통짜 (`├── 1-1. 정의와 본질\n...`).
- **body는 MEDIUMTEXT**: Reviewer 조치 · TEXT 64KB 상한이 사용자 예시 하네스 로드맵 subtree에 근접해 MEDIUMTEXT(16MB)로 상향.
- **Flyway V버전 재할당**: 밀스톤 문서의 V18 계획은 V16~V19가 이미 사용 중이라 **V20**으로 재할당 (사용자 승인).
- **axis_roadmap 아카이브 스킵**: `axis_roadmap` 테이블이 프로덕션 배포된 적 없어 RENAME 아카이브 불필요.

## 작업 내용

### Story-LT-E3-S3-6 (도메인)
- `feat(learning-facade)`: `AxisRoadmapNode` Entity 신설 — title(VARCHAR 200) · rationale(VARCHAR 500 nullable) · body(MEDIUMTEXT) · display_order(1-based) · audit + soft delete
- `feat(learning-facade)`: `LearningAxis` 확장 — `addRoadmapNode`, `reorderRoadmapNodes`, `removeRoadmapNode`, `findRoadmapNode`, `getRoadmapNodes(unmodifiable)`
- `feat(common)`: ErrorCode 4종 신설 — `ROADMAP_NODE_NOT_FOUND`(404) · `ROADMAP_NODE_TITLE_BLANK`(400) · `ROADMAP_NODE_BODY_BLANK`(400) · `ROADMAP_NODE_ORDER_MISMATCH`(400)
- `test(learning-facade)`: 도메인 단위 테스트 18건 (해피/엣지/예외)

### Story-LT-E3-S3-7 (Flyway)
- `feat(learning-facade)`: `V20__axis_roadmap_node.sql` — CASCADE FK · CHECK ≥ 1 · 인덱스 2종 (커버링 + soft delete filter)
- `R20__` 롤백 스크립트
- Repository Port / JpaRepository / Adapter 3파일
- Repository Slice 테스트 3건 (정렬 · @SQLRestriction 필터 · audit 자동 기록)

### Story-LT-E3-S3-8 (API)
- `feat(learning-facade)`: 5개 REST 엔드포인트 (`/api/v1` prefix)
  - `POST /axes/{axisId}/roadmap-nodes` → 201 + Location header
  - `GET /axes/{axisId}/roadmap-nodes` → 200 (display_order ASC)
  - `PATCH /roadmap-nodes/{nodeId}` → 200 (부분 필드 업데이트)
  - `DELETE /roadmap-nodes/{nodeId}` → 204 (soft delete)
  - `PUT /axes/{axisId}/roadmap-nodes/order` → 200
- Command/Request/Response record + Application Service 2종 (Command + Query)
- 소유권 검증 — facade → axis → node 체인 (다른 유저 노드는 NOT_FOUND 통일)
- Application Service 단위 테스트 8건

### Reviewer 5관점 조치 (별도 커밋)
- Request DTO `@NotBlank` on title/body — 이중 방어 강화 (API Reviewer Major)
- body 컬럼 TEXT → MEDIUMTEXT — 상한 확보 (Sceptical Reviewer Major)

## 변경 유형
- [x] feat  - [x] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.*"` → **BUILD SUCCESSFUL**
- 전체 스위트 `./gradlew test` → **BUILD SUCCESSFUL**
- 신규 테스트 29건 (도메인 18 · Repository Slice 3 · Application Service 8)

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] BC 간 의존 방향 위반 없음 (LearningFacade BC 내부만 + Common/ErrorCode 확장)
- [x] Reviewer 5관점 세션 완료 · 즉시 조치 2건 별도 커밋
- [x] 대상 브랜치 `develop` 확인

## 관련 이슈
- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-learning-tower.md` Epic 3 재정의 판 (line 1042~1603)
- Milestone: `workflow/task/milestones/version/0.0.3v/milestone.md` §Epic PR #3
- SUPERSEDES: `workflow/task/fix/brainstorming/version/0.0.2v/issue-06-roadmap-selections-dualaxis.md`
- 이관 이슈: `issue-15-roadmap-node-model.md`

## 남은 지적 (별도 브랜치 처리)
- PATCH의 JSON `null` vs 필드 부재 구분 (rationale 완전 삭제 경로) — v2 JsonNullable 도입 검토
- Update partial 필드별 3 시나리오 테스트 보강
- Reorder 1개/2개 노드 경계값 테스트 보강