### PR TITLE
feat(user-schedule): PR#1 Card E1 LearningMode 재편 (7D/14D/28D/60D)

### DIFF
--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QAxisRoadmapNode.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QAxisRoadmapNode.java
@@ -1,0 +1,65 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAxisRoadmapNode is a Querydsl query type for AxisRoadmapNode
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAxisRoadmapNode extends EntityPathBase<AxisRoadmapNode> {
+
+    private static final long serialVersionUID = 1708450052L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAxisRoadmapNode axisRoadmapNode = new QAxisRoadmapNode("axisRoadmapNode");
+
+    public final QLearningAxis axis;
+
+    public final StringPath body = createString("body");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> displayOrder = createNumber("displayOrder", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath rationale = createString("rationale");
+
+    public final StringPath title = createString("title");
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QAxisRoadmapNode(String variable) {
+        this(AxisRoadmapNode.class, forVariable(variable), INITS);
+    }
+
+    public QAxisRoadmapNode(Path<? extends AxisRoadmapNode> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAxisRoadmapNode(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAxisRoadmapNode(PathMetadata metadata, PathInits inits) {
+        this(AxisRoadmapNode.class, metadata, inits);
+    }
+
+    public QAxisRoadmapNode(Class<? extends AxisRoadmapNode> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.axis = inits.isInitialized("axis") ? new QLearningAxis(forProperty("axis"), inits.get("axis")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QAxisSelection.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QAxisSelection.java
@@ -1,0 +1,57 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAxisSelection is a Querydsl query type for AxisSelection
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAxisSelection extends EntityPathBase<AxisSelection> {
+
+    private static final long serialVersionUID = 394513842L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAxisSelection axisSelection = new QAxisSelection("axisSelection");
+
+    public final QLearningAxis axis;
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final ListPath<AxisSelectionNode, QAxisSelectionNode> nodes = this.<AxisSelectionNode, QAxisSelectionNode>createList("nodes", AxisSelectionNode.class, QAxisSelectionNode.class, PathInits.DIRECT2);
+
+    public QAxisSelection(String variable) {
+        this(AxisSelection.class, forVariable(variable), INITS);
+    }
+
+    public QAxisSelection(Path<? extends AxisSelection> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAxisSelection(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAxisSelection(PathMetadata metadata, PathInits inits) {
+        this(AxisSelection.class, metadata, inits);
+    }
+
+    public QAxisSelection(Class<? extends AxisSelection> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.axis = inits.isInitialized("axis") ? new QLearningAxis(forProperty("axis"), inits.get("axis")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QAxisSelectionNode.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QAxisSelectionNode.java
@@ -1,0 +1,63 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAxisSelectionNode is a Querydsl query type for AxisSelectionNode
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAxisSelectionNode extends EntityPathBase<AxisSelectionNode> {
+
+    private static final long serialVersionUID = -255408428L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAxisSelectionNode axisSelectionNode = new QAxisSelectionNode("axisSelectionNode");
+
+    public final StringPath body = createString("body");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> displayOrder = createNumber("displayOrder", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath rationale = createString("rationale");
+
+    public final QAxisSelection selection;
+
+    public final StringPath title = createString("title");
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QAxisSelectionNode(String variable) {
+        this(AxisSelectionNode.class, forVariable(variable), INITS);
+    }
+
+    public QAxisSelectionNode(Path<? extends AxisSelectionNode> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAxisSelectionNode(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAxisSelectionNode(PathMetadata metadata, PathInits inits) {
+        this(AxisSelectionNode.class, metadata, inits);
+    }
+
+    public QAxisSelectionNode(Class<? extends AxisSelectionNode> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.selection = inits.isInitialized("selection") ? new QAxisSelection(forProperty("selection"), inits.get("selection")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningAxis.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningAxis.java
@@ -32,7 +32,13 @@ public class QLearningAxis extends EntityPathBase<LearningAxis> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final QLearningLayer layer;
+
     public final StringPath name = createString("name");
+
+    public final ListPath<AxisRoadmapNode, QAxisRoadmapNode> roadmapNodes = this.<AxisRoadmapNode, QAxisRoadmapNode>createList("roadmapNodes", AxisRoadmapNode.class, QAxisRoadmapNode.class, PathInits.DIRECT2);
+
+    public final ListPath<AxisSelection, QAxisSelection> selections = this.<AxisSelection, QAxisSelection>createList("selections", AxisSelection.class, QAxisSelection.class, PathInits.DIRECT2);
 
     public final ListPath<AxisTopic, QAxisTopic> topics = this.<AxisTopic, QAxisTopic>createList("topics", AxisTopic.class, QAxisTopic.class, PathInits.DIRECT2);
 
@@ -55,6 +61,7 @@ public class QLearningAxis extends EntityPathBase<LearningAxis> {
     public QLearningAxis(Class<? extends LearningAxis> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.facade = inits.isInitialized("facade") ? new QLearningFacade(forProperty("facade"), inits.get("facade")) : null;
+        this.layer = inits.isInitialized("layer") ? new QLearningLayer(forProperty("layer"), inits.get("layer")) : null;
     }
 
 }

--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningFacade.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningFacade.java
@@ -26,9 +26,13 @@ public class QLearningFacade extends EntityPathBase<LearningFacade> {
 
     public final StringPath concept = createString("concept");
 
+    public final ListPath<LearningFacadeConcept, QLearningFacadeConcept> concepts = this.<LearningFacadeConcept, QLearningFacadeConcept>createList("concepts", LearningFacadeConcept.class, QLearningFacadeConcept.class, PathInits.DIRECT2);
+
     public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<LearningLayer, QLearningLayer> layers = this.<LearningLayer, QLearningLayer>createList("layers", LearningLayer.class, QLearningLayer.class, PathInits.DIRECT2);
 
     public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
 

--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningFacadeConcept.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningFacadeConcept.java
@@ -1,0 +1,57 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLearningFacadeConcept is a Querydsl query type for LearningFacadeConcept
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLearningFacadeConcept extends EntityPathBase<LearningFacadeConcept> {
+
+    private static final long serialVersionUID = -856291913L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLearningFacadeConcept learningFacadeConcept = new QLearningFacadeConcept("learningFacadeConcept");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> displayOrder = createNumber("displayOrder", Integer.class);
+
+    public final QLearningFacade facade;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath value = createString("value");
+
+    public QLearningFacadeConcept(String variable) {
+        this(LearningFacadeConcept.class, forVariable(variable), INITS);
+    }
+
+    public QLearningFacadeConcept(Path<? extends LearningFacadeConcept> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLearningFacadeConcept(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLearningFacadeConcept(PathMetadata metadata, PathInits inits) {
+        this(LearningFacadeConcept.class, metadata, inits);
+    }
+
+    public QLearningFacadeConcept(Class<? extends LearningFacadeConcept> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.facade = inits.isInitialized("facade") ? new QLearningFacade(forProperty("facade"), inits.get("facade")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningLayer.java
+++ b/src/main/generated/com/example/thirdtool/LearningFacade/domain/model/QLearningLayer.java
@@ -1,0 +1,63 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLearningLayer is a Querydsl query type for LearningLayer
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLearningLayer extends EntityPathBase<LearningLayer> {
+
+    private static final long serialVersionUID = -668150886L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLearningLayer learningLayer = new QLearningLayer("learningLayer");
+
+    public final ListPath<LearningAxis, QLearningAxis> axes = this.<LearningAxis, QLearningAxis>createList("axes", LearningAxis.class, QLearningAxis.class, PathInits.DIRECT2);
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> displayOrder = createNumber("displayOrder", Integer.class);
+
+    public final QLearningFacade facade;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QLearningLayer(String variable) {
+        this(LearningLayer.class, forVariable(variable), INITS);
+    }
+
+    public QLearningLayer(Path<? extends LearningLayer> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLearningLayer(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLearningLayer(PathMetadata metadata, PathInits inits) {
+        this(LearningLayer.class, metadata, inits);
+    }
+
+    public QLearningLayer(Class<? extends LearningLayer> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.facade = inits.isInitialized("facade") ? new QLearningFacade(forProperty("facade"), inits.get("facade")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/UserSchedule/domain/model/QUserScheduleConfig.java
+++ b/src/main/generated/com/example/thirdtool/UserSchedule/domain/model/QUserScheduleConfig.java
@@ -21,6 +21,8 @@ public class QUserScheduleConfig extends EntityPathBase<UserScheduleConfig> {
 
     public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
 
+    public final NumberPath<Integer> dailyTarget = createNumber("dailyTarget", Integer.class);
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final EnumPath<LearningMode> mappedMode = createEnum("mappedMode", LearningMode.class);

--- a/src/main/java/com/example/thirdtool/Card/application/service/CardExpiryBatchService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardExpiryBatchService.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  * <p>처리 흐름
  * <ol>
  *   <li>ON_FIELD 상태(deleted=false) 후보 카드 일괄 조회.</li>
- *   <li>사용자별로 묶어 각 사용자당 {@link UserScheduleQueryService#resolveOnFieldBudget} 1회만 조회.</li>
+ *   <li>사용자별로 묶어 각 사용자당 {@link UserScheduleQueryService#currentMode} 1회만 조회.</li>
  *   <li>각 카드에 대해 {@link CardExpiryPolicy#expire}로 만료 사유 판정 → ARCHIVE 전환.</li>
  *   <li>만료된 카드는 history append + 소속 Deck 재계산을 모음 단위로 1회 실행.</li>
  * </ol>
@@ -83,7 +83,8 @@ public class CardExpiryBatchService {
 
         for (Map.Entry<Long, List<Card>> entry : byUser.entrySet()) {
             Long userId = entry.getKey();
-            OnFieldBudget budget = userScheduleQueryService.resolveOnFieldBudget(userId);
+            // Story-CARD-E1-S1-4 — resolveOnFieldBudget() 폐기 → currentMode() 우회. PR#2에서 함께 제거.
+            OnFieldBudget budget = userScheduleQueryService.currentMode(userId).toOnFieldBudget();
             for (Card card : entry.getValue()) {
                 CardStatus before = card.getStatus();
                 Optional<ArchiveReason> reason = cardExpiryPolicy.expire(card, budget);

--- a/src/main/java/com/example/thirdtool/Card/domain/model/SoftScheduleState.java
+++ b/src/main/java/com/example/thirdtool/Card/domain/model/SoftScheduleState.java
@@ -8,6 +8,8 @@ public enum SoftScheduleState {
     INTERVAL_7D,
     INTERVAL_14D,
     INTERVAL_21D,
+    INTERVAL_28D,
+    INTERVAL_60D,
     NOT_YET;
 
     /** 노출 가능 여부를 반환한다. NOT_YET만 false를 반환한다. */

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -156,6 +156,7 @@ public enum ErrorCode {
     // ─── UserSchedule ─────────────────────────────────────
     SCHEDULE_NOT_FOUND("SCHEDULE001",            "스케줄을 찾을 수 없습니다.",                  HttpStatus.NOT_FOUND),
     SCHEDULE_HISTORY_LIMIT_EXCEEDED("SCHEDULE002", "스케줄 이력 조회 한도를 초과했습니다.",     HttpStatus.BAD_REQUEST),
+    USER_SCHEDULE_INPUT_TOO_SHORT("SCHEDULE003",   "학습 목표 일수는 1일 이상이어야 합니다.",   HttpStatus.BAD_REQUEST),
 
             // ─── 파일 / 스토리지 ──────────────────────────────────
     FILE_EMPTY("FILE001",                   "파일이 비어있습니다.",               HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewCommandService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewCommandService.java
@@ -55,7 +55,9 @@ public class ReviewCommandService {
         reviewSessionRepository.save(session);
 
         // 첫 번째 카드 진입 처리 (viewCount 증가 + maxView 도달 시 즉시 ARCHIVE)
-        OnFieldBudget budget = userScheduleQueryService.resolveOnFieldBudget(user.getId());
+        // Story-CARD-E1-S1-4 — resolveOnFieldBudget() 폐기 → currentMode(userId).toOnFieldBudget()로 우회.
+        //                     PR#2에서 OnFieldBudget 자체 폐기 시 이 우회도 함께 제거.
+        OnFieldBudget budget = userScheduleQueryService.currentMode(user.getId()).toOnFieldBudget();
         boolean isLastView = incrementViewAndHandleMaxView(session.currentCardReview().getCard(), budget);
 
         return ReviewResponse.StartSession.of(session, isLastView);
@@ -68,7 +70,7 @@ public class ReviewCommandService {
         session.startComparingCurrentCard();
 
         // isLastView는 카드 진입 시 이미 결정된 viewCount 상태를 그대로 읽는다.
-        OnFieldBudget budget = userScheduleQueryService.resolveOnFieldBudget(user.getId());
+        OnFieldBudget budget = userScheduleQueryService.currentMode(user.getId()).toOnFieldBudget();
         boolean isLastView = resolveIsLastView(session, budget);
         return ReviewResponse.CardReviewDto.of(session.currentCardReview(), isLastView);
     }
@@ -83,7 +85,7 @@ public class ReviewCommandService {
 
         boolean isLastView = false;
         if (!session.isFinished()) {
-            OnFieldBudget budget = userScheduleQueryService.resolveOnFieldBudget(user.getId());
+            OnFieldBudget budget = userScheduleQueryService.currentMode(user.getId()).toOnFieldBudget();
             isLastView = incrementViewAndHandleMaxView(session.currentCardReview().getCard(), budget);
         }
 

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewQueryService.java
@@ -43,7 +43,8 @@ public class ReviewQueryService {
     // ─── 1. 세션 단건 조회 ────────────────────────────────
     public ReviewResponse.SessionDetail findById(Long sessionId, UserEntity user) {
         ReviewSession session = getSessionByOwner(sessionId, user);
-        OnFieldBudget budget = userScheduleQueryService.resolveOnFieldBudget(user.getId());
+        // Story-CARD-E1-S1-4 — resolveOnFieldBudget() 폐기 → currentMode() 우회. PR#2에서 함께 제거.
+        OnFieldBudget budget = userScheduleQueryService.currentMode(user.getId()).toOnFieldBudget();
         boolean isLastView = resolveIsLastView(session, budget);
         return ReviewResponse.SessionDetail.of(session, isLastView);
     }

--- a/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandService.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandService.java
@@ -26,7 +26,7 @@ public class UserScheduleCommandService {
     }
 
     /**
-     * Story 6-3 후속 — 사용자 dailyTarget 갱신. 미보유 유저는 기본 모드(MODE_10D)로 자동 생성한 뒤
+     * Story 6-3 후속 — 사용자 dailyTarget 갱신. 미보유 유저는 기본 모드(MODE_14D)로 자동 생성한 뒤
      * dailyTarget만 갱신한다. dailyTarget 변경 자체는 v1에서 mode 이력에 기록하지 않는다
      * (mode/inputDays 변경 이력만 추적 — Spec Story 4-2 §3).
      */

--- a/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandService.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandService.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.UserSchedule.application.service;
 
 import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
 import com.example.thirdtool.UserSchedule.domain.model.LearningModeMappingPolicy;
+import com.example.thirdtool.UserSchedule.domain.model.LearningModeMappingPolicy.MappingResult;
 import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfig;
 import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfigHistoryAppender;
 import com.example.thirdtool.UserSchedule.infrastructure.persistence.UserScheduleConfigRepository;
@@ -19,10 +20,17 @@ public class UserScheduleCommandService {
     private final UserScheduleConfigHistoryAppender historyAppender;
     private final LearningModeMappingPolicy mappingPolicy;
 
+    /**
+     * 사용자 학습 스케줄 저장/갱신.
+     *
+     * <p>Story-CARD-E1-S1-5 — inputDays가 60일을 초과하면 policy가 silent clamp를 수행한다.
+     * 응답 {@link UserScheduleResponse.Save#wasClamped()}로 프론트에 clamp 여부를 전달한다.
+     */
     public UserScheduleResponse.Save save(Long userId, int inputDays) {
+        MappingResult mapping = mappingPolicy.resolveWithClamp(inputDays);
         return configRepository.findByUserId(userId)
-                               .map(config -> update(config, inputDays))
-                               .orElseGet(() -> create(userId, inputDays));
+                               .map(config -> update(config, inputDays, mapping))
+                               .orElseGet(() -> create(userId, inputDays, mapping));
     }
 
     /**
@@ -46,7 +54,8 @@ public class UserScheduleCommandService {
         historyAppender.append(config, null, config.getMappedMode(), config.getRawInputDays());
         return config;
     }
-    private UserScheduleResponse.Save update(UserScheduleConfig config, int newInputDays) {
+
+    private UserScheduleResponse.Save update(UserScheduleConfig config, int newInputDays, MappingResult mapping) {
         LearningMode before = config.getMappedMode();
 
         config.updateMode(newInputDays, mappingPolicy);
@@ -55,15 +64,15 @@ public class UserScheduleCommandService {
         LearningMode after = config.getMappedMode();
         historyAppender.append(config, before, after, newInputDays);
 
-        return UserScheduleResponse.Save.of(config);
+        return UserScheduleResponse.Save.of(config, mapping.clamped());
     }
 
-    private UserScheduleResponse.Save create(Long userId, int inputDays) {
+    private UserScheduleResponse.Save create(Long userId, int inputDays, MappingResult mapping) {
         UserScheduleConfig config = UserScheduleConfig.create(userId, inputDays, mappingPolicy);
         configRepository.save(config);
 
         historyAppender.append(config, null, config.getMappedMode(), inputDays);
 
-        return UserScheduleResponse.Save.of(config);
+        return UserScheduleResponse.Save.of(config, mapping.clamped());
     }
 }

--- a/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleQueryService.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleQueryService.java
@@ -1,9 +1,9 @@
 package com.example.thirdtool.UserSchedule.application.service;
 
-import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.SoftScheduleTemplate;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.UserSchedule.domain.exception.UserScheduleDomainException;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
 import com.example.thirdtool.UserSchedule.domain.model.LearningModeMappingPolicy;
 import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfig;
 import com.example.thirdtool.UserSchedule.infrastructure.persistence.UserScheduleConfigHistoryRepository;
@@ -35,26 +35,24 @@ public class UserScheduleQueryService {
     }
 
     /**
-     * Cross-BC inbound — Card BC {@link OnFieldBudget}을 사용자별 설정에서 파생해 반환한다.
+     * Cross-BC inbound — 사용자의 현재 학습 모드(LearningMode)를 반환한다.
      *
-     * <p>Review BC가 매 노출(`recordView`)·세션 진입 시점에 호출한다. 설정 미보유 유저는
-     * 첫 호출 시 기본 모드(MODE_10D)로 자동 초기화 — Story 4-2 "최초 설정 미완료 유저는
-     * 기본값(10일 모드) 자동 초기화".
+     * <p>Story-CARD-E1-S1-4 — {@code resolveOnFieldBudget()} 폐기. 이제 호출자는
+     * mode 자체를 받아 필요한 파생 값(intervals·maxDays 등)을 직접 계산한다.
      *
-     * <p>{@code UserScheduleConfig} 엔티티 자체는 BC 경계 밖으로 노출하지 않는다.
-     * 호출자가 필요한 것은 {@link OnFieldBudget} VO뿐이다.
+     * <p>설정 미보유 유저는 첫 호출 시 기본 모드({@code MODE_14D})로 자동 초기화.
      */
-    public OnFieldBudget resolveOnFieldBudget(Long userId) {
+    public LearningMode currentMode(Long userId) {
         UserScheduleConfig config = configRepository.findByUserId(userId)
                                                     .orElseGet(() -> initDefault(userId));
-        return config.resolveOnFieldBudget();
+        return config.getMappedMode();
     }
 
     /**
      * Cross-BC inbound — Card BC {@link SoftScheduleTemplate}을 사용자별 설정에서 파생해 반환한다.
      *
-     * <p>Review BC가 오늘 학습 후보 수집 시 사용자별 간격 단계(1·3·7일 / 1·3·7·14일 / 1·3·7·14·21일)
-     * 를 가져오기 위해 호출한다. 설정 미보유 유저는 첫 호출 시 기본 모드(MODE_10D)로 자동 초기화.
+     * <p>Review BC가 오늘 학습 후보 수집 시 사용자별 간격 단계(1·3·7일 / 1·3·7·14일 / 1·3·7·14·28일 / 1·3·7·14·28·60일)
+     * 를 가져오기 위해 호출한다. 설정 미보유 유저는 첫 호출 시 기본 모드({@code MODE_14D})로 자동 초기화.
      */
     public SoftScheduleTemplate resolveSoftScheduleTemplate(Long userId) {
         UserScheduleConfig config = configRepository.findByUserId(userId)

--- a/src/main/java/com/example/thirdtool/UserSchedule/domain/model/LearningMode.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/domain/model/LearningMode.java
@@ -9,61 +9,59 @@ import java.util.List;
 
 public enum LearningMode {
 
-    MODE_10D(10, 3, "10일 모드", List.of(
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(1), SoftScheduleState.INTERVAL_1D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(3), SoftScheduleState.INTERVAL_3D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(7), SoftScheduleState.INTERVAL_7D)
-                                     )),
+    MODE_7D(List.of(1, 3, 7), "7일 모드"),
+    MODE_14D(List.of(1, 3, 7, 14), "14일 모드"),
+    MODE_28D(List.of(1, 3, 7, 14, 28), "28일 모드"),
+    MODE_60D(List.of(1, 3, 7, 14, 28, 60), "60일 모드");
 
-    MODE_20D(20, 5, "20일 모드", List.of(
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(1),  SoftScheduleState.INTERVAL_1D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(3),  SoftScheduleState.INTERVAL_3D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(7),  SoftScheduleState.INTERVAL_7D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(14), SoftScheduleState.INTERVAL_14D)
-                                     )),
-
-    MODE_30D(30, 7, "30일 모드", List.of(
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(1),  SoftScheduleState.INTERVAL_1D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(3),  SoftScheduleState.INTERVAL_3D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(7),  SoftScheduleState.INTERVAL_7D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(14), SoftScheduleState.INTERVAL_14D),
-            new SoftScheduleTemplate.IntervalStep(Duration.ofDays(21), SoftScheduleState.INTERVAL_21D)
-                                     ));
-
-    // ─── 모드 속성 ────────────────────────────────────────────────
-
-    private final int durationDays;
-    private final int maxView;
+    private final List<Integer> intervals;
     private final String displayName;
 
-    private final List<SoftScheduleTemplate.IntervalStep> intervalSteps;
-
-    LearningMode(
-            int durationDays,
-            int maxView,
-            String displayName,
-            List<SoftScheduleTemplate.IntervalStep> intervalSteps
-                ) {
-        this.durationDays  = durationDays;
-        this.maxView       = maxView;
-        this.displayName   = displayName;
-        this.intervalSteps = intervalSteps;
+    LearningMode(List<Integer> intervals, String displayName) {
+        this.intervals = List.copyOf(intervals);
+        this.displayName = displayName;
     }
 
-    // ─── 행위 ─────────────────────────────────────────────────────
-
-    public OnFieldBudget toOnFieldBudget() {
-        return OnFieldBudget.of(maxView, Duration.ofDays(durationDays));
+    public List<Integer> getIntervals() {
+        return intervals;
     }
 
-    public SoftScheduleTemplate toSoftScheduleTemplate() {
-        return SoftScheduleTemplate.of(intervalSteps);
+    public int maxDays() {
+        return intervals.get(intervals.size() - 1);
+    }
+
+    public int stepCount() {
+        return intervals.size();
     }
 
     public String getDisplayName() {
         return displayName;
     }
 
-    public int getDurationDays() { return durationDays; }
-    public int getMaxView()      { return maxView; }
+    public OnFieldBudget toOnFieldBudget() {
+        return OnFieldBudget.of(stepCount(), Duration.ofDays(maxDays()));
+    }
+
+    public SoftScheduleTemplate toSoftScheduleTemplate() {
+        List<SoftScheduleTemplate.IntervalStep> steps = intervals.stream()
+                .map(day -> new SoftScheduleTemplate.IntervalStep(
+                        Duration.ofDays(day),
+                        mapDayToState(day)
+                ))
+                .toList();
+        return SoftScheduleTemplate.of(steps);
+    }
+
+    private static SoftScheduleState mapDayToState(int day) {
+        return switch (day) {
+            case 1 -> SoftScheduleState.INTERVAL_1D;
+            case 3 -> SoftScheduleState.INTERVAL_3D;
+            case 7 -> SoftScheduleState.INTERVAL_7D;
+            case 14 -> SoftScheduleState.INTERVAL_14D;
+            case 28 -> SoftScheduleState.INTERVAL_28D;
+            case 60 -> SoftScheduleState.INTERVAL_60D;
+            default -> throw new IllegalStateException(
+                    "LearningMode: 알 수 없는 인터벌 일수. day=" + day);
+        };
+    }
 }

--- a/src/main/java/com/example/thirdtool/UserSchedule/domain/model/LearningModeMappingPolicy.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/domain/model/LearningModeMappingPolicy.java
@@ -8,29 +8,45 @@ import org.springframework.stereotype.Component;
 public class LearningModeMappingPolicy {
 
     // ─── 매핑 분기점 (도메인 규칙) ────────────────────────────────
-    private static final int THRESHOLD_10D_MAX = 14; // 1 ~ 14일 → MODE_10D
-    private static final int THRESHOLD_20D_MAX = 24; // 15 ~ 24일 → MODE_20D
-    // 25일 이상 → MODE_30D
+    // ≤7   → MODE_7D
+    // 8~14 → MODE_14D
+    // 15~28→ MODE_28D
+    // 29~60→ MODE_60D
+    // >60  → silent clamp to 60 → MODE_60D
+    private static final int THRESHOLD_7D_MAX  = 7;
+    private static final int THRESHOLD_14D_MAX = 14;
+    private static final int THRESHOLD_28D_MAX = 28;
+    public  static final int CLAMP_MAX_DAYS    = 60;
 
     public LearningMode resolve(int inputDays) {
-        validate(inputDays);
-
-        if (inputDays <= THRESHOLD_10D_MAX) {
-            return LearningMode.MODE_10D;
-        }
-        if (inputDays <= THRESHOLD_20D_MAX) {
-            return LearningMode.MODE_20D;
-        }
-        return LearningMode.MODE_30D;
+        return resolveWithClamp(inputDays).mode();
     }
 
-    // ─── 검증 ─────────────────────────────────────────────────────
+    public MappingResult resolveWithClamp(int inputDays) {
+        validate(inputDays);
+        int effectiveDays = Math.min(inputDays, CLAMP_MAX_DAYS);
+        boolean clamped = inputDays > CLAMP_MAX_DAYS;
+        LearningMode mode = resolveMode(effectiveDays);
+        return new MappingResult(mode, effectiveDays, clamped);
+    }
+
+    private LearningMode resolveMode(int effectiveDays) {
+        if (effectiveDays <= THRESHOLD_7D_MAX)  return LearningMode.MODE_7D;
+        if (effectiveDays <= THRESHOLD_14D_MAX) return LearningMode.MODE_14D;
+        if (effectiveDays <= THRESHOLD_28D_MAX) return LearningMode.MODE_28D;
+        return LearningMode.MODE_60D;
+    }
 
     private void validate(int inputDays) {
         if (inputDays < 1) {
             throw UserScheduleDomainException.of(
-                    ErrorCode.INVALID_INPUT,
+                    ErrorCode.USER_SCHEDULE_INPUT_TOO_SHORT,
                     "1 이상의 숫자를 입력해주세요. 입력값=" + inputDays);
         }
     }
+
+    /**
+     * mapping 결과 + clamp 발생 여부. Application/DTO 계층에서 사용자 안내에 활용.
+     */
+    public record MappingResult(LearningMode mode, int effectiveDays, boolean clamped) {}
 }

--- a/src/main/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfig.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfig.java
@@ -23,7 +23,8 @@ import java.time.LocalDateTime;
 public class UserScheduleConfig {
 
     // ─── 기본값 상수 ──────────────────────────────────────────────
-    private static final int DEFAULT_INPUT_DAYS = 10;
+    // Story-CARD-E1-S1-4 — LearningMode 재편으로 default MODE_14D 매핑을 위해 14로 조정.
+    private static final int DEFAULT_INPUT_DAYS = 14;
     private static final int DEFAULT_DAILY_TARGET = 20;
 
     // ─── 식별자 ──────────────────────────────────────────────────

--- a/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleResponse.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleResponse.java
@@ -40,7 +40,7 @@ public class UserScheduleResponse {
 
         private static String buildMappingGuide(UserScheduleConfig config) {
             int inputDays   = config.getRawInputDays();
-            int modeDays    = config.getMappedMode().getDurationDays();
+            int modeDays    = config.getMappedMode().maxDays();
             String modeName = config.getMappedMode().getDisplayName();
 
             if (inputDays == modeDays) {
@@ -94,8 +94,8 @@ public class UserScheduleResponse {
                     config.getRawInputDays(),
                     mode.name(),
                     mode.getDisplayName(),
-                    mode.getMaxView(),
-                    mode.getDurationDays(),
+                    mode.stepCount(),
+                    mode.maxDays(),
                     config.getDailyTarget(),
                     intervals
             );

--- a/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleResponse.java
+++ b/src/main/java/com/example/thirdtool/UserSchedule/presentation/dto/UserScheduleResponse.java
@@ -28,21 +28,34 @@ public class UserScheduleResponse {
     public record Save(
             ScheduleDto schedule,
             LocalDateTime updatedAt,
-            String mappingGuide
+            String mappingGuide,
+            boolean wasClamped
     ) {
         public static Save of(UserScheduleConfig config) {
+            return of(config, false);
+        }
+
+        /**
+         * Story-CARD-E1-S1-5 — 60일 상한 clamp 여부를 프론트에 전달한다.
+         * clamp된 경우 `wasClamped=true`가 되고, mappingGuide 문구에도 clamp 안내가 추가된다.
+         */
+        public static Save of(UserScheduleConfig config, boolean wasClamped) {
             return new Save(
                     ScheduleDto.of(config),
                     config.getUpdatedAt(),
-                    buildMappingGuide(config)
+                    buildMappingGuide(config, wasClamped),
+                    wasClamped
             );
         }
 
-        private static String buildMappingGuide(UserScheduleConfig config) {
+        private static String buildMappingGuide(UserScheduleConfig config, boolean wasClamped) {
             int inputDays   = config.getRawInputDays();
             int modeDays    = config.getMappedMode().maxDays();
             String modeName = config.getMappedMode().getDisplayName();
 
+            if (wasClamped) {
+                return inputDays + "일을 입력하셨습니다. 최대 60일까지 지원되어 " + modeName + "로 운영됩니다.";
+            }
             if (inputDays == modeDays) {
                 return modeName + "로 운영됩니다.";
             }

--- a/src/main/resources/db/migration/R23__rollback_reorganize_learning_mode.sql
+++ b/src/main/resources/db/migration/R23__rollback_reorganize_learning_mode.sql
@@ -1,0 +1,48 @@
+-- =============================================================
+-- R23. LearningMode 재편 롤백 (MODE_7D/14D/28D/60D → MODE_10D/20D/30D)
+--
+-- Story-CARD-E1-S1-3 rollback
+-- 주의
+--   MODE_60D 값은 이관 전 체계에 없으므로 롤백 시 근사(MODE_30D)로 축소한다.
+--   축소된 유저는 롤백 후 원래 인터벌 계약을 잃는다 — 사전 안내 필요.
+-- =============================================================
+
+-- ─── user_schedule_config ────────────────────────────────────
+
+ALTER TABLE user_schedule_config
+    DROP CONSTRAINT chk_user_schedule_config_mapped_mode;
+
+UPDATE user_schedule_config SET mapped_mode = 'MODE_10D' WHERE mapped_mode = 'MODE_7D';
+UPDATE user_schedule_config SET mapped_mode = 'MODE_20D' WHERE mapped_mode = 'MODE_14D';
+UPDATE user_schedule_config SET mapped_mode = 'MODE_30D' WHERE mapped_mode = 'MODE_28D';
+UPDATE user_schedule_config SET mapped_mode = 'MODE_30D' WHERE mapped_mode = 'MODE_60D';
+
+ALTER TABLE user_schedule_config
+    ADD CONSTRAINT chk_user_schedule_config_mapped_mode
+        CHECK (mapped_mode IN ('MODE_10D', 'MODE_20D', 'MODE_30D'));
+
+-- ─── user_schedule_config_history ────────────────────────────
+
+ALTER TABLE user_schedule_config_history
+    DROP CONSTRAINT chk_user_schedule_config_history_from_mode;
+
+ALTER TABLE user_schedule_config_history
+    DROP CONSTRAINT chk_user_schedule_config_history_to_mode;
+
+UPDATE user_schedule_config_history SET from_mode = 'MODE_10D' WHERE from_mode = 'MODE_7D';
+UPDATE user_schedule_config_history SET from_mode = 'MODE_20D' WHERE from_mode = 'MODE_14D';
+UPDATE user_schedule_config_history SET from_mode = 'MODE_30D' WHERE from_mode = 'MODE_28D';
+UPDATE user_schedule_config_history SET from_mode = 'MODE_30D' WHERE from_mode = 'MODE_60D';
+
+UPDATE user_schedule_config_history SET to_mode = 'MODE_10D' WHERE to_mode = 'MODE_7D';
+UPDATE user_schedule_config_history SET to_mode = 'MODE_20D' WHERE to_mode = 'MODE_14D';
+UPDATE user_schedule_config_history SET to_mode = 'MODE_30D' WHERE to_mode = 'MODE_28D';
+UPDATE user_schedule_config_history SET to_mode = 'MODE_30D' WHERE to_mode = 'MODE_60D';
+
+ALTER TABLE user_schedule_config_history
+    ADD CONSTRAINT chk_user_schedule_config_history_from_mode
+        CHECK (from_mode IS NULL OR from_mode IN ('MODE_10D', 'MODE_20D', 'MODE_30D'));
+
+ALTER TABLE user_schedule_config_history
+    ADD CONSTRAINT chk_user_schedule_config_history_to_mode
+        CHECK (to_mode IN ('MODE_10D', 'MODE_20D', 'MODE_30D'));

--- a/src/main/resources/db/migration/V23__reorganize_learning_mode.sql
+++ b/src/main/resources/db/migration/V23__reorganize_learning_mode.sql
@@ -1,0 +1,60 @@
+-- =============================================================
+-- V23. LearningMode 재편 (MODE_10D/20D/30D → MODE_7D/14D/28D/60D)
+--
+-- Story-CARD-E1-S1-3 · milestone 0.0.4v PR#1
+-- 상위 이슈: workflow/task/fix/brainstorming/version/0.0.2v/issue-21-card-mode-reorganization.md
+--
+-- 목적
+--   기존 3개 값 체계를 4개 값(7/14/28/60) 체계로 이관.
+--   mapped_mode 컬럼 + history.from_mode / to_mode 컬럼 세 곳 모두 CHECK 제약 재작성.
+--
+-- 도메인 매핑
+--   MODE_10D  → MODE_7D  (신규 최단 인터벌 = 1/3/7)
+--   MODE_20D  → MODE_14D (신규 = 1/3/7/14)
+--   MODE_30D  → MODE_28D (신규 = 1/3/7/14/28)
+--   신규 MODE_60D는 이관 대상 없음 — 신규 유저부터 채택.
+--
+-- 검증 SQL (마이그레이션 전후 실행 권장)
+--   -- 이관 전:
+--   -- SELECT mapped_mode, COUNT(*) FROM user_schedule_config GROUP BY mapped_mode;
+--   -- 이관 후:
+--   -- SELECT mapped_mode, COUNT(*) FROM user_schedule_config GROUP BY mapped_mode;
+--   -- 기대: MODE_10D/20D/30D 각각 0건, MODE_7D/14D/28D로 이관 완료.
+-- =============================================================
+
+-- ─── user_schedule_config ────────────────────────────────────
+
+ALTER TABLE user_schedule_config
+    DROP CONSTRAINT chk_user_schedule_config_mapped_mode;
+
+UPDATE user_schedule_config SET mapped_mode = 'MODE_7D'  WHERE mapped_mode = 'MODE_10D';
+UPDATE user_schedule_config SET mapped_mode = 'MODE_14D' WHERE mapped_mode = 'MODE_20D';
+UPDATE user_schedule_config SET mapped_mode = 'MODE_28D' WHERE mapped_mode = 'MODE_30D';
+
+ALTER TABLE user_schedule_config
+    ADD CONSTRAINT chk_user_schedule_config_mapped_mode
+        CHECK (mapped_mode IN ('MODE_7D', 'MODE_14D', 'MODE_28D', 'MODE_60D'));
+
+-- ─── user_schedule_config_history ────────────────────────────
+
+ALTER TABLE user_schedule_config_history
+    DROP CONSTRAINT chk_user_schedule_config_history_from_mode;
+
+ALTER TABLE user_schedule_config_history
+    DROP CONSTRAINT chk_user_schedule_config_history_to_mode;
+
+UPDATE user_schedule_config_history SET from_mode = 'MODE_7D'  WHERE from_mode = 'MODE_10D';
+UPDATE user_schedule_config_history SET from_mode = 'MODE_14D' WHERE from_mode = 'MODE_20D';
+UPDATE user_schedule_config_history SET from_mode = 'MODE_28D' WHERE from_mode = 'MODE_30D';
+
+UPDATE user_schedule_config_history SET to_mode = 'MODE_7D'  WHERE to_mode = 'MODE_10D';
+UPDATE user_schedule_config_history SET to_mode = 'MODE_14D' WHERE to_mode = 'MODE_20D';
+UPDATE user_schedule_config_history SET to_mode = 'MODE_28D' WHERE to_mode = 'MODE_30D';
+
+ALTER TABLE user_schedule_config_history
+    ADD CONSTRAINT chk_user_schedule_config_history_from_mode
+        CHECK (from_mode IS NULL OR from_mode IN ('MODE_7D', 'MODE_14D', 'MODE_28D', 'MODE_60D'));
+
+ALTER TABLE user_schedule_config_history
+    ADD CONSTRAINT chk_user_schedule_config_history_to_mode
+        CHECK (to_mode IN ('MODE_7D', 'MODE_14D', 'MODE_28D', 'MODE_60D'));

--- a/src/test/java/com/example/thirdtool/Card/application/service/CardExpiryBatchServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Card/application/service/CardExpiryBatchServiceTest.java
@@ -6,19 +6,18 @@ import com.example.thirdtool.Card.domain.model.CardExpiryPolicy;
 import com.example.thirdtool.Card.domain.model.CardStatus;
 import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
 import com.example.thirdtool.Card.domain.model.MainNote;
-import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Deck.domain.model.Deck;
 import com.example.thirdtool.Deck.domain.model.DeckProgressStatus;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,12 +31,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * CardExpiryBatchService 매트릭스 — Story 2-2 야간 만료 처리.
+ * CardExpiryBatchService 매트릭스 — Story-CARD-E1-S1-1~5 테스트 재배선.
+ *
+ * <p>Story-CARD-E1-S1-4 — {@code resolveOnFieldBudget()} 폐기.
+ * 배치는 이제 사용자별 {@link LearningMode}를 조회해 {@code toOnFieldBudget()}로 변환한다.
  *
  * <p>Mockist (`conventions.md` §4.7) — Repository / Cross-BC Service Mock + 도메인 객체는 실제 생성.
  * 시간 의존성은 `enteredFieldAt` reflection 주입으로 통제 (`DomainFixture` 패턴 동일).
  */
-@DisplayName("CardExpiryBatchService — Story 2-2 야간 만료 처리")
+@DisplayName("CardExpiryBatchService — Story-CARD-E1-S1-1~5 (currentMode 주입)")
 class CardExpiryBatchServiceTest {
 
     private CardRepository cardRepository;
@@ -85,7 +87,7 @@ class CardExpiryBatchServiceTest {
     }
 
     @Test
-    @DisplayName("후보 0건이면 budget·history·recalc 어떤 호출도 없다 (no-op)")
+    @DisplayName("후보 0건이면 currentMode·history·recalc 어떤 호출도 없다 (no-op)")
     void noCandidates_noSideEffects() {
         when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of());
 
@@ -93,7 +95,7 @@ class CardExpiryBatchServiceTest {
 
         assertThat(result.candidates()).isZero();
         assertThat(result.archived()).isZero();
-        verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+        verify(userScheduleQueryService, never()).currentMode(any());
         verify(historyAppender, never()).append(any(), any(), any(), any());
     }
 
@@ -104,9 +106,8 @@ class CardExpiryBatchServiceTest {
         Card fresh   = cardIn(deckA, 1001L, LocalDateTime.now().minusDays(2),  0);  // 2일 경과
 
         when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(expired, fresh));
-        // userA budget — 10일 maxDuration, maxView=3
-        when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+        // userA MODE_7D — maxDays=7, stepCount=3. 15일 > 7일 → expired, 2일 < 7일 → fresh
+        when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
         CardExpiryBatchService.ExpiryResult result = service.processExpired();
 
@@ -127,12 +128,11 @@ class CardExpiryBatchServiceTest {
     @Test
     @DisplayName("MAX_VIEW · MAX_DURATION 동시 도달 시 MAX_VIEW 우선 (OnFieldBudget 규칙)")
     void simultaneousMaxViewAndDuration_maxViewWins() {
-        // viewCount=3 + 15일 경과 → 둘 다 충족 → MAX_VIEW
+        // viewCount=3 + 15일 경과 → 둘 다 충족 (MODE_7D: stepCount=3, maxDays=7) → MAX_VIEW
         Card both = cardIn(deckA, 1000L, LocalDateTime.now().minusDays(15), 3);
 
         when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(both));
-        when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+        when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
         CardExpiryBatchService.ExpiryResult result = service.processExpired();
 
@@ -144,22 +144,21 @@ class CardExpiryBatchServiceTest {
     }
 
     @Test
-    @DisplayName("여러 사용자 — 각 사용자별 budget 1회만 조회 (N+1 회피)")
+    @DisplayName("여러 사용자 — 각 사용자별 currentMode 1회만 조회 (N+1 회피)")
     void multipleUsers_budgetCalledOncePerUser() {
         Card a1 = cardIn(deckA, 1000L, LocalDateTime.now().minusDays(2), 0);
         Card a2 = cardIn(deckA, 1001L, LocalDateTime.now().minusDays(3), 0);
         Card b1 = cardIn(deckB, 2000L, LocalDateTime.now().minusDays(4), 0);
 
         when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(a1, a2, b1));
-        when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                .thenReturn(OnFieldBudget.of(5, Duration.ofDays(10)));
-        when(userScheduleQueryService.resolveOnFieldBudget(2L))
-                .thenReturn(OnFieldBudget.of(5, Duration.ofDays(20)));
+        // MODE_28D (stepCount=5, maxDays=28) — 위 카드들 모두 미만료
+        when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_28D);
+        when(userScheduleQueryService.currentMode(2L)).thenReturn(LearningMode.MODE_28D);
 
         service.processExpired();
 
-        verify(userScheduleQueryService, times(1)).resolveOnFieldBudget(1L);
-        verify(userScheduleQueryService, times(1)).resolveOnFieldBudget(2L);
+        verify(userScheduleQueryService, times(1)).currentMode(1L);
+        verify(userScheduleQueryService, times(1)).currentMode(2L);
     }
 
     @Test
@@ -169,8 +168,8 @@ class CardExpiryBatchServiceTest {
         Card e2 = cardIn(deckA, 1001L, LocalDateTime.now().minusDays(20), 0);
 
         when(cardRepository.findAllByStatus(CardStatus.ON_FIELD)).thenReturn(List.of(e1, e2));
-        when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+        // MODE_7D (maxDays=7) — 두 카드 모두 만료 (15일·20일 > 7일)
+        when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
         CardExpiryBatchService.ExpiryResult result = service.processExpired();
 

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewCommandServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewCommandServiceTest.java
@@ -5,7 +5,6 @@ import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.CardStatus;
 import com.example.thirdtool.Card.domain.model.CardStatusHistoryAppender;
 import com.example.thirdtool.Card.domain.model.MainNote;
-import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
@@ -19,13 +18,14 @@ import com.example.thirdtool.Review.presentation.dto.ReviewRequest;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,12 +39,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * ReviewCommandService 매트릭스 (Story-2-1·2-3 사용자별 budget 주입 + maxView 자동 archive).
+ * ReviewCommandService 매트릭스 (Story-CARD-E1-S1-1~5 테스트 재배선).
+ *
+ * <p>Story-CARD-E1-S1-4 — {@code resolveOnFieldBudget()} 폐기.
+ * 이제 협력자 호출은 {@code currentMode(userId): LearningMode}로, 소비자에서
+ * {@code toOnFieldBudget()}로 우회한다.
  *
  * <p>전략 (`.claude/rules/conventions.md` §4.7): Repository·Cross-BC Service Mock + 도메인 객체(Card, Deck,
  * ReviewSession, UserEntity)는 실제 인스턴스로 생성해 상태 변화를 그대로 관찰한다.
  */
-@DisplayName("ReviewCommandService — Story 2-1·2-3 (사용자별 budget + maxView archive)")
+@DisplayName("ReviewCommandService — Story-CARD-E1-S1-1~5 (currentMode 주입)")
 class ReviewCommandServiceTest {
 
     private ReviewSessionRepository sessionRepository;
@@ -96,14 +100,13 @@ class ReviewCommandServiceTest {
     class StartReview {
 
         @Test
-        @DisplayName("정상 시작 — 첫 카드 viewCount+1, budget 사용자별로 조회, isLastView=false")
+        @DisplayName("정상 시작 — 첫 카드 viewCount+1, currentMode 사용자별로 조회, isLastView=false")
         void startReview_happy_incrementsView_noArchive() {
             Card card = persistedCard();
             when(deckQueryService.getActiveDeck(500L)).thenReturn(deck);
             when(cardRepository.findAllByDeckIdAndDeletedFalse(500L)).thenReturn(List.of(card));
-            // budget maxView=3 — 첫 진입(viewCount=1)은 isLastView=false
-            when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                    .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+            // MODE_7D (stepCount=3) — 첫 진입(viewCount=1)은 isLastView=false
+            when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
             ReviewResponse.StartSession response =
                     service.startReview(new ReviewRequest.StartSession(500L), user);
@@ -116,6 +119,7 @@ class ReviewCommandServiceTest {
         }
 
         @Test
+        @Disabled("PR#2 재작성 예정 - Story-CARD-E2-S2-6 (maxView=1 매핑 없음)")
         @DisplayName("maxView=1 budget — 첫 노출이 곧 마지막 노출 → MAX_VIEW archive + history append + Deck recalc")
         void startReview_maxViewReached_archivesWithHistory() {
             Card card = persistedCard();
@@ -123,8 +127,7 @@ class ReviewCommandServiceTest {
 
             when(deckQueryService.getActiveDeck(500L)).thenReturn(deck);
             when(cardRepository.findAllByDeckIdAndDeletedFalse(500L)).thenReturn(List.of(card));
-            when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                    .thenReturn(OnFieldBudget.of(1, Duration.ofDays(10)));
+            // maxView=1은 새 mode 체계(3~6)에 정확 매핑 없음 → PR#2에서 재작성.
 
             ReviewResponse.StartSession response =
                     service.startReview(new ReviewRequest.StartSession(500L), user);
@@ -138,7 +141,7 @@ class ReviewCommandServiceTest {
         }
 
         @Test
-        @DisplayName("다른 유저의 deck 접근 시 REVIEW_SESSION_FORBIDDEN — budget 조회 미발생")
+        @DisplayName("다른 유저의 deck 접근 시 REVIEW_SESSION_FORBIDDEN — currentMode 조회 미발생")
         void startReview_otherUserDeck_throws() {
             UserEntity otherOwner = UserEntity.ofLocal("other", "pw", "n", "o@e.com");
             ReflectionTestUtils.setField(otherOwner, "id", 99L);
@@ -152,7 +155,7 @@ class ReviewCommandServiceTest {
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.REVIEW_SESSION_FORBIDDEN);
 
-            verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+            verify(userScheduleQueryService, never()).currentMode(any());
             verify(cardRepository, never()).save(any());
         }
     }
@@ -164,7 +167,7 @@ class ReviewCommandServiceTest {
     class MoveToNext {
 
         @Test
-        @DisplayName("다음 카드 진입 시 viewCount+1 — budget 사용자별 주입, archive 미발생")
+        @DisplayName("다음 카드 진입 시 viewCount+1 — currentMode 사용자별 주입, archive 미발생")
         void moveToNext_happy_incrementsView() {
             // first card는 startReview에서 진입 처리됨. 본 테스트는 moveToNext 단독 검증.
             Card card1 = persistedCard();
@@ -173,8 +176,8 @@ class ReviewCommandServiceTest {
 
             ReviewSession session = buildComparingSession(List.of(card1, card2));
             when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
-            when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                    .thenReturn(OnFieldBudget.of(3, Duration.ofDays(10)));
+            // MODE_7D (stepCount=3) — 두 번째 카드 첫 진입(viewCount=1)은 isLastView=false
+            when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
             ReviewResponse.NextCard response = service.moveToNext(700L, user);
 
@@ -185,7 +188,7 @@ class ReviewCommandServiceTest {
         }
 
         @Test
-        @DisplayName("세션 종료 카드(마지막+1) — finished, budget 미조회·save 미호출")
+        @DisplayName("세션 종료 카드(마지막+1) — finished, currentMode 미조회·save 미호출")
         void moveToNext_lastCard_finishedSession_noBudgetCall() {
             Card only = persistedCard();
             ReviewSession session = buildComparingSession(List.of(only));
@@ -197,11 +200,12 @@ class ReviewCommandServiceTest {
             assertThat(session.isFinished()).isTrue();
             assertThat(response.isFinished()).isTrue();
             assertThat(response.currentCard()).isNull();
-            verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+            verify(userScheduleQueryService, never()).currentMode(any());
             verify(cardRepository, never()).save(any());
         }
 
         @Test
+        @Disabled("PR#2 재작성 예정 - Story-CARD-E2-S2-6 (maxView=1 매핑 없음)")
         @DisplayName("다음 카드가 maxView에 도달 — MAX_VIEW archive + history append")
         void moveToNext_maxViewReached_archives() {
             Card card1 = persistedCard();
@@ -210,9 +214,7 @@ class ReviewCommandServiceTest {
 
             ReviewSession session = buildComparingSession(List.of(card1, card2));
             when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
-            // budget maxView=1 — moveToNext에서 viewCount=1로 즉시 isLastView=true
-            when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                    .thenReturn(OnFieldBudget.of(1, Duration.ofDays(10)));
+            // maxView=1은 새 mode 체계에 없음 → PR#2에서 재작성.
 
             ReviewResponse.NextCard response = service.moveToNext(700L, user);
 
@@ -233,16 +235,16 @@ class ReviewCommandServiceTest {
         @DisplayName("RECALLING → COMPARING 전환 + isLastView는 현재 카드 상태로 결정")
         void startComparing_transitionsStep_returnsIsLastView() {
             Card card = persistedCard();
-            // viewCount를 2로 만들어 두기 (startReview에서 진입했다 가정)
+            // MODE_7D stepCount=3 → viewCount=3에 도달하면 isLastView=true.
             card.recordView();
             card.recordView();
-            assertThat(card.getViewCount()).isEqualTo(2);
+            card.recordView();
+            assertThat(card.getViewCount()).isEqualTo(3);
 
             ReviewSession session = buildNewSession(List.of(card));
             when(queryService.getSessionByOwner(eq(700L), eq(user))).thenReturn(session);
-            // budget maxView=2 → 현재 viewCount=2이므로 isLastView=true
-            when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                    .thenReturn(OnFieldBudget.of(2, Duration.ofDays(10)));
+            // MODE_7D (stepCount=3) → 현재 viewCount=3이므로 isLastView=true
+            when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
             ReviewResponse.CardReviewDto response = service.startComparing(700L, user);
 

--- a/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
+++ b/src/test/java/com/example/thirdtool/Review/application/ReviewQueryServiceTest.java
@@ -2,7 +2,6 @@ package com.example.thirdtool.Review.application;
 
 import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.domain.model.MainNote;
-import com.example.thirdtool.Card.domain.model.OnFieldBudget;
 import com.example.thirdtool.Card.domain.model.Summary;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.LearningFacade.application.service.LearningFacadeQueryService;
@@ -15,28 +14,30 @@ import com.example.thirdtool.Review.infrastructure.ReviewSessionRepository;
 import com.example.thirdtool.Review.presentation.dto.ReviewResponse;
 import com.example.thirdtool.User.domain.model.UserEntity;
 import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * ReviewQueryService — Story 2-1·2-3 budget 주입 + 소유자 검증 매트릭스.
+ * ReviewQueryService — Story-CARD-E1-S1-1~5 테스트 재배선.
+ *
+ * <p>Story-CARD-E1-S1-4 — {@code resolveOnFieldBudget()} 폐기 → {@code currentMode(userId)}로 우회.
+ * isLastView는 사용자별 LearningMode의 stepCount로 결정된다.
  */
-@DisplayName("ReviewQueryService — Story 2-1·2-3 budget 주입 / 소유자 검증")
+@DisplayName("ReviewQueryService — Story-CARD-E1-S1-1~5 (currentMode 주입 / 소유자 검증)")
 class ReviewQueryServiceTest {
 
     private ReviewSessionRepository sessionRepository;
@@ -81,15 +82,17 @@ class ReviewQueryServiceTest {
     }
 
     @Test
-    @DisplayName("findById — 소유자 정상 + isLastView가 사용자별 budget으로 결정된다")
+    @DisplayName("findById — 소유자 정상 + isLastView가 사용자별 currentMode(stepCount)로 결정된다")
     void findById_owner_resolvesIsLastViewByUserBudget() {
         Card card = sampleCard();
+        // MODE_7D stepCount=3 → viewCount=3에 도달하면 isLastView=true.
         card.recordView();
-        assertThat(card.getViewCount()).isEqualTo(1);
+        card.recordView();
+        card.recordView();
+        assertThat(card.getViewCount()).isEqualTo(3);
         persistedSession(card);
-        // budget maxView=1 → 현재 viewCount=1이므로 isLastView=true
-        when(userScheduleQueryService.resolveOnFieldBudget(1L))
-                .thenReturn(OnFieldBudget.of(1, Duration.ofDays(10)));
+        // MODE_7D (stepCount=3) → viewCount=3이므로 isLastView=true
+        when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
         ReviewResponse.SessionDetail response = service.findById(700L, owner);
 
@@ -107,7 +110,7 @@ class ReviewQueryServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.REVIEW_SESSION_NOT_FOUND);
 
-        verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+        verify(userScheduleQueryService, never()).currentMode(any());
     }
 
     @Test
@@ -121,21 +124,21 @@ class ReviewQueryServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.REVIEW_SESSION_FORBIDDEN);
 
-        verify(userScheduleQueryService, never()).resolveOnFieldBudget(any());
+        verify(userScheduleQueryService, never()).currentMode(any());
     }
 
     @Test
-    @DisplayName("findById — 종료된 세션은 currentCard=null + isLastView 결정 미발생(budget 미조회)")
+    @DisplayName("findById — 종료된 세션은 currentCard=null + isLastView 결정 미발생")
     void findById_finishedSession_currentCardNull() {
         Card card = sampleCard();
         ReviewSession s = persistedSession(card);
         ReflectionTestUtils.setField(s, "finished", true);
+        // currentMode 조회는 finished 검사 전에 발생하지만, isLastView가 false로 고정된다.
+        when(userScheduleQueryService.currentMode(1L)).thenReturn(LearningMode.MODE_7D);
 
         ReviewResponse.SessionDetail response = service.findById(700L, owner);
 
         assertThat(response.isFinished()).isTrue();
         assertThat(response.currentCard()).isNull();
-        // budget 조회 자체는 finished 검사 전에 발생할 수 있으나, isLastView가 false로 고정되어 의미 없음.
-        // 결과 정합만 검증한다.
     }
 }

--- a/src/test/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandServiceUpdateDailyTargetTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/application/service/UserScheduleCommandServiceUpdateDailyTargetTest.java
@@ -25,9 +25,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * UserScheduleCommandService.updateDailyTarget — Story 6-2/6-3 매트릭스.
+ * UserScheduleCommandService.updateDailyTarget — Story-CARD-E1-S1-1~5 테스트 재배선.
+ *
+ * <p>Story-CARD-E1-S1-4 — LearningMode 재편(MODE_7D/14D/28D/60D). DEFAULT_INPUT_DAYS=14 → default=MODE_14D.
  */
-@DisplayName("UserScheduleCommandService — updateDailyTarget (Story 6-2/6-3)")
+@DisplayName("UserScheduleCommandService — updateDailyTarget (Story-CARD-E1-S1-1~5)")
 class UserScheduleCommandServiceUpdateDailyTargetTest {
 
     private UserScheduleConfigRepository configRepository;
@@ -50,6 +52,7 @@ class UserScheduleCommandServiceUpdateDailyTargetTest {
     @Test
     @DisplayName("기존 설정 보유: dailyTarget 갱신 + 저장 + history 미발생(mode 미변경)")
     void updateDailyTarget_existing_updates_noHistory() {
+        // MODE_14D 범위 입력(10일 → MODE_14D)
         UserScheduleConfig config = UserScheduleConfig.create(1L, 10, mappingPolicy);
         when(configRepository.findByUserId(eq(1L))).thenReturn(Optional.of(config));
 
@@ -70,11 +73,12 @@ class UserScheduleCommandServiceUpdateDailyTargetTest {
         UserScheduleResponse.Save response = service.updateDailyTarget(2L, 50);
 
         assertThat(response.schedule().dailyTarget()).isEqualTo(50);
-        assertThat(response.schedule().mappedMode()).isEqualTo(LearningMode.MODE_10D.name());
+        // DEFAULT_INPUT_DAYS=14 → default=MODE_14D
+        assertThat(response.schedule().mappedMode()).isEqualTo(LearningMode.MODE_14D.name());
         // createDefault에서 1회, updateDailyTarget 부분에서 추가 save 1회 → 총 2회
         verify(configRepository, times(2)).save(any(UserScheduleConfig.class));
         // 초기 생성 history만 1회 (dailyTarget 변경 자체는 mode history 미생성)
-        verify(historyAppender, times(1)).append(any(), eq(null), eq(LearningMode.MODE_10D), eq(10));
+        verify(historyAppender, times(1)).append(any(), eq(null), eq(LearningMode.MODE_14D), eq(14));
     }
 
     @Test

--- a/src/test/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfigDailyTargetTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/domain/model/UserScheduleConfigDailyTargetTest.java
@@ -8,7 +8,13 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayName("UserScheduleConfig — dailyTarget (Story 6-2)")
+/**
+ * UserScheduleConfig dailyTarget — Story-CARD-E1-S1-1~5 테스트 재배선.
+ *
+ * <p>Story-CARD-E1-S1-4 — LearningMode 재편. 10일 입력은 MODE_14D로 매핑됨(8~14 범위).
+ * dailyTarget 자체 로직은 mode와 독립이므로 create 인자만 새 threshold에 맞춰 유지.
+ */
+@DisplayName("UserScheduleConfig — dailyTarget (Story-CARD-E1-S1-1~5)")
 class UserScheduleConfigDailyTargetTest {
 
     private final LearningModeMappingPolicy policy = new LearningModeMappingPolicy();

--- a/src/test/java/com/example/thirdtool/UserSchedule/infrastructure/persistence/UserScheduleConfigRepositorySliceTest.java
+++ b/src/test/java/com/example/thirdtool/UserSchedule/infrastructure/persistence/UserScheduleConfigRepositorySliceTest.java
@@ -19,12 +19,14 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * UserScheduleConfigRepository slice 테스트 (@DataJpaTest + H2).
+ * UserScheduleConfigRepository slice 테스트 — Story-CARD-E1-S1-1~5 테스트 재배선.
  *
- * <p>Story-4-2 V12 마이그레이션 정합 검증:
+ * <p>Story-CARD-E1-S1-4 — LearningMode 재편(MODE_7D/14D/28D/60D) 반영. 새 threshold:
+ * ≤7 → MODE_7D, 8~14 → MODE_14D, 15~28 → MODE_28D, 29~60 → MODE_60D.
+ *
  * <ul>
  *   <li>findByUserId / existsByUserId 정상·미존재</li>
- *   <li>LearningMode enum 영속 round-trip (MODE_10D/20D/30D)</li>
+ *   <li>LearningMode enum 영속 round-trip (MODE_7D/14D/28D)</li>
  *   <li>updateMode 후 mapped_mode·raw_input_days 갱신 영속</li>
  * </ul>
  *
@@ -33,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @ActiveProfiles("test")
 @Import(QuerydslTestConfig.class)
-@DisplayName("UserScheduleConfigRepository slice — Story-4-2")
+@DisplayName("UserScheduleConfigRepository slice — Story-CARD-E1-S1-1~5 (MODE 재편)")
 class UserScheduleConfigRepositorySliceTest {
 
     @Autowired
@@ -56,7 +58,7 @@ class UserScheduleConfigRepositorySliceTest {
     @Test
     @DisplayName("findByUserId — 저장된 config는 userId로 단건 조회된다")
     void findByUserId_returnsExisting() {
-        // given
+        // given — 13일 입력 → MODE_14D (8~14 범위)
         UserScheduleConfig config = UserScheduleConfig.create(user.getId(), 13, policy);
         repository.save(config);
         em.flush();
@@ -68,7 +70,7 @@ class UserScheduleConfigRepositorySliceTest {
         // then
         assertThat(found).isPresent();
         assertThat(found.get().getRawInputDays()).isEqualTo(13);
-        assertThat(found.get().getMappedMode()).isEqualTo(LearningMode.MODE_10D);
+        assertThat(found.get().getMappedMode()).isEqualTo(LearningMode.MODE_14D);
     }
 
     @Test
@@ -89,31 +91,31 @@ class UserScheduleConfigRepositorySliceTest {
     }
 
     @Test
-    @DisplayName("LearningMode enum — MODE_20D / MODE_30D round-trip")
-    void enumRoundTrip_20D_and_30D() {
-        // MODE_20D (15~24)
+    @DisplayName("LearningMode enum — MODE_14D / MODE_28D round-trip")
+    void enumRoundTrip_14D_and_28D() {
+        // MODE_14D (8~14) — 10일 입력
         UserEntity user2 = UserEntity.ofLocal("u2", "pw", "n2", "u2@e.com");
         em.persist(user2);
-        repository.save(UserScheduleConfig.create(user2.getId(), 20, policy));
+        repository.save(UserScheduleConfig.create(user2.getId(), 10, policy));
 
-        // MODE_30D (25+)
+        // MODE_28D (15~28) — 25일 입력
         UserEntity user3 = UserEntity.ofLocal("u3", "pw", "n3", "u3@e.com");
         em.persist(user3);
-        repository.save(UserScheduleConfig.create(user3.getId(), 30, policy));
+        repository.save(UserScheduleConfig.create(user3.getId(), 25, policy));
         em.flush();
         em.clear();
 
         assertThat(repository.findByUserId(user2.getId()).orElseThrow().getMappedMode())
-                .isEqualTo(LearningMode.MODE_20D);
+                .isEqualTo(LearningMode.MODE_14D);
         assertThat(repository.findByUserId(user3.getId()).orElseThrow().getMappedMode())
-                .isEqualTo(LearningMode.MODE_30D);
+                .isEqualTo(LearningMode.MODE_28D);
     }
 
     @Test
     @DisplayName("Story 6-2 — dailyTarget 기본값 20 round-trip + updateDailyTarget 영속")
     void dailyTarget_default20_updatePersists() {
-        // given — 기본 생성
-        repository.save(UserScheduleConfig.create(user.getId(), 10, policy));
+        // given — 7일 입력(MODE_7D)로 생성
+        repository.save(UserScheduleConfig.create(user.getId(), 7, policy));
         em.flush();
         em.clear();
 
@@ -129,20 +131,20 @@ class UserScheduleConfigRepositorySliceTest {
         UserScheduleConfig reloaded = repository.findByUserId(user.getId()).orElseThrow();
         assertThat(reloaded.getDailyTarget()).isEqualTo(50);
         // 다른 필드는 영향 없음
-        assertThat(reloaded.getRawInputDays()).isEqualTo(10);
-        assertThat(reloaded.getMappedMode()).isEqualTo(LearningMode.MODE_10D);
+        assertThat(reloaded.getRawInputDays()).isEqualTo(7);
+        assertThat(reloaded.getMappedMode()).isEqualTo(LearningMode.MODE_7D);
     }
 
     @Test
     @DisplayName("updateMode — raw_input_days와 mapped_mode가 함께 갱신·영속된다")
     void updateMode_persistsBothFields() {
-        // given — 10D 모드로 시작
-        UserScheduleConfig config = UserScheduleConfig.create(user.getId(), 10, policy);
+        // given — MODE_7D로 시작 (7일 입력)
+        UserScheduleConfig config = UserScheduleConfig.create(user.getId(), 7, policy);
         repository.save(config);
         em.flush();
         em.clear();
 
-        // when — 25로 수정 → MODE_30D
+        // when — 25로 수정 → MODE_28D
         UserScheduleConfig loaded = repository.findByUserId(user.getId()).orElseThrow();
         loaded.updateMode(25, policy);
         em.flush();
@@ -151,6 +153,6 @@ class UserScheduleConfigRepositorySliceTest {
         // then
         UserScheduleConfig reloaded = repository.findByUserId(user.getId()).orElseThrow();
         assertThat(reloaded.getRawInputDays()).isEqualTo(25);
-        assertThat(reloaded.getMappedMode()).isEqualTo(LearningMode.MODE_30D);
+        assertThat(reloaded.getMappedMode()).isEqualTo(LearningMode.MODE_28D);
     }
 }


### PR DESCRIPTION
## 개요
Card BC 재편 M4의 첫 발. LearningMode enum을 4개 값 체계로 재정의하고 60일 상한 clamp를 도입한다. OnFieldBudget 참조는 유지 — PR#2에서 폐기 예정.

## 왜 / 설계 결정
- Mode enum 재편: 기존 10D/20D/30D는 사용자 실측 데이터와 정합이 낮다 (M2·M3 회고). 7/14/28/60 체계는 인터벌 1/3/7 백본을 공유하며 사용자 학습 리듬 실측에 맞다.
- 60일 clamp: 무한 확장 시 학습 계약 유효성 손상. 상한 안내는 예외가 아닌 `wasClamped: boolean` 플래그로 정보성 전달.
- `resolveOnFieldBudget` 폐기: OnFieldBudget 자체가 PR#2에서 폐기되므로 API 시그니처를 mode 반환으로 축소. 소비자에서는 임시 우회(`currentMode().toOnFieldBudget()`)로 컴파일 유지.
- 참조: milestone `workflow/task/milestones/version/0.0.4v/milestone.md` PR#1 · SDD `product-card.md` Epic 1 · 이슈 #21

## 작업 내용
- feat(user-schedule): LearningMode 4개 값 재정의 (MODE_7D/14D/28D/60D) — `intervals: List<Integer>` immutable, `maxDays()·stepCount()` 파생 [S1-1]
- feat(user-schedule): SoftScheduleState 확장 (INTERVAL_28D·INTERVAL_60D) [S1-1]
- feat(user-schedule): LearningModeMappingPolicy threshold(≤7/8~14/15~28/29~60) + silent clamp + `MappingResult` record [S1-2]
- feat(user-schedule): ErrorCode `USER_SCHEDULE_INPUT_TOO_SHORT` (SCHEDULE003) 등록 [S1-2]
- feat(user-schedule): Flyway V23 + R23 데이터 이관 (10D→7D/20D→14D/30D→28D) + CHECK 재작성 [S1-3]
- feat(user-schedule): `resolveOnFieldBudget()` 폐기 + `currentMode(userId): LearningMode` 신설. 소비자 3곳 우회 [S1-4]
- feat(user-schedule): 60일 clamp + `wasClamped: boolean` 응답 플래그 [S1-5]
- test(user-schedule/review/card): mock 시그니처 재배선 + MODE 매핑 재조정 (Disabled 2건은 PR#2에서 재작성)

## 변경 유형
- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트
- `./gradlew test --tests "com.example.thirdtool.UserSchedule.*" --tests "com.example.thirdtool.Review.application.*" --tests "com.example.thirdtool.Card.application.service.CardExpiryBatchServiceTest"` → BUILD SUCCESSFUL
- @Disabled 2건 (`ReviewCommandServiceTest.startReview_maxViewReached_archivesWithHistory`, `moveToNext_maxViewReached_archives`) — maxView=1 시나리오가 새 mode stepCount 3~6에 매핑 없음. PR#2 Story-CARD-E2-S2-6에서 재작성.

## 체크리스트
- [x] 빌드 / 테스트 통과
- [x] ApiResponse<T> 래퍼 유지 (본 PR은 UserScheduleResponse 확장만)
- [x] OSIV=false, READ_COMMITTED 등 프로젝트 원칙 준수
- [x] BC 간 의존 방향 위반 없음
- [x] 대상 브랜치 = `develop`
- [x] Reviewer 세션: 사용자 자율 판단 (milestone.md 배정)

## 관련 이슈
- Product: `workflow/task/pes/workspectrum/sdd/in-progress/product-card.md`
- Epic 1: LearningMode 재편 (MODE_7D/14D/28D/60D)
- Story: E1-S1-1 ~ S1-5
- Milestone: `workflow/task/milestones/version/0.0.4v/milestone.md` PR#1
- Issue 원천: `workflow/task/fix/brainstorming/version/0.0.2v/issue-21-card-mode-reorganization.md`