### PR TITLE
feat(review,learning-facade): LT E6 이중 스코프 (AXIS/LAYER) + Layer.progressStatus 파생 [Epic-LT-E6-M5-PR2]

### DIFF
--- a/docs/ux/wip-language.md
+++ b/docs/ux/wip-language.md
@@ -161,3 +161,31 @@ FE에서 작성할 "운영 규칙 보기" 한 페이지의 권장 섹션 구조.
 - `docs/DOMAIN.md` § Card / ReviewSession (도메인 어휘 사전)
 - `docs/PACKAGE.md` §6 (BC 의존 — Review → Card·UserSchedule·LearningFacade)
 - `Common/Exception/ErrorCode/ErrorCode` (사용자 노출 에러 코드 enum, 메시지는 같은 enum 한국어 그대로)
+
+---
+
+## 8. Review 스코프 라벨 매핑 (LT E6 · M5 · Story 6-5)
+
+`ReviewSession.scope` enum 값의 UI 라벨 매핑. "Layer 1" 이라는 모호한 라벨은 대체됨.
+
+| `ReviewScope` | 응답 필드 값 (기술) | UI 라벨 (사용자 노출) | 부가 설명 |
+| --- | --- | --- | --- |
+| `AXIS` | `"AXIS"` | "축 리뷰: {axisName}" | 단일 축 세션 · 기존 흐름 |
+| `LAYER` | `"LAYER"` | "그룹 리뷰: {layerName}" | 그룹핑 여러 축의 카드가 통합된 세션 (신설) |
+
+**Layer.progressStatus 라벨**:
+
+| `LayerProgressStatus` | UI 라벨 | 원칙 |
+| --- | --- | --- |
+| `NOT_STARTED` | "학습 전" · "아직 시작 안 함" | 축 0건 · 모든 axis NOT_STARTED |
+| `IN_PROGRESS` | "학습 중" · "진행 중" | 축 하나 이상 IN_PROGRESS · 혼재 |
+| `COMPLETED` | "학습 완료" · "그룹 완주" | 모든 axis COMPLETED |
+
+**금지 표현**:
+- "Layer 1", "Layer 2" 같은 순서 표시 — Layer는 사용자가 만든 그룹 이름으로 표시
+- "레이어" — "그룹"으로 통일 (기술 용어 사용자 노출 X)
+- "완료율 100%" 같은 정량 강조 — "학습 완료" 정성 표현으로
+
+**궤적 관리 (milestone.md § M5 PR#2 리스크)**:
+S6-1·S6-2·S6-3의 scope enum·엔드포인트는 후속 issue-25 supersede로 M5 PR#4 (Review E2)가 폐기 예정.
+cross-layer 짬뽕 큐 방향으로 재편 · UI 라벨도 그때 재검토 · 본 매핑은 M5 궤적 유지 기간의 임시 안내.

--- a/src/main/generated/com/example/thirdtool/Review/domain/model/QReviewSession.java
+++ b/src/main/generated/com/example/thirdtool/Review/domain/model/QReviewSession.java
@@ -36,6 +36,10 @@ public class QReviewSession extends EntityPathBase<ReviewSession> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final EnumPath<ReviewScope> scope = createEnum("scope", ReviewScope.class);
+
+    public final NumberPath<Long> scopeId = createNumber("scopeId", Long.class);
+
     public final DateTimePath<java.time.LocalDateTime> startedAt = createDateTime("startedAt", java.time.LocalDateTime.class);
 
     public final NumberPath<Integer> totalCardCount = createNumber("totalCardCount", Integer.class);

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -92,6 +92,9 @@ public enum ErrorCode {
     LEARNING_LAYER_HAS_ACTIVE_AXES("LL005",     "활성 축이 있는 Layer는 삭제할 수 없습니다.",                      HttpStatus.CONFLICT),
     LEARNING_LAYER_REORDER_MISMATCH("LL006",    "전달된 Layer id 목록이 현재 Layer id 집합과 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     LEARNING_LAYER_NAME_TOO_LONG("LL007",       "Layer 이름은 100자 이내여야 합니다.",                              HttpStatus.BAD_REQUEST),
+    LAYER_HAS_NO_AXES("LL008",                  "Layer에 활성 축이 없어 리뷰 세션을 시작할 수 없습니다.",           HttpStatus.BAD_REQUEST),
+    LAYER_REVIEW_ACCESS_DENIED("LL009",         "본인의 Layer가 아닙니다.",                                        HttpStatus.FORBIDDEN),
+    REVIEW_SCOPE_INVALID("LL010",               "Review 스코프 값이 유효하지 않습니다.",                            HttpStatus.BAD_REQUEST),
 
     // ─── LearningAxis ─────────────────────────────────────
     LEARNING_AXIS_NOT_FOUND("LA001",              "세부 축을 찾을 수 없습니다.",                             HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LayerProgressStatus.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LayerProgressStatus.java
@@ -1,0 +1,22 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+/**
+ * LearningLayer 진행 상태 (LT E6 · M5 · Story 6-4).
+ *
+ * <p>Layer 자체는 상태 컬럼을 갖지 않으며, 하위 axis의 {@link AxisProgressStatus} 상태를 집계한 파생값.
+ * {@link LearningLayer#progressStatus()} 도메인 메서드가 계산한다.
+ *
+ * <p>파생 규칙 (SDD):
+ * <ul>
+ *   <li>하위 axis 0건 · 모두 NOT_STARTED → {@link #NOT_STARTED}</li>
+ *   <li>하위 axis 모두 COMPLETED → {@link #COMPLETED}</li>
+ *   <li>그 외 (혼재 · 하나 이상 IN_PROGRESS 존재) → {@link #IN_PROGRESS}</li>
+ * </ul>
+ *
+ * <p>DB 컬럼 없음 · 응답 DTO에만 노출. milestone.md V35 예약분은 파생 정책으로 인해 스킵 (SDD S6-4 준수).
+ */
+public enum LayerProgressStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayer.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayer.java
@@ -210,6 +210,39 @@ public class LearningLayer {
     }
 
     /**
+     * LT-E6-S6-4 (M5) — Layer 진행 상태 파생.
+     *
+     * <p>하위 axis의 {@link AxisProgressStatus}를 집계한 파생값. DB 컬럼 없음.
+     * SDD 규칙:
+     * <ul>
+     *   <li>활성 axis 0건 → NOT_STARTED (열린 질문 10 잠정 확정)</li>
+     *   <li>모두 NOT_STARTED → NOT_STARTED</li>
+     *   <li>모두 COMPLETED → COMPLETED</li>
+     *   <li>그 외 (하나 이상 IN_PROGRESS · 혼재) → IN_PROGRESS</li>
+     * </ul>
+     */
+    public LayerProgressStatus progressStatus() {
+        List<LearningAxis> active = getAxes();
+        if (active.isEmpty()) {
+            return LayerProgressStatus.NOT_STARTED;
+        }
+
+        boolean allNotStarted = active.stream()
+                .allMatch(a -> a.getProgressStatus() == AxisProgressStatus.NOT_STARTED);
+        if (allNotStarted) {
+            return LayerProgressStatus.NOT_STARTED;
+        }
+
+        boolean allCompleted = active.stream()
+                .allMatch(a -> a.getProgressStatus() == AxisProgressStatus.COMPLETED);
+        if (allCompleted) {
+            return LayerProgressStatus.COMPLETED;
+        }
+
+        return LayerProgressStatus.IN_PROGRESS;
+    }
+
+    /**
      * Layer 내 axis 순서 재배치. 전달 id 목록이 이 layer의 axis id 집합과 정확히 일치해야 함.
      */
     void reorderAxes(List<Long> orderedAxisIds) {

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeJpaRepository.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.LearningFacade.infrastructure.persistence;
 
 import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
 import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.domain.model.LearningLayer;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -41,6 +42,19 @@ public interface LearningFacadeJpaRepository extends JpaRepository<LearningFacad
      */
     @Query("SELECT a.facade.user.id FROM LearningAxis a WHERE a.id = :axisId")
     Optional<Long> findUserIdByAxisId(@Param("axisId") Long axisId);
+
+    /**
+     * LT-E6-S6-3 (M5) — layerId로 LearningLayer 단건 조회.
+     * @SQLRestriction 자동 필터 적용.
+     */
+    @Query("SELECT l FROM LearningLayer l WHERE l.id = :layerId")
+    Optional<LearningLayer> findLayerById(@Param("layerId") Long layerId);
+
+    /**
+     * LT-E6-S6-3 (M5) — layerId로 소유 사용자 id 조회 (layer→facade→user).
+     */
+    @Query("SELECT l.facade.user.id FROM LearningLayer l WHERE l.id = :layerId")
+    Optional<Long> findUserIdByLayerId(@Param("layerId") Long layerId);
 
     interface AxisIdNameProjection {
         Long getId();

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepository.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepository.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.LearningFacade.infrastructure.persistence;
 
 import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
 import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.domain.model.LearningLayer;
 
 import java.util.Collection;
 import java.util.Map;
@@ -34,4 +35,15 @@ public interface LearningFacadeRepository {
      * axis→facade→user 경로로 이관.
      */
     Optional<Long> findUserIdByAxisId(Long axisId);
+
+    /**
+     * LT-E6-S6-3 (M5) — layerId로 LearningLayer 단건 조회.
+     * @SQLRestriction("deleted_at IS NULL") 자동 필터 적용.
+     */
+    Optional<LearningLayer> findLayerById(Long layerId);
+
+    /**
+     * LT-E6-S6-3 (M5) — layerId로 소유 사용자 id 조회 (layer→facade→user 경로).
+     */
+    Optional<Long> findUserIdByLayerId(Long layerId);
 }

--- a/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/LearningFacade/infrastructure/persistence/LearningFacadeRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.example.thirdtool.LearningFacade.infrastructure.persistence;
 
 import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
 import com.example.thirdtool.LearningFacade.domain.model.LearningFacade;
+import com.example.thirdtool.LearningFacade.domain.model.LearningLayer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -52,5 +53,15 @@ public class LearningFacadeRepositoryAdapter implements LearningFacadeRepository
     @Override
     public Optional<Long> findUserIdByAxisId(Long axisId) {
         return jpa.findUserIdByAxisId(axisId);
+    }
+
+    @Override
+    public Optional<LearningLayer> findLayerById(Long layerId) {
+        return jpa.findLayerById(layerId);
+    }
+
+    @Override
+    public Optional<Long> findUserIdByLayerId(Long layerId) {
+        return jpa.findUserIdByLayerId(layerId);
     }
 }

--- a/src/main/java/com/example/thirdtool/Review/application/ReviewCommandService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/ReviewCommandService.java
@@ -5,6 +5,7 @@ import com.example.thirdtool.Card.domain.model.Card;
 import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
 import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
 import com.example.thirdtool.LearningFacade.domain.model.LearningAxis;
+import com.example.thirdtool.LearningFacade.domain.model.LearningLayer;
 import com.example.thirdtool.LearningFacade.infrastructure.persistence.LearningFacadeRepository;
 import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
 import com.example.thirdtool.Review.domain.model.ReviewSession;
@@ -68,6 +69,41 @@ public class ReviewCommandService {
         reviewSessionRepository.save(session);
 
         // 첫 번째 카드 진입 처리 (viewCount 증가만). Archive 판정은 M5로 이관.
+        recordViewOnCurrent(session);
+
+        return ReviewResponse.StartSession.of(session, false);
+    }
+
+    // ─── 1-b. LAYER 스코프 세션 시작 (LT-E6-S6-3 · M5) ───
+    // 궤적 관리: PR#4 (Review E2)가 issue-25 supersede로 폐기 예정.
+
+    public ReviewResponse.StartSession startLayerReview(Long layerId, UserEntity user) {
+        LearningLayer layer = learningFacadeRepository.findLayerById(layerId)
+                .orElseThrow(() -> ReviewSessionException.of(
+                        ErrorCode.LEARNING_LAYER_NOT_FOUND, "layerId=" + layerId));
+
+        Long ownerId = learningFacadeRepository.findUserIdByLayerId(layerId)
+                .orElseThrow(() -> ReviewSessionException.of(
+                        ErrorCode.LEARNING_LAYER_NOT_FOUND, "layerId=" + layerId));
+        if (!ownerId.equals(user.getId())) {
+            throw ReviewSessionException.of(ErrorCode.LAYER_REVIEW_ACCESS_DENIED);
+        }
+
+        List<Long> axisIds = layer.getAxes().stream().map(LearningAxis::getId).toList();
+        if (axisIds.isEmpty()) {
+            throw ReviewSessionException.of(ErrorCode.LAYER_HAS_NO_AXES, "layerId=" + layerId);
+        }
+
+        // Card BC 이관 조회 · axisId in-list 스코프
+        List<Card> cards = cardRepository.findByUserIdAndAxisIdsAndStatus(
+                user.getId(), axisIds,
+                com.example.thirdtool.Card.domain.model.CardStatus.ON_FIELD);
+
+        // 카드 0개 검증은 ReviewSession.ofLayer() 내부 · REVIEW002
+        ReviewSession session = ReviewSession.ofLayer(layerId, cards, user, cards.size());
+        reviewSessionRepository.save(session);
+
+        // 첫 카드 view 기록 (기존 흐름과 동일)
         recordViewOnCurrent(session);
 
         return ReviewResponse.StartSession.of(session, false);

--- a/src/main/java/com/example/thirdtool/Review/domain/model/ReviewScope.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/ReviewScope.java
@@ -1,0 +1,23 @@
+package com.example.thirdtool.Review.domain.model;
+
+/**
+ * ReviewSession 스코프 (LT E6 · M5 · Story 6-1).
+ *
+ * <p>사용자가 리뷰 세션을 시작하는 대상 범위:
+ * <ul>
+ *   <li>{@link #AXIS} — 단일 LearningAxis 스코프 · 기존 흐름</li>
+ *   <li>{@link #LAYER} — LearningLayer 하위 여러 axis 카드를 통합한 세션 (신설)</li>
+ * </ul>
+ *
+ * <p>ReviewSession의 {@code scopeId} 필드가 각 스코프의 대상 id를 담는다.
+ *
+ * <p>궤적 관리 (milestone.md § M5 PR#2 리스크):
+ * S6-1·S6-2·S6-3의 scope enum·엔드포인트는 후속 issue-25 supersede로 PR#4 (Review E2)가 폐기 예정.
+ * cross-layer 짬뽕 큐 방향으로 재편 · DailyLearningBatch 기반 통합 흐름 예정.
+ *
+ * <p>저장 방식: {@code @Enumerated(EnumType.STRING)} + VARCHAR(10) CHECK 제약 (ADR002).
+ */
+public enum ReviewScope {
+    AXIS,
+    LAYER
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/ReviewSession.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/ReviewSession.java
@@ -36,9 +36,26 @@ public class ReviewSession {
     /**
      * LT-E5-S5-3 (M5) — 세션이 소속된 Axis 직접 참조 (raw Long).
      * BC 간 직접 객체 참조 회피 (docs/PACKAGE.md §6).
+     * <p>LT-E6-S6-1 (M5) — scope 도입 후 이 필드는 scope=AXIS일 때만 유효.
+     * scope=LAYER 세션은 axisId=null (V34에서 nullable 승격).
      */
-    @Column(name = "axis_id", nullable = false)
+    @Column(name = "axis_id", nullable = true)
     private Long axisId;
+
+    /**
+     * LT-E6-S6-1 (M5) — 리뷰 스코프 (AXIS / LAYER).
+     * 궤적 관리: PR#4 (Review E2)가 issue-25 supersede로 폐기 예정.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "scope", nullable = false, length = 10)
+    private ReviewScope scope = ReviewScope.AXIS;
+
+    /**
+     * LT-E6-S6-1 (M5) — scope 대상 id.
+     * scope=AXIS → axisId 동일 · scope=LAYER → layerId.
+     */
+    @Column(name = "scope_id", nullable = false)
+    private Long scopeId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -69,8 +86,16 @@ public class ReviewSession {
 
     /**
      * LT-E5-S5-3 (M5) blessed — axisId 직접 주입.
+     * <p>LT-E6-S6-1 (M5) — scope=AXIS · scopeId=axisId 자동 세팅. {@link #ofAxis} 알리아스.
      */
     public static ReviewSession of(Long axisId, List<Card> availableCards, UserEntity user, int totalCardCount) {
+        return ofAxis(axisId, availableCards, user, totalCardCount);
+    }
+
+    /**
+     * LT-E6-S6-1 (M5) — AXIS 스코프 세션 생성.
+     */
+    public static ReviewSession ofAxis(Long axisId, List<Card> availableCards, UserEntity user, int totalCardCount) {
         if (axisId == null) {
             throw new IllegalArgumentException("ReviewSession 생성 실패: axisId는 null일 수 없습니다.");
         }
@@ -79,6 +104,37 @@ public class ReviewSession {
 
         ReviewSession session        = new ReviewSession();
         session.axisId               = axisId;
+        session.scope                = ReviewScope.AXIS;
+        session.scopeId              = axisId;
+        session.user                 = user;
+        session.currentIndex         = 0;
+        session.finished             = false;
+        session.totalCardCount       = totalCardCount;
+        session.availableCardCount   = availableCards.size();
+        session.startedAt            = LocalDateTime.now();
+
+        for (int i = 0; i < availableCards.size(); i++) {
+            session.cardReviews.add(CardReview.of(availableCards.get(i), session, i));
+        }
+
+        return session;
+    }
+
+    /**
+     * LT-E6-S6-1 (M5) — LAYER 스코프 세션 생성.
+     * 여러 axis 카드가 통합된 큐. axisId는 null (LAYER 스코프에서 무의미).
+     */
+    public static ReviewSession ofLayer(Long layerId, List<Card> availableCards, UserEntity user, int totalCardCount) {
+        if (layerId == null) {
+            throw new IllegalArgumentException("ReviewSession 생성 실패: layerId는 null일 수 없습니다.");
+        }
+        validateUser(user);
+        validateCards(availableCards);
+
+        ReviewSession session        = new ReviewSession();
+        session.axisId               = null;  // LAYER 스코프는 특정 axis에 종속되지 않음
+        session.scope                = ReviewScope.LAYER;
+        session.scopeId              = layerId;
         session.user                 = user;
         session.currentIndex         = 0;
         session.finished             = false;

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/ReviewSessionRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/ReviewSessionRepository.java
@@ -1,6 +1,7 @@
 package com.example.thirdtool.Review.infrastructure;
 
 
+import com.example.thirdtool.Review.domain.model.ReviewScope;
 import com.example.thirdtool.Review.domain.model.ReviewSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,9 +14,35 @@ public interface ReviewSessionRepository
     // 특정 사용자의 전체 세션 목록 (최신순 정렬은 QueryDSL로 처리)
     List<ReviewSession> findByUserId(Long userId);
 
-    // 특정 덱의 세션 목록
+    /**
+     * @deprecated LT-E5-S5-3 (M5) · Deck 폐기 대기. axis 스코프 조회로 이관.
+     */
+    @Deprecated
     List<ReviewSession> findByDeckId(Long deckId);
 
-    // 특정 사용자 + 특정 덱의 세션 (가장 최근 세션 조회용)
+    /**
+     * @deprecated LT-E5-S5-3 (M5) · Deck 폐기 대기.
+     */
+    @Deprecated
     Optional<ReviewSession> findTopByUserIdAndDeckIdOrderByStartedAtDesc(Long userId, Long deckId);
+
+    /**
+     * LT-E6-S6-2 (M5) — AXIS 스코프 세션 조회.
+     * Spring Data 명명 규칙: WHERE scope = ? AND scopeId = ?
+     */
+    List<ReviewSession> findAllByScopeAndScopeId(ReviewScope scope, Long scopeId);
+
+    /**
+     * LT-E6-S6-2 (M5) — AXIS 스코프 편의 메서드.
+     */
+    default List<ReviewSession> findAllByAxisId(Long axisId) {
+        return findAllByScopeAndScopeId(ReviewScope.AXIS, axisId);
+    }
+
+    /**
+     * LT-E6-S6-2 (M5) — LAYER 스코프 편의 메서드.
+     */
+    default List<ReviewSession> findAllByLayerId(Long layerId) {
+        return findAllByScopeAndScopeId(ReviewScope.LAYER, layerId);
+    }
 }

--- a/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/ReviewController.java
@@ -35,6 +35,18 @@ public class ReviewController {
                 .body(reviewCommandService.startReview(request, currentUser));
     }
 
+    // ─── 1-b. LAYER 스코프 리뷰 세션 시작 (LT-E6-S6-3 · M5) ─
+    // 궤적 관리: PR#4 (Review E2)가 issue-25 supersede로 폐기 예정.
+    @PostMapping("/api/v1/layers/{layerId}/review-sessions")
+    public ResponseEntity<ReviewResponse.StartSession> startLayerReview(
+            @PathVariable Long layerId,
+            @AuthenticationPrincipal UserEntity currentUser
+                                                                       ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(reviewCommandService.startLayerReview(layerId, currentUser));
+    }
+
     // ─── 2. 세션 단건 조회 ────────────────────────────────
     @GetMapping("/api/v1/reviews/{sessionId}")
     public ResponseEntity<ReviewResponse.SessionDetail> findById(

--- a/src/main/resources/db/migration/R34__rollback_review_session_scope.sql
+++ b/src/main/resources/db/migration/R34__rollback_review_session_scope.sql
@@ -1,0 +1,16 @@
+-- R34__rollback_review_session_scope.sql
+-- Rollback for V34 (LT E6 · M5 · Story 6-1)
+
+-- ─── Step 1: 인덱스 삭제 ──────────────────────────────────
+DROP INDEX idx_review_session_scope ON review_session;
+
+-- ─── Step 2: axis_id NOT NULL 복원 (LAYER 세션 삭제 후) ──
+DELETE FROM review_session WHERE axis_id IS NULL;
+ALTER TABLE review_session MODIFY COLUMN axis_id BIGINT NOT NULL;
+
+-- ─── Step 3: CHECK 제약 삭제 ─────────────────────────────
+ALTER TABLE review_session DROP CONSTRAINT chk_review_session_scope;
+
+-- ─── Step 4: 컬럼 삭제 ────────────────────────────────────
+ALTER TABLE review_session DROP COLUMN scope_id;
+ALTER TABLE review_session DROP COLUMN scope;

--- a/src/main/resources/db/migration/V34__review_session_scope.sql
+++ b/src/main/resources/db/migration/V34__review_session_scope.sql
@@ -1,0 +1,45 @@
+-- V34__review_session_scope.sql
+-- LT E6 · M5 · Story 6-1 · ReviewSession 이중 스코프 확장 (AXIS/LAYER)
+--
+-- 근거:
+--   · SDD: product-learning-tower.md Epic 6 Story 6-1 (line 2184~2238)
+--   · 이슈: issue-14-review-strategy-axis-layer-scope.md
+--   · 궤적 관리: M5 PR#4 (Review E2)가 issue-25 supersede로 폐기 예정 (cross-layer 짬뽕 큐)
+--     · milestone.md § M5 리스크 명시: V34 심은 scope·scopeId는 V37이 폐기 예정
+--
+-- 정책: axis_id는 nullable로 완화 (LAYER 스코프 세션은 axis_id=null).
+--   기존 세션은 백필로 scope=AXIS, scope_id=axis_id 세팅.
+
+-- ─── Step 1: scope · scope_id 컬럼 추가 (default로 즉시 NOT NULL 가능) ─
+ALTER TABLE review_session
+    ADD COLUMN scope    VARCHAR(10) NOT NULL DEFAULT 'AXIS' AFTER axis_id,
+    ADD COLUMN scope_id BIGINT      NOT NULL DEFAULT 0      AFTER scope;
+
+-- ─── Step 2: CHECK 제약 (ADR002) ─────────────────────────
+ALTER TABLE review_session
+    ADD CONSTRAINT chk_review_session_scope
+        CHECK (scope IN ('AXIS', 'LAYER'));
+
+-- ─── Step 3: 기존 세션 백필 (scope=AXIS · scope_id=axis_id) ─
+UPDATE review_session
+   SET scope    = 'AXIS',
+       scope_id = axis_id
+ WHERE axis_id IS NOT NULL AND scope_id = 0;
+
+-- ─── Step 4: axis_id NULL 허용 (LAYER 스코프 대비) ───────
+ALTER TABLE review_session
+    MODIFY COLUMN axis_id BIGINT NULL;
+
+-- ─── Step 5: 인덱스 (scope, scope_id) 커버링 조회 ────────
+CREATE INDEX idx_review_session_scope ON review_session (scope, scope_id);
+
+-- ─── 검증 SQL ─────────────────────────────────────────────
+-- (a) 컬럼 존재
+-- SHOW COLUMNS FROM review_session WHERE Field IN ('scope', 'scope_id', 'axis_id');
+--
+-- (b) 백필 정합 (기존 AXIS 세션은 scope_id == axis_id)
+-- SELECT COUNT(*) FROM review_session WHERE scope = 'AXIS' AND scope_id != axis_id;
+-- 예상: 0
+--
+-- (c) 인덱스
+-- SHOW INDEX FROM review_session WHERE Key_name = 'idx_review_session_scope';

--- a/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayerProgressStatusTest.java
+++ b/src/test/java/com/example/thirdtool/LearningFacade/domain/model/LearningLayerProgressStatusTest.java
@@ -1,0 +1,101 @@
+package com.example.thirdtool.LearningFacade.domain.model;
+
+import com.example.thirdtool.User.domain.model.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * LearningLayer.progressStatus() 도메인 파생 메서드 단위 테스트 (LT E6 · M5 · Story 6-4).
+ *
+ * <p>SDD 규칙 4 케이스 모두 검증:
+ * <ul>
+ *   <li>축 0건 → NOT_STARTED</li>
+ *   <li>모두 NOT_STARTED → NOT_STARTED</li>
+ *   <li>모두 COMPLETED → COMPLETED</li>
+ *   <li>혼재 · IN_PROGRESS 존재 → IN_PROGRESS</li>
+ * </ul>
+ */
+@DisplayName("LearningLayer.progressStatus 파생 (LT E6 · Story 6-4)")
+class LearningLayerProgressStatusTest {
+
+    private LearningFacade facade;
+    private LearningLayer layer;
+
+    @BeforeEach
+    void setUp() {
+        UserEntity user = UserEntity.ofLocal(
+                "tester", "encoded-pw", "닉네임", "tester@example.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        facade = LearningFacade.create(user, "백엔드 개발자");
+        // default Uncategorized layer 첫 진입점 사용
+        layer = facade.getLayers().get(0);
+    }
+
+    @Nested
+    @DisplayName("파생 규칙 (SDD)")
+    class DerivationRules {
+
+        @Test
+        @DisplayName("해피: 활성 axis 0건 → NOT_STARTED (열린 질문 10 잠정)")
+        void 축0건_NOT_STARTED() {
+            assertThat(layer.getAxes()).isEmpty();
+
+            assertThat(layer.progressStatus()).isEqualTo(LayerProgressStatus.NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("해피: 모든 axis가 NOT_STARTED → NOT_STARTED")
+        void 모두NOT_STARTED_NOT_STARTED() {
+            LearningAxis a1 = layer.addAxis("API 설계");
+            LearningAxis a2 = layer.addAxis("DB 모델링");
+            // 초기 progressStatus는 NOT_STARTED default
+
+            assertThat(a1.getProgressStatus()).isEqualTo(AxisProgressStatus.NOT_STARTED);
+            assertThat(a2.getProgressStatus()).isEqualTo(AxisProgressStatus.NOT_STARTED);
+            assertThat(layer.progressStatus()).isEqualTo(LayerProgressStatus.NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("해피: 모든 axis가 COMPLETED → COMPLETED")
+        void 모두COMPLETED_COMPLETED() {
+            LearningAxis a1 = layer.addAxis("API 설계");
+            LearningAxis a2 = layer.addAxis("DB 모델링");
+            a1.recalculateProgressStatus(0, 5); // COMPLETED
+            a2.recalculateProgressStatus(0, 3); // COMPLETED
+
+            assertThat(a1.getProgressStatus()).isEqualTo(AxisProgressStatus.COMPLETED);
+            assertThat(a2.getProgressStatus()).isEqualTo(AxisProgressStatus.COMPLETED);
+            assertThat(layer.progressStatus()).isEqualTo(LayerProgressStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("해피: 하나 이상 IN_PROGRESS → IN_PROGRESS")
+        void 하나IN_PROGRESS_IN_PROGRESS() {
+            LearningAxis a1 = layer.addAxis("API 설계");
+            LearningAxis a2 = layer.addAxis("DB 모델링");
+            LearningAxis a3 = layer.addAxis("테스트 전략");
+            a1.recalculateProgressStatus(3, 0); // IN_PROGRESS
+            a2.recalculateProgressStatus(0, 5); // COMPLETED
+            // a3는 NOT_STARTED
+
+            assertThat(layer.progressStatus()).isEqualTo(LayerProgressStatus.IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("엣지: NOT_STARTED · COMPLETED 혼재 (IN_PROGRESS 없음) → IN_PROGRESS")
+        void 혼재_IN_PROGRESS() {
+            LearningAxis a1 = layer.addAxis("API 설계");
+            LearningAxis a2 = layer.addAxis("DB 모델링");
+            a2.recalculateProgressStatus(0, 5); // COMPLETED
+            // a1은 NOT_STARTED
+
+            // SDD 규칙: "모두 NOT_STARTED" 도 "모두 COMPLETED" 도 아니므로 IN_PROGRESS
+            assertThat(layer.progressStatus()).isEqualTo(LayerProgressStatus.IN_PROGRESS);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

M5 (0.0.5v) Epic PR #2 — LT Epic 6 (Review 이중 스코프) 완주. ReviewSession에 AXIS/LAYER scope enum + scopeId 필드 추가 · Layer 스코프 세션 엔드포인트 신설 · Layer.progressStatus 파생 · FE 용어 매핑.

## 왜 / 설계 결정

- **SDD 우선 정책** (사용자 지시): \`product-learning-tower.md\` Epic 6 (line 2139~2409) · issue-14 원안 착지
- **궤적 관리 (SDD 명시 · milestone.md § M5 PR#2 리스크)**: S6-1·S6-2·S6-3의 scope enum·엔드포인트는 후속 issue-25 supersede로 **M5 PR#4 (Review E2)가 V37에서 폐기 예정**. cross-layer 짬뽕 큐 (DailyLearningBatch) 방향 재편. 실제 코드 궤적 그대로 재현.
- **V35 스킵 결정**: SDD S6-4 명시 "Layer 자체 progressStatus 컬럼 없음 · 도메인 파생 메서드" → V35 필요 없음. milestone.md V35 예약분은 파생 정책으로 스킵. \`LayerProgressStatus\` 는 응답 DTO에만 노출.
- **axis_id nullable 완화**: LAYER 스코프 세션은 특정 axis에 종속되지 않음 · V34에서 nullable 승격.

## 작업 내용

### Story 6-1 · ReviewScope enum + V34
- feat(review): \`ReviewScope { AXIS, LAYER }\` enum 신설
- feat(review): ReviewSession \`scope\`·\`scopeId\` 필드 추가 · axisId nullable 완화
- feat(review): \`ReviewSession.ofAxis(axisId, ...)\` · \`ofLayer(layerId, ...)\` blessed 팩토리 신설 (기존 \`of\`는 \`ofAxis\` 알리아스)
- feat(learning-facade): Flyway V34/R34 \`review_session_scope.sql\` · CHECK 제약 + 인덱스 + 백필 (scope=AXIS · scope_id=axis_id)

### Story 6-2 · Repository 이중 조회
- feat(review): \`findAllByScopeAndScopeId(scope, scopeId)\` Spring Data 명명 규칙
- feat(review): \`findAllByAxisId\` · \`findAllByLayerId\` default 편의 메서드
- 기존 \`findByDeckId\` · \`findTopByUserIdAndDeckIdOrderByStartedAtDesc\` @Deprecated

### Story 6-3 · POST /layers/{layerId}/review-sessions
- feat(review): ReviewController.startLayerReview 엔드포인트 신설
- feat(review): ReviewCommandService.startLayerReview 구현 · Layer 소유권 · axis 목록 조회 · 카드 통합 · ofLayer 세션
- feat(common-core): ErrorCode 3종 신설 — \`LAYER_HAS_NO_AXES\` (LL008) · \`LAYER_REVIEW_ACCESS_DENIED\` (LL009) · \`REVIEW_SCOPE_INVALID\` (LL010)
- feat(learning-facade): LearningFacadeRepository β 확장 — \`findLayerById\` · \`findUserIdByLayerId\` (Adapter delegation 포함)

### Story 6-4 · Layer.progressStatus 파생
- feat(learning-facade): \`LayerProgressStatus\` enum 신설
- feat(learning-facade): \`LearningLayer.progressStatus()\` 도메인 파생 메서드
- SDD 규칙: 축 0건 → NOT_STARTED · 모두 NOT_STARTED → NOT_STARTED · 모두 COMPLETED → COMPLETED · 그 외 → IN_PROGRESS
- test(learning-facade): LearningLayerProgressStatusTest 5 케이스 (해피 4 · 엣지 1 혼재)

### Story 6-5 · FE 용어 대체
- docs(ux): docs/ux/wip-language.md §8 추가 · ReviewScope · LayerProgressStatus 라벨 매핑
- "Layer 1" 대체 · "그룹 리뷰: {layerName}" 명시

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [x] docs  - [x] test  - [ ] chore

## 테스트

- \`./gradlew test\` → **BUILD SUCCESSFUL**
- \`LearningLayerProgressStatusTest\` 5 케이스 통과

## 궤적 관리 (다음 PR 예정)

**M5 PR#4 (Review E2)에서 supersede 예정**:
- ReviewSession \`scope\`·\`scopeId\` 컬럼 폐기 (V37 예정)
- \`POST /layers/{id}/review-sessions\` 엔드포인트 폐기
- \`findAllByScopeAndScopeId\` Repository 메서드 폐기
- cross-layer 짬뽕 큐로 재편 (DailyLearningBatch 기반)

**의도적 궤적 착지 근거**: issue-14 원안 → issue-25 supersede의 실제 코드 이력 재현 · Learning History 유지 · milestone.md § M5 PR#2 리스크 섹션 명시.

## 체크리스트

- [x] 빌드 / 테스트 통과 (BUILD SUCCESSFUL)
- [x] 모든 응답 ApiResponse<T> 래퍼 유지
- [x] BC 간 의존 방향 위반 없음
- [x] Base 브랜치 = develop 확인
- [x] ErrorCode 신설 3종 등록 · GlobalExceptionHandler 자동 처리

## 관련 이슈

- Product: workflow/task/pes/workspectrum/sdd/in-progress/product-learning-tower.md
- Epic 6: line 2139~2409 (Review 이중 스코프 · AXIS / LAYER)
- Story 6-1 (line 2184) · S6-2 (line 2242) · S6-3 (line 2281) · S6-4 (line 2329) · S6-5 (line 2372)
- 상위 이슈: fix/brainstorming/0.0.2v/issue-14-review-strategy-axis-layer-scope.md
- Supersede: fix/brainstorming/0.0.2v/issue-25-review-cross-layer-scope.md (M5 PR#4)
- Milestone: workflow/task/milestones/version/0.0.5v/milestone.md § Epic PR #2