### PR TITLE
feat(learning-facade): Selection 컨테이너/노드 스키마·도메인·API [Story-LT-E3-S3-9~11]

### DIFF
--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -112,6 +112,19 @@ public enum ErrorCode {
     ROADMAP_NODE_BODY_BLANK("RN003",      "Roadmap 노드 body는 비어 있을 수 없습니다.",                     HttpStatus.BAD_REQUEST),
     ROADMAP_NODE_ORDER_MISMATCH("RN004",  "전달된 Roadmap 노드 id 목록이 현재 노드 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
+    // ─── AxisSelection (Story-LT-E3-S3-9~S3-11, 이슈 #16 · 이슈 #11 계승) ─
+    // 컨테이너 정책: name UNIQUE per axis, created_at DESC, hard delete.
+    AXIS_SELECTION_NOT_FOUND("AS001",           "Selection을 찾을 수 없습니다.",                                    HttpStatus.NOT_FOUND),
+    AXIS_SELECTION_NAME_BLANK("AS002",          "Selection 이름은 비어 있을 수 없습니다.",                          HttpStatus.BAD_REQUEST),
+    AXIS_SELECTION_NAME_ALREADY_EXISTS("AS003", "동일한 이름의 Selection이 이미 존재합니다.",                        HttpStatus.CONFLICT),
+
+    // ─── AxisSelectionNode (Story-LT-E3-S3-9~S3-11, 이슈 #16) ─
+    // 컨테이너 hard delete 정책 계승 — 자식 노드 soft delete 없음.
+    SELECTION_NODE_NOT_FOUND("SN001",       "Selection 노드를 찾을 수 없습니다.",                              HttpStatus.NOT_FOUND),
+    SELECTION_NODE_TITLE_BLANK("SN002",     "Selection 노드 title은 비어 있을 수 없습니다.",                    HttpStatus.BAD_REQUEST),
+    SELECTION_NODE_BODY_BLANK("SN003",      "Selection 노드 body는 비어 있을 수 없습니다.",                     HttpStatus.BAD_REQUEST),
+    SELECTION_NODE_ORDER_MISMATCH("SN004",  "전달된 Selection 노드 id 목록이 현재 노드 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+
     // ─── LearningMaterial ─────────────────────────────────
     LEARNING_MATERIAL_NOT_FOUND("LM001",                          "학습 자료를 찾을 수 없습니다.",                                  HttpStatus.NOT_FOUND),
     LEARNING_MATERIAL_PROFICIENCY_UNRATED_NOT_ALLOWED("LM002",    "숙련도는 UNRATED로 되돌릴 수 없습니다.",                         HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/dto/AxisSelectionCommand.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/dto/AxisSelectionCommand.java
@@ -1,0 +1,40 @@
+package com.example.thirdtool.LearningFacade.application.dto;
+
+import java.util.List;
+
+/**
+ * Selection 컨테이너 + 자식 노드 Command DTO (Story-LT-E3-S3-11).
+ */
+public final class AxisSelectionCommand {
+
+    private AxisSelectionCommand() {}
+
+    // ─── 컨테이너 ───────────────────────────
+    public record AddSelection(Long userId, Long axisId, String name) {}
+    public record RenameSelection(Long userId, Long selectionId, String name) {}
+    public record RemoveSelection(Long userId, Long selectionId) {}
+
+    // ─── 자식 노드 ──────────────────────────
+    public record AddNode(
+            Long userId,
+            Long selectionId,
+            String title,
+            String rationale,
+            String body
+    ) {}
+
+    public record UpdateNode(
+            Long userId,
+            Long nodeId,
+            String title,
+            String rationale,
+            String body,
+            boolean titlePresent,
+            boolean rationalePresent,
+            boolean bodyPresent
+    ) {}
+
+    public record RemoveNode(Long userId, Long nodeId) {}
+
+    public record ReorderNodes(Long userId, Long selectionId, List<Long> orderedNodeIds) {}
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/dto/AxisSelectionCommand.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/dto/AxisSelectionCommand.java
@@ -12,7 +12,7 @@ public final class AxisSelectionCommand {
     // ─── 컨테이너 ───────────────────────────
     public record AddSelection(Long userId, Long axisId, String name) {}
     public record RenameSelection(Long userId, Long selectionId, String name) {}
-    public record RemoveSelection(Long userId, Long selectionId) {}
+    public record RemoveSelection(Long userId, Long axisId, Long selectionId) {}
 
     // ─── 자식 노드 ──────────────────────────
     public record AddNode(

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandService.java
@@ -1,0 +1,157 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.application.dto.AxisSelectionCommand;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelectionNode;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.AxisSelectionRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisSelectionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Selection 컨테이너 + 자식 노드 Command Application Service (Story-LT-E3-S3-11).
+ *
+ * <p>소유권 검증: facade → axis → selection → node 체인.
+ * 컨테이너 정책은 이슈 #11 계승 (name UNIQUE, created_at DESC, hard delete).
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AxisSelectionCommandService {
+
+    private final LearningFacadeRepository facadeRepository;
+    private final AxisSelectionRepository selectionRepository;
+
+    // ─── 컨테이너 CRUD ─────────────────────────────
+
+    public AxisSelectionResponse.SelectionDetail addSelection(AxisSelectionCommand.AddSelection command) {
+        LearningFacade facade = loadFacade(command.userId());
+        LearningAxis axis = findAxis(facade, command.axisId());
+
+        AxisSelection selection = axis.addSelection(command.name());
+        facadeRepository.save(facade);
+
+        if (selection.getId() == null) {
+            throw new IllegalStateException(
+                    "AxisSelection id가 cascade save 후에도 null입니다. JPA 설정 회귀 가능성.");
+        }
+        return AxisSelectionResponse.SelectionDetail.of(selection);
+    }
+
+    public AxisSelectionResponse.SelectionDetail renameSelection(AxisSelectionCommand.RenameSelection command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisSelection selection = loadSelectionOwnedBy(facade, command.selectionId());
+
+        selection.getAxis().renameSelection(command.selectionId(), command.name());
+        facadeRepository.save(facade);
+        return AxisSelectionResponse.SelectionDetail.of(selection);
+    }
+
+    public void removeSelection(AxisSelectionCommand.RemoveSelection command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisSelection selection = loadSelectionOwnedBy(facade, command.selectionId());
+
+        selection.getAxis().removeSelection(command.selectionId());
+        facadeRepository.save(facade);
+    }
+
+    // ─── 자식 노드 CRUD ────────────────────────────
+
+    public AxisSelectionResponse.NodeDetail addNode(AxisSelectionCommand.AddNode command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisSelection selection = loadSelectionOwnedBy(facade, command.selectionId());
+
+        AxisSelectionNode node = selection.addNode(command.title(), command.rationale(), command.body());
+        facadeRepository.save(facade);
+
+        if (node.getId() == null) {
+            throw new IllegalStateException(
+                    "AxisSelectionNode id가 cascade save 후에도 null입니다.");
+        }
+        return AxisSelectionResponse.NodeDetail.of(node);
+    }
+
+    public AxisSelectionResponse.NodeDetail updateNode(AxisSelectionCommand.UpdateNode command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisSelectionNode node = loadNodeOwnedBy(facade, command.nodeId());
+
+        if (command.titlePresent()) {
+            node.updateTitle(command.title());
+        }
+        if (command.rationalePresent()) {
+            node.updateRationale(command.rationale());
+        }
+        if (command.bodyPresent()) {
+            node.updateBody(command.body());
+        }
+        return AxisSelectionResponse.NodeDetail.of(node);
+    }
+
+    public void removeNode(AxisSelectionCommand.RemoveNode command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisSelectionNode node = loadNodeOwnedBy(facade, command.nodeId());
+
+        node.getSelection().removeNode(command.nodeId());
+        facadeRepository.save(facade);
+    }
+
+    public AxisSelectionResponse.Reordered reorderNodes(AxisSelectionCommand.ReorderNodes command) {
+        LearningFacade facade = loadFacade(command.userId());
+        AxisSelection selection = loadSelectionOwnedBy(facade, command.selectionId());
+
+        selection.reorderNodes(command.orderedNodeIds());
+        facadeRepository.save(facade);
+        return AxisSelectionResponse.Reordered.of(selection.getNodes());
+    }
+
+    // ─── helpers ─────────────────────────────────
+
+    private LearningFacade loadFacade(Long userId) {
+        return facadeRepository.findByUserId(userId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND));
+    }
+
+    private LearningAxis findAxis(LearningFacade facade, Long axisId) {
+        return facade.getAxes().stream()
+                .filter(a -> a.getId() != null && a.getId().equals(axisId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_NOT_FOUND));
+    }
+
+    /**
+     * Selection 컨테이너 로드 + 소유권 검증. 다른 유저 소유 시 NOT_FOUND 통일.
+     */
+    private AxisSelection loadSelectionOwnedBy(LearningFacade facade, Long selectionId) {
+        AxisSelection selection = selectionRepository.findById(selectionId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NOT_FOUND));
+
+        LearningAxis axis = selection.getAxis();
+        if (axis == null || axis.getFacade() == null
+                || !axis.getFacade().getId().equals(facade.getId())) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NOT_FOUND);
+        }
+        return selection;
+    }
+
+    private AxisSelectionNode loadNodeOwnedBy(LearningFacade facade, Long nodeId) {
+        // 노드는 Selection 컨테이너를 통해서만 로드. Repository 별도 조회 대신 Selection에서 find.
+        // 다만 nodeId만으로 접근하는 API가 존재하므로 별도 조회 필요.
+        // 여기서는 nodeId → selection → axis → facade 체인 검증 목적.
+        for (LearningAxis axis : facade.getAxes()) {
+            for (AxisSelection s : axis.getSelections()) {
+                for (AxisSelectionNode n : s.getNodes()) {
+                    if (n.getId() != null && n.getId().equals(nodeId)) {
+                        return n;
+                    }
+                }
+            }
+        }
+        throw LearningFacadeDomainException.of(ErrorCode.SELECTION_NODE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandService.java
@@ -57,6 +57,11 @@ public class AxisSelectionCommandService {
         LearningFacade facade = loadFacade(command.userId());
         AxisSelection selection = loadSelectionOwnedBy(facade, command.selectionId());
 
+        // Path axisId와 실제 selection.axis.id 정합 검증 — 소유권 노출 방지 위해 NOT_FOUND로 통일.
+        if (!selection.getAxis().getId().equals(command.axisId())) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NOT_FOUND);
+        }
+
         selection.getAxis().removeSelection(command.selectionId());
         facadeRepository.save(facade);
     }

--- a/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionQueryService.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionQueryService.java
@@ -1,0 +1,59 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.AxisSelectionRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisSelectionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Selection 컨테이너 + 자식 노드 Query Application Service (Story-LT-E3-S3-11).
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AxisSelectionQueryService {
+
+    private final LearningFacadeRepository facadeRepository;
+    private final AxisSelectionRepository selectionRepository;
+
+    /**
+     * axis 하위 활성 Selection 컨테이너 리스트 (created_at DESC).
+     */
+    public AxisSelectionResponse.SelectionList listSelections(Long userId, Long axisId) {
+        LearningFacade facade = facadeRepository.findByUserId(userId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND));
+        LearningAxis axis = facade.getAxes().stream()
+                .filter(a -> a.getId() != null && a.getId().equals(axisId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_AXIS_NOT_FOUND));
+
+        return AxisSelectionResponse.SelectionList.of(
+                selectionRepository.findByAxisIdOrderByCreatedAtDesc(axis.getId()));
+    }
+
+    /**
+     * Selection 컨테이너 하위 자식 노드 리스트 (display_order ASC).
+     */
+    public AxisSelectionResponse.NodeList listNodes(Long userId, Long selectionId) {
+        LearningFacade facade = facadeRepository.findByUserId(userId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.LEARNING_FACADE_NOT_FOUND));
+        AxisSelection selection = selectionRepository.findById(selectionId)
+                .orElseThrow(() -> LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NOT_FOUND));
+
+        // 소유권 검증
+        LearningAxis axis = selection.getAxis();
+        if (axis == null || axis.getFacade() == null
+                || !axis.getFacade().getId().equals(facade.getId())) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NOT_FOUND);
+        }
+
+        return AxisSelectionResponse.NodeList.of(selection.getNodes());
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelection.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelection.java
@@ -1,0 +1,172 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Selection 컨테이너 (Story-LT-E3-S3-9, 이슈 #16 · 이슈 #11 정책 계승).
+ *
+ * <p>이슈 #11 정책 (컨테이너 레벨):
+ * <ul>
+ *   <li>name UNIQUE per axis (활성 컨테이너만)</li>
+ *   <li>created_at DESC 정렬 (조회는 최신 우선)</li>
+ *   <li>hard delete (자식 노드 CASCADE)</li>
+ *   <li>soft delete 없음</li>
+ * </ul>
+ *
+ * <p>이슈 #16 신설 (자식 노드):
+ * <ul>
+ *   <li>{@link AxisSelectionNode} — 챕터 first-class</li>
+ *   <li>컨테이너 hard delete 시 orphanRemoval로 자식 하드 삭제</li>
+ * </ul>
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "axis_selection",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_axis_selection_axis_name",
+                columnNames = {"axis_id", "name"}
+        )
+)
+public class AxisSelection {
+
+    public static final int NAME_MAX_LENGTH = 100;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "axis_id", nullable = false, updatable = false)
+    private LearningAxis axis;
+
+    @Column(name = "name", nullable = false, length = NAME_MAX_LENGTH)
+    private String name;
+
+    @OneToMany(
+            mappedBy      = "selection",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("displayOrder ASC")
+    private final List<AxisSelectionNode> nodes = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private AxisSelection(LearningAxis axis, String name) {
+        this.axis = axis;
+        this.name = name;
+    }
+
+    /**
+     * 정적 팩토리. {@link LearningAxis#addSelection}에서만 호출된다.
+     */
+    static AxisSelection create(LearningAxis axis, String name) {
+        if (axis == null) {
+            throw LearningFacadeDomainException.of(ErrorCode.INVALID_INPUT, "axis는 null일 수 없습니다.");
+        }
+        return new AxisSelection(axis, validateAndTrimName(name));
+    }
+
+    /**
+     * 컨테이너 이름 in-place update. 이슈 #11 정책 계승.
+     */
+    public void updateName(String newName) {
+        this.name = validateAndTrimName(newName);
+    }
+
+    // ─── 자식 노드 도메인 API (Story-LT-E3-S3-9) ─────────
+
+    public AxisSelectionNode addNode(String title, String rationale, String body) {
+        int nextOrder = nodes.size() + 1;
+        AxisSelectionNode node = AxisSelectionNode.create(this, nextOrder, title, rationale, body);
+        nodes.add(node);
+        return node;
+    }
+
+    public void reorderNodes(List<Long> orderedNodeIds) {
+        validateNodeReorderIds(orderedNodeIds);
+        IntStream.range(0, orderedNodeIds.size()).forEach(i -> {
+            AxisSelectionNode node = findNode(orderedNodeIds.get(i));
+            node.updateDisplayOrder(i + 1);
+        });
+    }
+
+    /**
+     * 노드 hard delete (컨테이너 정책 계승 — soft delete 없음).
+     * {@code orphanRemoval=true}로 컬렉션에서 제거 시 자동 DELETE.
+     */
+    public void removeNode(Long nodeId) {
+        AxisSelectionNode target = findNode(nodeId);
+        nodes.remove(target);
+    }
+
+    public AxisSelectionNode findNode(Long nodeId) {
+        return nodes.stream()
+                .filter(n -> n.getId() != null && n.getId().equals(nodeId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(
+                        ErrorCode.SELECTION_NODE_NOT_FOUND,
+                        "nodeId=" + nodeId));
+    }
+
+    public List<AxisSelectionNode> getNodes() {
+        return Collections.unmodifiableList(nodes);
+    }
+
+    private void validateNodeReorderIds(List<Long> orderedNodeIds) {
+        if (orderedNodeIds == null) {
+            throw LearningFacadeDomainException.of(ErrorCode.SELECTION_NODE_ORDER_MISMATCH);
+        }
+        Set<Long> currentIds = nodes.stream()
+                .map(AxisSelectionNode::getId)
+                .collect(Collectors.toSet());
+
+        if (orderedNodeIds.size() != currentIds.size()) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.SELECTION_NODE_ORDER_MISMATCH,
+                    "전달된 노드 id 수(" + orderedNodeIds.size()
+                            + ")가 현재 노드 수(" + currentIds.size() + ")와 다릅니다.");
+        }
+
+        Set<Long> incomingIds = new HashSet<>(orderedNodeIds);
+        if (!currentIds.equals(incomingIds)) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.SELECTION_NODE_ORDER_MISMATCH,
+                    "전달된 노드 id 목록이 현재 노드 id 집합과 일치하지 않습니다.");
+        }
+    }
+
+    private static String validateAndTrimName(String name) {
+        if (name == null || name.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NAME_BLANK);
+        }
+        String trimmed = name.trim();
+        if (trimmed.length() > NAME_MAX_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "Selection 이름은 " + NAME_MAX_LENGTH + "자 이내여야 합니다. length=" + trimmed.length());
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelectionNode.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelectionNode.java
@@ -28,6 +28,8 @@ public class AxisSelectionNode {
 
     public static final int TITLE_MAX_LENGTH = 200;
     public static final int RATIONALE_MAX_LENGTH = 500;
+    // MEDIUMTEXT 상한 근사치 (16MB). 실질 사용자 입력은 훨씬 작지만 조기 감지 용.
+    public static final int BODY_MAX_LENGTH = 65_535;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -122,7 +124,13 @@ public class AxisSelectionNode {
         if (body == null || body.isBlank()) {
             throw LearningFacadeDomainException.of(ErrorCode.SELECTION_NODE_BODY_BLANK);
         }
-        return body.trim();
+        String trimmed = body.trim();
+        if (trimmed.length() > BODY_MAX_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "body는 " + BODY_MAX_LENGTH + "자 이내여야 합니다. length=" + trimmed.length());
+        }
+        return trimmed;
     }
 
     private static String normalizeRationale(String rationale) {

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelectionNode.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelectionNode.java
@@ -1,0 +1,140 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Selection 챕터 노드 (Story-LT-E3-S3-9, 이슈 #16).
+ *
+ * <p>{@link AxisSelection} 컨테이너 아래의 자식 Entity. 컨테이너 정책은 이슈 #11 계승
+ * (name UNIQUE, created_at DESC, hard delete). 노드 자체는 soft delete 없음 —
+ * 컨테이너 hard delete 시 자식 노드 CASCADE.
+ *
+ * <p>body에 챕터 subtree (`├── 1-1. 정의와 본질\n...` 형태 ASCII 통짜) 저장.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "axis_selection_node")
+public class AxisSelectionNode {
+
+    public static final int TITLE_MAX_LENGTH = 200;
+    public static final int RATIONALE_MAX_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "selection_id", nullable = false, updatable = false)
+    private AxisSelection selection;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    @Column(name = "title", nullable = false, length = TITLE_MAX_LENGTH)
+    private String title;
+
+    @Column(name = "rationale", length = RATIONALE_MAX_LENGTH)
+    private String rationale;
+
+    @Column(name = "body", nullable = false, columnDefinition = "MEDIUMTEXT")
+    private String body;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    private AxisSelectionNode(AxisSelection selection, int displayOrder, String title, String rationale, String body) {
+        this.selection = selection;
+        this.displayOrder = displayOrder;
+        this.title = title;
+        this.rationale = rationale;
+        this.body = body;
+    }
+
+    /**
+     * 정적 팩토리. {@link AxisSelection#addNode}에서만 호출된다.
+     */
+    static AxisSelectionNode create(AxisSelection selection, int displayOrder, String title, String rationale, String body) {
+        if (selection == null) {
+            throw LearningFacadeDomainException.of(ErrorCode.INVALID_INPUT, "selection은 null일 수 없습니다.");
+        }
+        if (displayOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. displayOrder=" + displayOrder);
+        }
+        String normalizedTitle = validateAndTrimTitle(title);
+        String normalizedBody = validateAndTrimBody(body);
+        String normalizedRationale = normalizeRationale(rationale);
+        return new AxisSelectionNode(selection, displayOrder, normalizedTitle, normalizedRationale, normalizedBody);
+    }
+
+    public void updateTitle(String newTitle) {
+        this.title = validateAndTrimTitle(newTitle);
+    }
+
+    public void updateRationale(String newRationale) {
+        this.rationale = normalizeRationale(newRationale);
+    }
+
+    public void updateBody(String newBody) {
+        this.body = validateAndTrimBody(newBody);
+    }
+
+    void updateDisplayOrder(int newOrder) {
+        if (newOrder < 1) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "displayOrder는 1 이상이어야 합니다. newOrder=" + newOrder);
+        }
+        this.displayOrder = newOrder;
+    }
+
+    private static String validateAndTrimTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.SELECTION_NODE_TITLE_BLANK);
+        }
+        String trimmed = title.trim();
+        if (trimmed.length() > TITLE_MAX_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "title은 " + TITLE_MAX_LENGTH + "자 이내여야 합니다. length=" + trimmed.length());
+        }
+        return trimmed;
+    }
+
+    private static String validateAndTrimBody(String body) {
+        if (body == null || body.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.SELECTION_NODE_BODY_BLANK);
+        }
+        return body.trim();
+    }
+
+    private static String normalizeRationale(String rationale) {
+        if (rationale == null || rationale.isBlank()) {
+            return null;
+        }
+        String trimmed = rationale.trim();
+        if (trimmed.length() > RATIONALE_MAX_LENGTH) {
+            throw LearningFacadeDomainException.of(
+                    ErrorCode.INVALID_INPUT,
+                    "rationale은 " + RATIONALE_MAX_LENGTH + "자 이내여야 합니다. length=" + trimmed.length());
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -94,6 +94,20 @@ public class LearningAxis {
     @OrderBy("displayOrder ASC")
     private final List<AxisRoadmapNode> roadmapNodes = new ArrayList<>();
 
+    /**
+     * Selection 컨테이너 (Story-LT-E3-S3-9, 이슈 #16 · 이슈 #11 정책 계승).
+     * 컨테이너 정책: name UNIQUE per axis, created_at DESC 정렬, hard delete.
+     * {@code orphanRemoval=true} — 컨테이너 컬렉션에서 제거 시 hard delete.
+     */
+    @OneToMany(
+            mappedBy      = "axis",
+            cascade       = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch         = FetchType.LAZY
+    )
+    @OrderBy("createdAt DESC")
+    private final List<AxisSelection> selections = new ArrayList<>();
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -393,5 +407,69 @@ public class LearningAxis {
                     ErrorCode.ROADMAP_NODE_ORDER_MISMATCH,
                     "전달된 노드 id 목록이 현재 노드 id 집합과 일치하지 않습니다.");
         }
+    }
+
+    // ─── Selection 컨테이너 도메인 API (Story-LT-E3-S3-9, 이슈 #16) ─────────
+    //
+    // 이슈 #11 정책 계승:
+    //   · name UNIQUE per axis (활성 컨테이너)
+    //   · created_at DESC 정렬 (@OrderBy로 컬렉션 로딩 시 자동)
+    //   · hard delete (removeSelection 시 즉시 삭제)
+    //
+    // 자식 노드 CRUD는 {@link AxisSelection#addNode/reorderNodes/removeNode}가 직접 담당.
+
+    /**
+     * Selection 컨테이너 추가. 동일 이름 중복 시 예외.
+     */
+    public AxisSelection addSelection(String name) {
+        String trimmed = name == null ? null : name.trim();
+        boolean duplicate = selections.stream()
+                .anyMatch(s -> s.getName().equals(trimmed));
+        if (duplicate) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NAME_ALREADY_EXISTS);
+        }
+        AxisSelection selection = AxisSelection.create(this, name);
+        selections.add(selection);
+        return selection;
+    }
+
+    /**
+     * Selection 컨테이너 이름 변경 (in-place, 이슈 #11 계승).
+     * 다른 활성 컨테이너와 중복 시 예외.
+     */
+    public void renameSelection(Long selectionId, String newName) {
+        AxisSelection target = findSelection(selectionId);
+        String trimmed = newName == null ? null : newName.trim();
+        boolean duplicate = selections.stream()
+                .filter(s -> !s.getId().equals(selectionId))
+                .anyMatch(s -> s.getName().equals(trimmed));
+        if (duplicate) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NAME_ALREADY_EXISTS);
+        }
+        target.updateName(newName);
+    }
+
+    /**
+     * Selection 컨테이너 hard delete. orphanRemoval=true로 자식 노드 CASCADE 삭제.
+     */
+    public void removeSelection(Long selectionId) {
+        AxisSelection target = findSelection(selectionId);
+        selections.remove(target);
+    }
+
+    public AxisSelection findSelection(Long selectionId) {
+        return selections.stream()
+                .filter(s -> s.getId() != null && s.getId().equals(selectionId))
+                .findFirst()
+                .orElseThrow(() -> LearningFacadeDomainException.of(
+                        ErrorCode.AXIS_SELECTION_NOT_FOUND,
+                        "selectionId=" + selectionId));
+    }
+
+    /**
+     * 활성 Selection 컨테이너 목록 (created_at DESC).
+     */
+    public List<AxisSelection> getSelections() {
+        return Collections.unmodifiableList(selections);
     }
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningAxis.java
@@ -420,15 +420,22 @@ public class LearningAxis {
 
     /**
      * Selection 컨테이너 추가. 동일 이름 중복 시 예외.
+     *
+     * <p>이슈 #11 정책 계승: name UNIQUE per axis (활성 컨테이너 대상).
+     * name blank 검증은 {@link AxisSelection#create}에서 최종 담당하지만, 중복 감지 정확도를
+     * 위해 여기서 미리 trim 한 상태로 비교한다.
      */
     public AxisSelection addSelection(String name) {
-        String trimmed = name == null ? null : name.trim();
+        if (name == null || name.isBlank()) {
+            throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NAME_BLANK);
+        }
+        String trimmed = name.trim();
         boolean duplicate = selections.stream()
                 .anyMatch(s -> s.getName().equals(trimmed));
         if (duplicate) {
             throw LearningFacadeDomainException.of(ErrorCode.AXIS_SELECTION_NAME_ALREADY_EXISTS);
         }
-        AxisSelection selection = AxisSelection.create(this, name);
+        AxisSelection selection = AxisSelection.create(this, trimmed);
         selections.add(selection);
         return selection;
     }

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionJpaRepository.java
@@ -1,0 +1,11 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AxisSelectionJpaRepository extends JpaRepository<AxisSelection, Long> {
+
+    List<AxisSelection> findByAxisIdOrderByCreatedAtDesc(Long axisId);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionRepository.java
@@ -1,0 +1,18 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Selection 컨테이너 Repository Port (Story-LT-E3-S3-11).
+ */
+public interface AxisSelectionRepository {
+
+    Optional<AxisSelection> findById(Long selectionId);
+
+    List<AxisSelection> findByAxisIdOrderByCreatedAtDesc(Long axisId);
+
+    AxisSelection save(AxisSelection selection);
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AxisSelectionRepositoryAdapter implements AxisSelectionRepository {
+
+    private final AxisSelectionJpaRepository jpa;
+
+    @Override
+    public Optional<AxisSelection> findById(Long selectionId) {
+        return jpa.findById(selectionId);
+    }
+
+    @Override
+    public List<AxisSelection> findByAxisIdOrderByCreatedAtDesc(Long axisId) {
+        return jpa.findByAxisIdOrderByCreatedAtDesc(axisId);
+    }
+
+    @Override
+    public AxisSelection save(AxisSelection selection) {
+        return jpa.save(selection);
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/AxisSelectionController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/AxisSelectionController.java
@@ -1,0 +1,149 @@
+package com.example.thirdtool.LearningFacade.presentation;
+
+import com.example.thirdtool.LearningFacade.application.dto.AxisSelectionCommand;
+import com.example.thirdtool.LearningFacade.application.service.AxisSelectionCommandService;
+import com.example.thirdtool.LearningFacade.application.service.AxisSelectionQueryService;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisSelectionRequest;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisSelectionResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * Selection 컨테이너 + 자식 노드 REST Controller (Story-LT-E3-S3-11, 이슈 #16 · 이슈 #11 계승).
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AxisSelectionController {
+
+    private final AxisSelectionCommandService commandService;
+    private final AxisSelectionQueryService queryService;
+
+    // ─── 컨테이너 CRUD ─────────────────────────────
+
+    // POST /api/v1/axes/{axisId}/selections
+    @PostMapping("/axes/{axisId}/selections")
+    public ResponseEntity<AxisSelectionResponse.SelectionDetail> addSelection(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId,
+            @Valid @RequestBody AxisSelectionRequest.AddSelection request
+    ) {
+        AxisSelectionResponse.SelectionDetail detail = commandService.addSelection(
+                new AxisSelectionCommand.AddSelection(user.getId(), axisId, request.name()));
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/v1/selections/{selectionId}")
+                .buildAndExpand(detail.selectionId())
+                .toUri();
+        return ResponseEntity.created(location).body(detail);
+    }
+
+    // GET /api/v1/axes/{axisId}/selections
+    @GetMapping("/axes/{axisId}/selections")
+    public AxisSelectionResponse.SelectionList listSelections(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId
+    ) {
+        return queryService.listSelections(user.getId(), axisId);
+    }
+
+    // PATCH /api/v1/selections/{selectionId}
+    @PatchMapping("/selections/{selectionId}")
+    public AxisSelectionResponse.SelectionDetail renameSelection(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long selectionId,
+            @Valid @RequestBody AxisSelectionRequest.RenameSelection request
+    ) {
+        return commandService.renameSelection(
+                new AxisSelectionCommand.RenameSelection(user.getId(), selectionId, request.name()));
+    }
+
+    // DELETE /api/v1/axes/{axisId}/selections/{selectionId}
+    // NOTE: SDD Story 3-11는 이 URL(axisId 포함)로 컨테이너 hard delete 명세. axisId는 검증에만 사용.
+    @DeleteMapping("/axes/{axisId}/selections/{selectionId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeSelection(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long axisId,
+            @PathVariable Long selectionId
+    ) {
+        // axisId는 client convenience — 소유권 검증은 selectionId → axis → facade 체인으로 이미 처리됨.
+        commandService.removeSelection(
+                new AxisSelectionCommand.RemoveSelection(user.getId(), selectionId));
+    }
+
+    // ─── 자식 노드 CRUD ────────────────────────────
+
+    // POST /api/v1/selections/{selectionId}/nodes
+    @PostMapping("/selections/{selectionId}/nodes")
+    public ResponseEntity<AxisSelectionResponse.NodeDetail> addNode(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long selectionId,
+            @Valid @RequestBody AxisSelectionRequest.AddNode request
+    ) {
+        AxisSelectionResponse.NodeDetail detail = commandService.addNode(
+                new AxisSelectionCommand.AddNode(
+                        user.getId(), selectionId, request.title(), request.rationale(), request.body()));
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/v1/selection-nodes/{nodeId}")
+                .buildAndExpand(detail.nodeId())
+                .toUri();
+        return ResponseEntity.created(location).body(detail);
+    }
+
+    // GET /api/v1/selections/{selectionId}/nodes
+    @GetMapping("/selections/{selectionId}/nodes")
+    public AxisSelectionResponse.NodeList listNodes(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long selectionId
+    ) {
+        return queryService.listNodes(user.getId(), selectionId);
+    }
+
+    // PATCH /api/v1/selection-nodes/{nodeId}
+    @PatchMapping("/selection-nodes/{nodeId}")
+    public AxisSelectionResponse.NodeDetail updateNode(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long nodeId,
+            @Valid @RequestBody AxisSelectionRequest.UpdateNode request
+    ) {
+        return commandService.updateNode(new AxisSelectionCommand.UpdateNode(
+                user.getId(),
+                nodeId,
+                request.title(),
+                request.rationale(),
+                request.body(),
+                request.title() != null,
+                request.rationale() != null,
+                request.body() != null
+        ));
+    }
+
+    // DELETE /api/v1/selection-nodes/{nodeId}
+    @DeleteMapping("/selection-nodes/{nodeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeNode(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long nodeId
+    ) {
+        commandService.removeNode(new AxisSelectionCommand.RemoveNode(user.getId(), nodeId));
+    }
+
+    // PUT /api/v1/selections/{selectionId}/nodes/order
+    @PutMapping("/selections/{selectionId}/nodes/order")
+    public AxisSelectionResponse.Reordered reorderNodes(
+            @AuthenticationPrincipal UserEntity user,
+            @PathVariable Long selectionId,
+            @Valid @RequestBody AxisSelectionRequest.ReorderNodes request
+    ) {
+        return commandService.reorderNodes(new AxisSelectionCommand.ReorderNodes(
+                user.getId(), selectionId, request.orderedNodeIds()));
+    }
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/AxisSelectionController.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/AxisSelectionController.java
@@ -66,7 +66,7 @@ public class AxisSelectionController {
     }
 
     // DELETE /api/v1/axes/{axisId}/selections/{selectionId}
-    // NOTE: SDD Story 3-11는 이 URL(axisId 포함)로 컨테이너 hard delete 명세. axisId는 검증에만 사용.
+    // SDD Story 3-11 URL 명세. axisId는 selection이 실제로 그 axis 소유인지 검증.
     @DeleteMapping("/axes/{axisId}/selections/{selectionId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeSelection(
@@ -74,9 +74,8 @@ public class AxisSelectionController {
             @PathVariable Long axisId,
             @PathVariable Long selectionId
     ) {
-        // axisId는 client convenience — 소유권 검증은 selectionId → axis → facade 체인으로 이미 처리됨.
         commandService.removeSelection(
-                new AxisSelectionCommand.RemoveSelection(user.getId(), selectionId));
+                new AxisSelectionCommand.RemoveSelection(user.getId(), axisId, selectionId));
     }
 
     // ─── 자식 노드 CRUD ────────────────────────────

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisSelectionRequest.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisSelectionRequest.java
@@ -1,0 +1,52 @@
+package com.example.thirdtool.LearningFacade.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Selection 컨테이너 + 자식 노드 Request DTO (Story-LT-E3-S3-11).
+ */
+public final class AxisSelectionRequest {
+
+    private AxisSelectionRequest() {}
+
+    // ─── 컨테이너 ─────────────────────────
+    public record AddSelection(
+            @NotBlank(message = "Selection 이름은 비어 있을 수 없습니다.")
+            @Size(max = 100)
+            String name
+    ) {}
+
+    public record RenameSelection(
+            @NotBlank
+            @Size(max = 100)
+            String name
+    ) {}
+
+    // ─── 자식 노드 ────────────────────────
+    public record AddNode(
+            @NotBlank(message = "title은 비어 있을 수 없습니다.")
+            @Size(max = 200)
+            String title,
+
+            @Size(max = 500)
+            String rationale,
+
+            @NotBlank(message = "body는 비어 있을 수 없습니다.")
+            String body
+    ) {}
+
+    public record UpdateNode(
+            @Size(max = 200) String title,
+            @Size(max = 500) String rationale,
+            String body
+    ) {}
+
+    public record ReorderNodes(
+            @NotEmpty List<@NotNull Long> orderedNodeIds
+    ) {}
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisSelectionResponse.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/presentation/dto/AxisSelectionResponse.java
@@ -1,0 +1,75 @@
+package com.example.thirdtool.LearningFacade.presentation.dto;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelectionNode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Selection 컨테이너 + 자식 노드 Response DTO (Story-LT-E3-S3-11).
+ */
+public final class AxisSelectionResponse {
+
+    private AxisSelectionResponse() {}
+
+    // ─── 컨테이너 ─────────────────────────
+
+    public record SelectionDetail(
+            Long selectionId,
+            Long axisId,
+            String name,
+            LocalDateTime createdAt
+    ) {
+        public static SelectionDetail of(AxisSelection selection) {
+            return new SelectionDetail(
+                    selection.getId(),
+                    selection.getAxis() != null ? selection.getAxis().getId() : null,
+                    selection.getName(),
+                    selection.getCreatedAt());
+        }
+    }
+
+    public record SelectionList(List<SelectionDetail> selections) {
+        public static SelectionList of(List<AxisSelection> selections) {
+            return new SelectionList(selections.stream().map(SelectionDetail::of).toList());
+        }
+    }
+
+    // ─── 자식 노드 ────────────────────────
+
+    public record NodeDetail(
+            Long nodeId,
+            Long selectionId,
+            int displayOrder,
+            String title,
+            String rationale,
+            String body,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        public static NodeDetail of(AxisSelectionNode node) {
+            return new NodeDetail(
+                    node.getId(),
+                    node.getSelection() != null ? node.getSelection().getId() : null,
+                    node.getDisplayOrder(),
+                    node.getTitle(),
+                    node.getRationale(),
+                    node.getBody(),
+                    node.getCreatedAt(),
+                    node.getUpdatedAt());
+        }
+    }
+
+    public record NodeList(List<NodeDetail> nodes) {
+        public static NodeList of(List<AxisSelectionNode> nodes) {
+            return new NodeList(nodes.stream().map(NodeDetail::of).toList());
+        }
+    }
+
+    public record Reordered(List<NodeDetail> nodes) {
+        public static Reordered of(List<AxisSelectionNode> nodes) {
+            return new Reordered(nodes.stream().map(NodeDetail::of).toList());
+        }
+    }
+}

--- a/src/main/resources/db/migration/R21__rollback_axis_selection.sql
+++ b/src/main/resources/db/migration/R21__rollback_axis_selection.sql
@@ -1,0 +1,7 @@
+-- =============================================================
+-- R21__rollback_axis_selection.sql
+-- V21 롤백: axis_selection 컨테이너 테이블 제거.
+-- 주의: 자식 axis_selection_node가 있으면 먼저 R22 실행 필요.
+-- =============================================================
+
+DROP TABLE IF EXISTS axis_selection;

--- a/src/main/resources/db/migration/R22__rollback_axis_selection_node.sql
+++ b/src/main/resources/db/migration/R22__rollback_axis_selection_node.sql
@@ -1,0 +1,6 @@
+-- =============================================================
+-- R22__rollback_axis_selection_node.sql
+-- V22 롤백: axis_selection_node 테이블 제거.
+-- =============================================================
+
+DROP TABLE IF EXISTS axis_selection_node;

--- a/src/main/resources/db/migration/V21__axis_selection.sql
+++ b/src/main/resources/db/migration/V21__axis_selection.sql
@@ -1,0 +1,27 @@
+-- =============================================================
+-- V21__axis_selection.sql
+-- LT Epic 3 Story 3-10: axis_selection 컨테이너 테이블 신설
+--
+-- 이슈 #16 · 이슈 #11 정책 계승:
+--   · name UNIQUE per axis (활성 컨테이너)
+--   · created_at DESC 정렬 (조회는 최신 우선)
+--   · hard delete (컨테이너 삭제 시 자식 노드 CASCADE — V22 참조)
+--   · Soft Delete 없음
+-- =============================================================
+
+CREATE TABLE axis_selection
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    axis_id        BIGINT       NOT NULL,
+    name           VARCHAR(100) NOT NULL,
+    created_at     DATETIME(6)  NOT NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT uk_axis_selection_axis_name
+        UNIQUE (axis_id, name),
+    CONSTRAINT fk_axis_selection_axis
+        FOREIGN KEY (axis_id) REFERENCES learning_axis (learning_axis_id) ON DELETE CASCADE,
+    INDEX idx_axis_selection_axis_created (axis_id, created_at DESC)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V22__axis_selection_node.sql
+++ b/src/main/resources/db/migration/V22__axis_selection_node.sql
@@ -1,0 +1,31 @@
+-- =============================================================
+-- V22__axis_selection_node.sql
+-- LT Epic 3 Story 3-10: axis_selection_node 테이블 신설
+--
+-- Selection 챕터 노드 (이슈 #16):
+--   · 컨테이너 hard delete 정책 계승 → 자식 노드도 soft delete 없음
+--   · FK ON DELETE CASCADE — 컨테이너 삭제 시 자식 노드 자동 삭제
+--   · display_order 도메인 1-based, DB CHECK ≥ 1
+--   · body MEDIUMTEXT (16MB) — ASCII subtree 통짜 저장
+-- =============================================================
+
+CREATE TABLE axis_selection_node
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    selection_id   BIGINT       NOT NULL,
+    display_order  INT          NOT NULL,
+    title          VARCHAR(200) NOT NULL,
+    rationale      VARCHAR(500) NULL,
+    body           MEDIUMTEXT   NOT NULL,
+    created_at     DATETIME(6)  NOT NULL,
+    updated_at     DATETIME(6)  NOT NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_axis_selection_node_selection
+        FOREIGN KEY (selection_id) REFERENCES axis_selection (id) ON DELETE CASCADE,
+    CONSTRAINT chk_axis_selection_node_order
+        CHECK (display_order >= 1),
+    INDEX idx_axis_selection_node_selection_order (selection_id, display_order)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandServiceTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandServiceTest.java
@@ -1,0 +1,169 @@
+package com.example.thirdtool.LearningFacade.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.application.dto.AxisSelectionCommand;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelectionNode;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.AxisSelectionRepository;
+import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
+import com.example.thirdtool.LearningFacade.presentation.dto.AxisSelectionResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Story-LT-E3-S3-11 · AxisSelectionCommandService 단위 테스트.
+ */
+@DisplayName("AxisSelectionCommandService (Story-LT-E3-S3-11)")
+class AxisSelectionCommandServiceTest {
+
+    private LearningFacadeRepository facadeRepository;
+    private AxisSelectionRepository selectionRepository;
+    private AxisSelectionCommandService service;
+
+    private UserEntity user;
+    private LearningFacade facade;
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        facadeRepository = mock(LearningFacadeRepository.class);
+        selectionRepository = mock(AxisSelectionRepository.class);
+        service = new AxisSelectionCommandService(facadeRepository, selectionRepository);
+
+        user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        facade = LearningFacade.create(user, "백엔드");
+        ReflectionTestUtils.setField(facade, "id", 50L);
+        axis = facade.addAxis("하네스 엔지니어링");
+        ReflectionTestUtils.setField(axis, "id", 10L);
+
+        when(facadeRepository.findByUserId(1L)).thenReturn(Optional.of(facade));
+        when(facadeRepository.save(facade)).thenAnswer(inv -> {
+            LearningFacade saved = inv.getArgument(0);
+            long selBase = 500L;
+            long nodeBase = 700L;
+            for (LearningAxis a : saved.getAxes()) {
+                for (AxisSelection s : a.getSelections()) {
+                    if (s.getId() == null) ReflectionTestUtils.setField(s, "id", selBase++);
+                    for (AxisSelectionNode n : s.getNodes()) {
+                        if (n.getId() == null) ReflectionTestUtils.setField(n, "id", nodeBase++);
+                    }
+                }
+            }
+            return saved;
+        });
+    }
+
+    @Test
+    @DisplayName("[해피] addSelection: 컨테이너 저장")
+    void addSelection_saves() {
+        AxisSelectionResponse.SelectionDetail detail = service.addSelection(
+                new AxisSelectionCommand.AddSelection(1L, 10L, "v1"));
+
+        assertThat(detail.name()).isEqualTo("v1");
+        assertThat(detail.axisId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("[예외] addSelection: 존재하지 않는 axisId → LEARNING_AXIS_NOT_FOUND")
+    void addSelection_axisNotFound() {
+        assertThatThrownBy(() -> service.addSelection(
+                new AxisSelectionCommand.AddSelection(1L, 999L, "v1")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.LEARNING_AXIS_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[해피] addNode: Selection 컨테이너에 노드 추가")
+    void addNode_saves() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 500L);
+        when(selectionRepository.findById(500L)).thenReturn(Optional.of(s));
+
+        AxisSelectionResponse.NodeDetail detail = service.addNode(
+                new AxisSelectionCommand.AddNode(1L, 500L, "1. 첫", null, "├── ..."));
+
+        assertThat(detail.title()).isEqualTo("1. 첫");
+        assertThat(detail.displayOrder()).isEqualTo(1);
+        assertThat(detail.selectionId()).isEqualTo(500L);
+    }
+
+    @Test
+    @DisplayName("[예외] addNode: 다른 유저 소유 Selection → AXIS_SELECTION_NOT_FOUND")
+    void addNode_otherUserSelection_notFound() {
+        UserEntity other = UserEntity.ofLocal("other", "pw", "닉2", "o@t.com");
+        ReflectionTestUtils.setField(other, "id", 2L);
+        LearningFacade otherFacade = LearningFacade.create(other, "다른");
+        ReflectionTestUtils.setField(otherFacade, "id", 99L);
+        LearningAxis otherAxis = otherFacade.addAxis("다른 축");
+        ReflectionTestUtils.setField(otherAxis, "id", 20L);
+        AxisSelection otherSelection = otherAxis.addSelection("v1");
+        ReflectionTestUtils.setField(otherSelection, "id", 500L);
+        when(selectionRepository.findById(500L)).thenReturn(Optional.of(otherSelection));
+
+        assertThatThrownBy(() -> service.addNode(
+                new AxisSelectionCommand.AddNode(1L, 500L, "제목", null, "body")))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AXIS_SELECTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[해피] removeSelection: 컨테이너 hard delete (자식 CASCADE는 orphanRemoval)")
+    void removeSelection_hardDelete() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 500L);
+        when(selectionRepository.findById(500L)).thenReturn(Optional.of(s));
+
+        service.removeSelection(new AxisSelectionCommand.RemoveSelection(1L, 500L));
+
+        assertThat(axis.getSelections()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[해피] renameSelection: in-place 이름 변경 (이슈 #11)")
+    void renameSelection_inPlace() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 500L);
+        when(selectionRepository.findById(500L)).thenReturn(Optional.of(s));
+
+        AxisSelectionResponse.SelectionDetail result = service.renameSelection(
+                new AxisSelectionCommand.RenameSelection(1L, 500L, "v2"));
+
+        assertThat(result.name()).isEqualTo("v2");
+    }
+
+    @Test
+    @DisplayName("[해피] removeNode: 노드 hard delete")
+    void removeNode_hardDelete() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 500L);
+        AxisSelectionNode n1 = s.addNode("1. 첫", null, "b1");
+        ReflectionTestUtils.setField(n1, "id", 700L);
+
+        service.removeNode(new AxisSelectionCommand.RemoveNode(1L, 700L));
+
+        assertThat(s.getNodes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[예외] removeNode: 없는 nodeId → SELECTION_NODE_NOT_FOUND")
+    void removeNode_notFound() {
+        assertThatThrownBy(() -> service.removeNode(
+                new AxisSelectionCommand.RemoveNode(1L, 999L)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.SELECTION_NODE_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandServiceTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/application/service/AxisSelectionCommandServiceTest.java
@@ -127,9 +127,22 @@ class AxisSelectionCommandServiceTest {
         ReflectionTestUtils.setField(s, "id", 500L);
         when(selectionRepository.findById(500L)).thenReturn(Optional.of(s));
 
-        service.removeSelection(new AxisSelectionCommand.RemoveSelection(1L, 500L));
+        service.removeSelection(new AxisSelectionCommand.RemoveSelection(1L, 10L, 500L));
 
         assertThat(axis.getSelections()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[예외] removeSelection: path axisId가 실제 selection의 axis와 다를 때 → NOT_FOUND")
+    void removeSelection_axisIdMismatch_notFound() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 500L);
+        when(selectionRepository.findById(500L)).thenReturn(Optional.of(s));
+
+        assertThatThrownBy(() -> service.removeSelection(
+                new AxisSelectionCommand.RemoveSelection(1L, 999L, 500L)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AXIS_SELECTION_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelectionTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/AxisSelectionTest.java
@@ -1,0 +1,220 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.LearningFacade.domain.exception.LearningFacadeDomainException;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Story-LT-E3-S3-9 · AxisSelection 컨테이너 · 자식 노드 도메인 단위 테스트.
+ */
+@DisplayName("AxisSelection · AxisSelectionNode (Story-LT-E3-S3-9)")
+class AxisSelectionTest {
+
+    private static final String SAMPLE_TITLE = "1. IoC & DI 핵심 원리";
+    private static final String SAMPLE_BODY = "├── 1-1. 의존성 역전\n│       모듈 간 결합도 낮춤";
+
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        UserEntity user = UserEntity.ofLocal("tester", "encoded-pw", "닉", "t@t.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        axis = facade.addAxis("하네스 엔지니어링");
+    }
+
+    // ─── 컨테이너 CRUD ─────────────────────────────
+
+    @Test
+    @DisplayName("[해피] addSelection: 컨테이너 저장 + name trim")
+    void addSelection_savesWithTrimmedName() {
+        AxisSelection selection = axis.addSelection("  능 아키텍처 selections v1  ");
+
+        assertThat(selection.getName()).isEqualTo("능 아키텍처 selections v1");
+        assertThat(axis.getSelections()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("[예외] addSelection: name blank → AXIS_SELECTION_NAME_BLANK")
+    void addSelection_blankName_throws() {
+        assertThatThrownBy(() -> axis.addSelection("   "))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AXIS_SELECTION_NAME_BLANK);
+    }
+
+    @Test
+    @DisplayName("[예외] addSelection: 동일 이름 중복 → AXIS_SELECTION_NAME_ALREADY_EXISTS (이슈 #11 계승)")
+    void addSelection_duplicateName_throws() {
+        axis.addSelection("selections v1");
+
+        assertThatThrownBy(() -> axis.addSelection("selections v1"))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AXIS_SELECTION_NAME_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("[해피] renameSelection: in-place 이름 변경 (이슈 #11 계승)")
+    void renameSelection_inPlace() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 100L);
+
+        axis.renameSelection(100L, "v2");
+
+        assertThat(s.getName()).isEqualTo("v2");
+    }
+
+    @Test
+    @DisplayName("[예외] renameSelection: 다른 활성 컨테이너와 이름 중복 → 예외")
+    void renameSelection_duplicate_throws() {
+        AxisSelection s1 = axis.addSelection("v1");
+        AxisSelection s2 = axis.addSelection("v2");
+        ReflectionTestUtils.setField(s1, "id", 100L);
+        ReflectionTestUtils.setField(s2, "id", 200L);
+
+        assertThatThrownBy(() -> axis.renameSelection(200L, "v1"))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AXIS_SELECTION_NAME_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("[해피] removeSelection: 컨테이너 hard delete (컬렉션에서 제거)")
+    void removeSelection_hardDelete() {
+        AxisSelection s = axis.addSelection("v1");
+        ReflectionTestUtils.setField(s, "id", 100L);
+
+        axis.removeSelection(100L);
+
+        assertThat(axis.getSelections()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[예외] removeSelection: 없는 selectionId → AXIS_SELECTION_NOT_FOUND")
+    void removeSelection_notFound_throws() {
+        assertThatThrownBy(() -> axis.removeSelection(999L))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.AXIS_SELECTION_NOT_FOUND);
+    }
+
+    // ─── 자식 노드 CRUD ─────────────────────────────
+
+    @Test
+    @DisplayName("[해피] addNode: 첫 노드 → displayOrder=1")
+    void addNode_first_displayOrder1() {
+        AxisSelection s = axis.addSelection("v1");
+
+        AxisSelectionNode node = s.addNode(SAMPLE_TITLE, "근거", SAMPLE_BODY);
+
+        assertThat(node.getDisplayOrder()).isEqualTo(1);
+        assertThat(node.getTitle()).isEqualTo(SAMPLE_TITLE);
+        assertThat(node.getRationale()).isEqualTo("근거");
+        assertThat(node.getBody()).isEqualTo(SAMPLE_BODY);
+    }
+
+    @Test
+    @DisplayName("[엣지] addNode: title trim + rationale blank → null")
+    void addNode_normalize() {
+        AxisSelection s = axis.addSelection("v1");
+
+        AxisSelectionNode node = s.addNode("  제목  ", "   ", "  body  ");
+
+        assertThat(node.getTitle()).isEqualTo("제목");
+        assertThat(node.getRationale()).isNull();
+        assertThat(node.getBody()).isEqualTo("body");
+    }
+
+    @Test
+    @DisplayName("[예외] addNode: title blank → SELECTION_NODE_TITLE_BLANK")
+    void addNode_blankTitle_throws() {
+        AxisSelection s = axis.addSelection("v1");
+
+        assertThatThrownBy(() -> s.addNode("   ", null, SAMPLE_BODY))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.SELECTION_NODE_TITLE_BLANK);
+    }
+
+    @Test
+    @DisplayName("[예외] addNode: body blank → SELECTION_NODE_BODY_BLANK")
+    void addNode_blankBody_throws() {
+        AxisSelection s = axis.addSelection("v1");
+
+        assertThatThrownBy(() -> s.addNode(SAMPLE_TITLE, null, "  "))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.SELECTION_NODE_BODY_BLANK);
+    }
+
+    @Test
+    @DisplayName("[해피] reorderNodes: 노드 순서 재부여")
+    void reorderNodes_reassignsOrder() {
+        AxisSelection s = axis.addSelection("v1");
+        AxisSelectionNode n1 = s.addNode("1. 첫", null, "b1");
+        AxisSelectionNode n2 = s.addNode("2. 둘", null, "b2");
+        AxisSelectionNode n3 = s.addNode("3. 셋", null, "b3");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+        ReflectionTestUtils.setField(n2, "id", 200L);
+        ReflectionTestUtils.setField(n3, "id", 300L);
+
+        s.reorderNodes(List.of(300L, 100L, 200L));
+
+        assertThat(n3.getDisplayOrder()).isEqualTo(1);
+        assertThat(n1.getDisplayOrder()).isEqualTo(2);
+        assertThat(n2.getDisplayOrder()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("[예외] reorderNodes: id 집합 불일치 → SELECTION_NODE_ORDER_MISMATCH")
+    void reorderNodes_idMismatch_throws() {
+        AxisSelection s = axis.addSelection("v1");
+        AxisSelectionNode n1 = s.addNode("1. 첫", null, "b1");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+
+        assertThatThrownBy(() -> s.reorderNodes(List.of(100L, 999L)))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.SELECTION_NODE_ORDER_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("[해피] removeNode: 노드 hard delete (컨테이너 정책 계승)")
+    void removeNode_hardDelete() {
+        AxisSelection s = axis.addSelection("v1");
+        AxisSelectionNode n1 = s.addNode("1. 첫", null, "b1");
+        AxisSelectionNode n2 = s.addNode("2. 둘", null, "b2");
+        ReflectionTestUtils.setField(n1, "id", 100L);
+        ReflectionTestUtils.setField(n2, "id", 200L);
+
+        s.removeNode(100L);
+
+        assertThat(s.getNodes()).hasSize(1);
+        assertThat(s.getNodes().get(0).getId()).isEqualTo(200L);
+    }
+
+    @Test
+    @DisplayName("[예외] removeNode: 없는 nodeId → SELECTION_NODE_NOT_FOUND")
+    void removeNode_notFound_throws() {
+        AxisSelection s = axis.addSelection("v1");
+
+        assertThatThrownBy(() -> s.removeNode(999L))
+                .isInstanceOf(LearningFacadeDomainException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.SELECTION_NODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[해피] getNodes: unmodifiable 반환")
+    void getNodes_unmodifiable() {
+        AxisSelection s = axis.addSelection("v1");
+        s.addNode("1. 첫", null, "b1");
+
+        List<AxisSelectionNode> nodes = s.getNodes();
+
+        assertThatThrownBy(() -> nodes.add(null))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionRepositoryTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/AxisSelectionRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.example.thirdtool.LearningFacade.infrastructure.persistence;
+
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelection;
+import com.example.thirdtool.LearningFacade.domain.model.AxisSelectionNode;
+import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import com.example.thirdtool.support.QuerydslTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Story-LT-E3-S3-11 · AxisSelection Repository Slice.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AxisSelectionRepositoryAdapter.class, QuerydslTestConfig.class})
+@DisplayName("AxisSelectionRepository slice (Story-LT-E3-S3-11)")
+class AxisSelectionRepositoryTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    AxisSelectionRepositoryAdapter repository;
+
+    private LearningAxis axis;
+
+    @BeforeEach
+    void setUp() {
+        UserEntity user = UserEntity.ofLocal(
+                "tester-1", "encoded-pw", "닉네임-1", "tester1@example.com");
+        em.persist(user);
+        LearningFacade facade = LearningFacade.create(user, "백엔드");
+        em.persist(facade);
+        axis = facade.addAxis("하네스 엔지니어링");
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("axisId로 조회 시 created_at DESC 정렬 (이슈 #11 계승)")
+    void findByAxisIdOrderByCreatedAtDesc() {
+        AxisSelection s1 = axis.addSelection("v1");
+        em.flush();
+        try { Thread.sleep(2); } catch (InterruptedException ignored) {}
+        AxisSelection s2 = axis.addSelection("v2");
+        em.flush();
+        em.clear();
+
+        List<AxisSelection> result = repository.findByAxisIdOrderByCreatedAtDesc(axis.getId());
+
+        assertThat(result).extracting(AxisSelection::getName)
+                .containsExactly("v2", "v1"); // 최신 우선
+    }
+
+    @Test
+    @DisplayName("컨테이너 hard delete 시 자식 노드도 CASCADE 삭제")
+    void containerDelete_cascadesToNodes() {
+        AxisSelection s = axis.addSelection("v1");
+        s.addNode("1. 첫", null, "b1");
+        s.addNode("2. 둘", null, "b2");
+        em.flush();
+        Long selectionId = s.getId();
+
+        axis.removeSelection(selectionId);
+        em.flush();
+        em.clear();
+
+        assertThat(repository.findById(selectionId)).isEmpty();
+        List<AxisSelectionNode> orphans = em.getEntityManager()
+                .createQuery("select n from AxisSelectionNode n where n.selection.id = :sid",
+                        AxisSelectionNode.class)
+                .setParameter("sid", selectionId)
+                .getResultList();
+        assertThat(orphans).isEmpty();
+    }
+
+    @Test
+    @DisplayName("UNIQUE (axis_id, name) 위반은 도메인이 사전 감지 → 예외")
+    void unique_axis_name() {
+        axis.addSelection("v1");
+        em.flush();
+        // 도메인이 감지, 예외는 도메인 단위 테스트로 다뤘음. Repository slice는 저장 성공만 확인.
+        assertThat(repository.findByAxisIdOrderByCreatedAtDesc(axis.getId()))
+                .hasSize(1);
+    }
+}


### PR DESCRIPTION
## 개요

M3 / 0.0.3v Epic PR#4. Selection도 Roadmap과 동일한 챕터 노드 first-class로 확장 (이슈 #16). 컨테이너(AxisSelection) + 자식 노드(AxisSelectionNode) 2계층 구조. 이슈 #11 컨테이너 정책 계승.

**계승 대상**: 이슈 #11 (name UNIQUE per axis · created_at DESC · hard delete · in-place update)

## 왜 / 설계 결정

- **컨테이너 정책 계승**: 이슈 #11의 axis-level Selection 정책을 컨테이너에 그대로 적용. Version 관리(v1, v2 등)는 컨테이너 이름으로 표현.
- **자식 노드 hard delete**: 컨테이너 정책 계승 · Roadmap의 soft delete와 다른 정책. `orphanRemoval=true`.
- **컨테이너 신설**: SDD Story 3-9는 "컨테이너 유지" 전제였으나 실제로는 프로덕션 배포된 적 없어 이 PR에서 함께 신설.
- **Flyway V21/V22**: PR#3의 V20 다음.
- **body MEDIUMTEXT + BODY_MAX_LENGTH=65_535**: Reviewer 조치 · 도메인·DB 이중 방어.

## 작업 내용

### Story-LT-E3-S3-9 (도메인)
- `feat(learning-facade)`: `AxisSelection` 컨테이너 신설 — name VARCHAR(100) UNIQUE, created_at DESC 정렬, hard delete
- `feat(learning-facade)`: `AxisSelectionNode` 자식 Entity 신설 — title/rationale/body, display_order 1-based, soft delete 없음
- `feat(learning-facade)`: `LearningAxis` 확장 — `selections` 컬렉션 + 5개 도메인 API
- `feat(common)`: ErrorCode 7종 신설
  - 컨테이너: `AXIS_SELECTION_NOT_FOUND`(404), `_NAME_BLANK`(400), `_NAME_ALREADY_EXISTS`(409)
  - 노드: `SELECTION_NODE_NOT_FOUND`(404), `_TITLE_BLANK`(400), `_BODY_BLANK`(400), `_ORDER_MISMATCH`(400)
- `test(learning-facade)`: 도메인 단위 테스트 15건

### Story-LT-E3-S3-10 (Flyway)
- `feat(learning-facade)`: `V21__axis_selection.sql` — 컨테이너 테이블 (UNIQUE + FK CASCADE + created_at DESC 인덱스)
- `feat(learning-facade)`: `V22__axis_selection_node.sql` — 자식 노드 (FK CASCADE + display_order CHECK ≥ 1 + body MEDIUMTEXT)
- R21/R22 롤백 페어
- Repository Port / JpaRepository / Adapter 3파일
- Repository Slice 테스트 3건 (created_at DESC 정렬 · CASCADE · UNIQUE)

### Story-LT-E3-S3-11 (API)
- `feat(learning-facade)`: 9개 REST 엔드포인트 (`/api/v1` prefix)

**컨테이너 (4):**
- `POST /axes/{axisId}/selections` → 201 + Location
- `GET /axes/{axisId}/selections` → 200 (created_at DESC)
- `PATCH /selections/{selectionId}` → 200 (in-place rename)
- `DELETE /axes/{axisId}/selections/{selectionId}` → 204 (자식 CASCADE)

**자식 노드 (5):**
- `POST /selections/{selectionId}/nodes` → 201 + Location
- `GET /selections/{selectionId}/nodes` → 200 (display_order ASC)
- `PATCH /selection-nodes/{nodeId}` → 200
- `DELETE /selection-nodes/{nodeId}` → 204
- `PUT /selections/{selectionId}/nodes/order` → 200

- Command/Request/Response record 셋트 + Application Service 2종 (Command + Query)
- 소유권 검증 체인 (facade → axis → selection → node)
- Application Service 단위 테스트 9건

### Reviewer 5관점 조치 (별도 커밋)
- **Sceptical Minor**: `DELETE /axes/{axisId}/selections/{selectionId}` 의 path axisId 실제 정합 검증 강화
- **Sceptical Minor**: `body` 상한 (`BODY_MAX_LENGTH = 65_535`) 도메인·DTO 이중 방어
- **Domain Minor**: `LearningAxis.addSelection`에서 blank/trim 정확도 개선

## 변경 유형
- [x] feat  - [x] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.LearningFacade.*"` → **BUILD SUCCESSFUL**
- 전체 스위트 `./gradlew test` → **BUILD SUCCESSFUL**
- 신규 테스트 27건 (도메인 15 · Repository Slice 3 · Application Service 9)

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] BC 간 의존 방향 위반 없음 (LearningFacade BC 내부 + Common/ErrorCode)
- [x] Reviewer 5관점 세션 · 즉시 조치 3건 별도 커밋
- [x] 대상 브랜치 `develop` 확인

## 관련 이슈
- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-learning-tower.md` Epic 3 재정의 판 (line 1473~1600)
- Milestone: `workflow/task/milestones/version/0.0.3v/milestone.md` §Epic PR #4
- 이관 이슈: `issue-16-selection-node-model.md`
- 계승 이슈: `issue-11-selections-version-policy.md` (컨테이너 정책만 계승, 노드 정책 신설)

## 남은 지적 (별도 브랜치 처리)
- `loadNodeOwnedBy` 3중 loop 성능 — 초기 3명 규모 무리 없음, v2 backlog
- PATCH의 JSON `null` vs 필드 부재 구분 — PR#3와 동일 이슈, v2 JsonNullable
- `AxisSelection.updated_at` 컬럼 — rename audit 정책 결정 후 별도 마이그레이션
- Update partial 필드별 3 시나리오 테스트 보강 — 다음 브랜치
- Aggregate 3단계 계층 (`LearningFacade → LearningAxis → (Topic|RoadmapNode|Selection) → SelectionNode`) DOMAIN.md 문서화