### PR TITLE
feat(review,card): DailyLearningBatch Aggregate + 자정 close cron + streak realtime [Epic-REV-E1-M5-PR3]

### DIFF
--- a/src/main/generated/com/example/thirdtool/Review/domain/model/QDailyCardEntry.java
+++ b/src/main/generated/com/example/thirdtool/Review/domain/model/QDailyCardEntry.java
@@ -1,0 +1,59 @@
+package com.example.thirdtool.Review.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDailyCardEntry is a Querydsl query type for DailyCardEntry
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDailyCardEntry extends EntityPathBase<DailyCardEntry> {
+
+    private static final long serialVersionUID = -110410430L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QDailyCardEntry dailyCardEntry = new QDailyCardEntry("dailyCardEntry");
+
+    public final QDailyLearningBatch batch;
+
+    public final NumberPath<Long> cardId = createNumber("cardId", Long.class);
+
+    public final NumberPath<Integer> cardIntervalDay = createNumber("cardIntervalDay", Integer.class);
+
+    public final DateTimePath<java.time.LocalDateTime> exposedAt = createDateTime("exposedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> viewedAt = createDateTime("viewedAt", java.time.LocalDateTime.class);
+
+    public QDailyCardEntry(String variable) {
+        this(DailyCardEntry.class, forVariable(variable), INITS);
+    }
+
+    public QDailyCardEntry(Path<? extends DailyCardEntry> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QDailyCardEntry(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QDailyCardEntry(PathMetadata metadata, PathInits inits) {
+        this(DailyCardEntry.class, metadata, inits);
+    }
+
+    public QDailyCardEntry(Class<? extends DailyCardEntry> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.batch = inits.isInitialized("batch") ? new QDailyLearningBatch(forProperty("batch")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/Review/domain/model/QDailyLearningBatch.java
+++ b/src/main/generated/com/example/thirdtool/Review/domain/model/QDailyLearningBatch.java
@@ -1,0 +1,50 @@
+package com.example.thirdtool.Review.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDailyLearningBatch is a Querydsl query type for DailyLearningBatch
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDailyLearningBatch extends EntityPathBase<DailyLearningBatch> {
+
+    private static final long serialVersionUID = 2057630908L;
+
+    public static final QDailyLearningBatch dailyLearningBatch = new QDailyLearningBatch("dailyLearningBatch");
+
+    public final DatePath<java.time.LocalDate> batchDate = createDate("batchDate", java.time.LocalDate.class);
+
+    public final DateTimePath<java.time.LocalDateTime> closedAt = createDateTime("closedAt", java.time.LocalDateTime.class);
+
+    public final ListPath<DailyCardEntry, QDailyCardEntry> entries = this.<DailyCardEntry, QDailyCardEntry>createList("entries", DailyCardEntry.class, QDailyCardEntry.class, PathInits.DIRECT2);
+
+    public final DateTimePath<java.time.LocalDateTime> generatedAt = createDateTime("generatedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public final EnumPath<com.example.thirdtool.UserSchedule.domain.model.LearningMode> userModeAtGeneration = createEnum("userModeAtGeneration", com.example.thirdtool.UserSchedule.domain.model.LearningMode.class);
+
+    public QDailyLearningBatch(String variable) {
+        super(DailyLearningBatch.class, forVariable(variable));
+    }
+
+    public QDailyLearningBatch(Path<? extends DailyLearningBatch> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QDailyLearningBatch(PathMetadata metadata) {
+        super(DailyLearningBatch.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/thirdtool/Card/application/service/CardCommandService.java
+++ b/src/main/java/com/example/thirdtool/Card/application/service/CardCommandService.java
@@ -186,6 +186,29 @@ public class CardCommandService {
         return CardResponse.Detail.of(card);
     }
 
+    // ─── REV E1 · Story 1-4 · 다건 archive orchestration ─
+    /**
+     * REV E1 · M5 · Story 1-4 — DailyLearningBatch generation 시 exhausted 카드 일괄 archive.
+     * Aggregate가 다른 BC를 호출하지 않는 원칙 준수 · Application Service 조율.
+     */
+    public void archiveMany(List<Long> cardIds, ArchiveReason reason) {
+        if (reason == null) {
+            throw CardDomainException.of(ErrorCode.INVALID_INPUT, "archiveMany: reason은 null일 수 없습니다.");
+        }
+        if (cardIds == null || cardIds.isEmpty()) return;
+
+        for (Long cardId : cardIds) {
+            Card card = cardRepository.findById(cardId).orElse(null);
+            if (card == null || card.isDeleted()) continue;
+            CardStatus fromStatus = card.getStatus();
+            card.archive();
+            if (fromStatus != card.getStatus()) {
+                cardStatusHistoryAppender.append(card, fromStatus, card.getStatus(), reason);
+                recalculateAxisProgress(card.getAxisId());
+            }
+        }
+    }
+
     // ─── 13. 카드 삭제 (Soft Delete) ──────────────────────
 
     public void softDelete(Long cardId) {

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -70,6 +70,10 @@ public enum ErrorCode {
     REVIEW_SESSION_ALREADY_FINISHED("REVIEW003", "이미 종료된 리뷰 세션입니다.", HttpStatus.BAD_REQUEST),
     REVIEW_COMPARING_REQUIRED("REVIEW004", "현재 카드를 먼저 비교(COMPARING) 단계로 전환해야 다음으로 이동할 수 있습니다.", HttpStatus.BAD_REQUEST),
     REVIEW_SESSION_FORBIDDEN("REVIEW005", "본인의 리뷰 세션이 아닙니다.", HttpStatus.FORBIDDEN),
+    // ─── Daily Batch (REV E1 · M5) ─────────────────────────
+    DAILY_BATCH_NOT_FOUND("DAILY001",   "일일 학습 배치를 찾을 수 없습니다.",                 HttpStatus.NOT_FOUND),
+    DAILY_BATCH_CLOSED("DAILY002",      "오늘 학습 세션이 종료되었습니다.",                    HttpStatus.CONFLICT),
+    DAILY_BATCH_FORBIDDEN("DAILY003",   "본인의 일일 배치가 아닙니다.",                        HttpStatus.FORBIDDEN),
 
     // ─── LearningFacade ───────────────────────────────────
     LEARNING_FACADE_NOT_FOUND("LF001",       "LearningFacade를 찾을 수 없습니다.",   HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/thirdtool/Review/application/scheduler/DailyBatchCloseScheduler.java
+++ b/src/main/java/com/example/thirdtool/Review/application/scheduler/DailyBatchCloseScheduler.java
@@ -1,0 +1,50 @@
+package com.example.thirdtool.Review.application.scheduler;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.infrastructure.DailyLearningBatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * REV E1 · M5 · Story 1-5 — 자정 close cron.
+ *
+ * <p>매일 00:05 KST에 어제 open 상태 batch를 모두 close.
+ * 원칙: "그날 못 본 카드 = 그냥 지나감".
+ * 멱등: 이미 closed batch에 대해서는 no-op.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DailyBatchCloseScheduler {
+
+    private final DailyLearningBatchRepository repository;
+
+    /**
+     * Cron: 매일 00:05 KST (`0 5 0 * * *`).
+     */
+    @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void closeYesterdaysBatches() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<DailyLearningBatch> openBatches = repository.findAllOpenByBatchDate(yesterday);
+
+        if (openBatches.isEmpty()) {
+            log.info("[DailyBatchCloseScheduler] 어제({}) open batch 없음 · no-op", yesterday);
+            return;
+        }
+
+        LocalDateTime closedAt = LocalDateTime.now();
+        for (DailyLearningBatch batch : openBatches) {
+            batch.close(closedAt);
+            repository.save(batch);
+        }
+        log.info("[DailyBatchCloseScheduler] 어제({}) {}건 close 완료", yesterday, openBatches.size());
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/application/service/DailyLearningBatchService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/service/DailyLearningBatchService.java
@@ -1,0 +1,100 @@
+package com.example.thirdtool.Review.application.service;
+
+import com.example.thirdtool.Card.application.service.CardCommandService;
+import com.example.thirdtool.Card.domain.model.ArchiveReason;
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Card.infrastructure.persistence.CardRepository;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.infrastructure.DailyLearningBatchRepository;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * DailyLearningBatchService — Story 1-3 + 1-4 통합.
+ *
+ * <p>Lazy 생성 · markViewed · queryHistory · generateFor 조율.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyLearningBatchService {
+
+    private final DailyLearningBatchRepository repository;
+    private final CardRepository cardRepository;
+    private final CardCommandService cardCommandService;
+    private final UserScheduleQueryService userScheduleQueryService;
+
+    /**
+     * Story 1-3 + 1-4 — 오늘 batch 조회 · 없으면 lazy 생성 · exhausted 카드 자동 archive.
+     */
+    public DailyLearningBatch getOrCreateToday(Long userId) {
+        LocalDate today = LocalDate.now();
+        return repository.findByUserIdAndBatchDate(userId, today)
+                .orElseGet(() -> generateAndPersist(userId, today));
+    }
+
+    private DailyLearningBatch generateAndPersist(Long userId, LocalDate today) {
+        LearningMode userMode = userScheduleQueryService.currentMode(userId);
+        // 사용자의 활성 ON_FIELD 카드 전체 (도메인이 due/exhausted 판정)
+        List<Card> allActive = cardRepository.findOnFieldEligibleByUserId(userId, LocalDateTime.MAX);
+
+        DailyLearningBatch.GenerationResult result = DailyLearningBatch.generateFor(
+                userId, today, userMode, allActive);
+
+        DailyLearningBatch saved = repository.save(result.batch());
+
+        // Story 1-4 · exhausted 카드 archive orchestration
+        if (!result.exhaustedCards().isEmpty()) {
+            List<Long> exhaustedIds = result.exhaustedCards().stream().map(Card::getId).toList();
+            // Reason 판정 (SDD § Story 1-4)
+            // createdMode.maxDays() > userCurrentMode.maxDays() → MODE_DOWNGRADED · else SCHEDULE_EXHAUSTED
+            // 단순화: 첫 카드 기준 판정. 실제 다중 reason은 v0.1.1v 정교화.
+            ArchiveReason reason = result.exhaustedCards().stream()
+                    .findFirst()
+                    .filter(c -> c.getCreatedMode().maxDays() > userMode.maxDays())
+                    .map(c -> ArchiveReason.MODE_DOWNGRADED)
+                    .orElse(ArchiveReason.SCHEDULE_EXHAUSTED);
+            cardCommandService.archiveMany(exhaustedIds, reason);
+        }
+
+        return saved;
+    }
+
+    /**
+     * Story 1-3 · markViewed — 오늘 batch의 카드 view 기록.
+     * closed 상태면 DAILY_BATCH_CLOSED 예외.
+     */
+    public void markViewed(Long userId, Long cardId, LocalDateTime viewedAt) {
+        DailyLearningBatch batch = repository.findByUserIdAndBatchDate(userId, LocalDate.now())
+                .orElseThrow(() -> ReviewSessionException.of(
+                        ErrorCode.DAILY_BATCH_NOT_FOUND, "userId=" + userId));
+        batch.markViewed(cardId, viewedAt);
+        repository.save(batch);
+    }
+
+    /**
+     * Story 1-3 · queryHistory — 사용자 · 기간 batch 목록 (batchDate DESC).
+     */
+    public List<DailyLearningBatch> queryHistory(Long userId, LocalDate from, LocalDate to) {
+        return repository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, to);
+    }
+
+    public DailyLearningBatch findByIdOwned(Long batchId, Long userId) {
+        DailyLearningBatch batch = repository.findById(batchId)
+                .orElseThrow(() -> ReviewSessionException.of(
+                        ErrorCode.DAILY_BATCH_NOT_FOUND, "batchId=" + batchId));
+        if (!batch.isOwner(userId)) {
+            throw ReviewSessionException.of(ErrorCode.DAILY_BATCH_FORBIDDEN);
+        }
+        return batch;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/DailyCardEntry.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/DailyCardEntry.java
@@ -1,0 +1,74 @@
+package com.example.thirdtool.Review.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * DailyCardEntry — DailyLearningBatch 자식 Entity (REV E1 · M5 · Story 1-2).
+ *
+ * <p>batch 안 카드 노출·조회 이력을 담는 자식. DailyLearningBatch를 통해서만 생성·변경.
+ * UNIQUE (batch_id, card_id) — 하나의 batch 안에서 카드 중복 없음.
+ */
+@Entity
+@Table(
+        name = "daily_card_entry",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_entry_batch_card",
+                columnNames = {"batch_id", "card_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyCardEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batch_id", nullable = false)
+    private DailyLearningBatch batch;
+
+    @Column(name = "card_id", nullable = false)
+    private Long cardId;
+
+    @Column(name = "card_interval_day", nullable = false)
+    private int cardIntervalDay;
+
+    @Column(name = "exposed_at", nullable = false, updatable = false)
+    private LocalDateTime exposedAt;
+
+    @Column(name = "viewed_at")
+    private LocalDateTime viewedAt;
+
+    private DailyCardEntry(DailyLearningBatch batch, Long cardId, int cardIntervalDay) {
+        this.batch = batch;
+        this.cardId = cardId;
+        this.cardIntervalDay = cardIntervalDay;
+        this.exposedAt = LocalDateTime.now();
+        this.viewedAt = null;
+    }
+
+    /**
+     * REV E1 · Story 1-2 — batch 큐에 카드 노출 등록 (package-private · Aggregate 통해서만).
+     */
+    static DailyCardEntry expose(DailyLearningBatch batch, Long cardId, int cardIntervalDay) {
+        return new DailyCardEntry(batch, cardId, cardIntervalDay);
+    }
+
+    /**
+     * REV E1 · Story 1-2 — view 기록 (멱등 · 이미 viewed면 시각 유지).
+     */
+    void markViewed(LocalDateTime viewedAt) {
+        if (this.viewedAt != null) return;  // 멱등
+        this.viewedAt = viewedAt;
+    }
+
+    public boolean isViewed() {
+        return this.viewedAt != null;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/DailyLearningBatch.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/DailyLearningBatch.java
@@ -1,0 +1,190 @@
+package com.example.thirdtool.Review.domain.model;
+
+import com.example.thirdtool.Card.domain.model.Card;
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * DailyLearningBatch — 하루당 1개 Aggregate Root (REV E1 · M5 · Story 1-2).
+ *
+ * <p>사용자별 그날 학습 큐(cross-layer 짬뽕) · 진행 상태 · 카드 관점 이력을 단일 도메인으로 응집.
+ * 자정 close cron으로 "그날 못 본 카드 = 그냥 지나감" 원칙 강제.
+ *
+ * <p>불변식:
+ * <ul>
+ *   <li>UNIQUE (user_id, batch_date) — 하루당 1개</li>
+ *   <li>closed 상태에서 markViewed → DAILY_BATCH_CLOSED 예외</li>
+ *   <li>close 재호출은 no-op (멱등)</li>
+ *   <li>entries=0 일 때 completionRatio = 1.0 (0 나누기 방지 · perfect clear 간주)</li>
+ * </ul>
+ */
+@Entity
+@Table(
+        name = "daily_learning_batch",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_daily_batch_user_date",
+                columnNames = {"user_id", "batch_date"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyLearningBatch {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "batch_date", nullable = false)
+    private LocalDate batchDate;
+
+    @Column(name = "generated_at", nullable = false, updatable = false)
+    private LocalDateTime generatedAt;
+
+    @Column(name = "closed_at")
+    private LocalDateTime closedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_mode_at_generation", nullable = false, length = 20)
+    private LearningMode userModeAtGeneration;
+
+    @OneToMany(
+            mappedBy = "batch",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private final List<DailyCardEntry> entries = new ArrayList<>();
+
+    private DailyLearningBatch(Long userId, LocalDate batchDate, LearningMode userModeAtGeneration) {
+        this.userId = userId;
+        this.batchDate = batchDate;
+        this.userModeAtGeneration = userModeAtGeneration;
+        this.generatedAt = LocalDateTime.now();
+        this.closedAt = null;
+    }
+
+    /**
+     * REV E1 · Story 1-2 — 빈 batch 생성 (테스트·간단 시나리오용).
+     * 실제 orchestration은 {@link #generateFor}를 통한 카드 큐 구성 필요.
+     */
+    public static DailyLearningBatch create(Long userId, LocalDate batchDate, LearningMode userModeAtGeneration) {
+        Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
+        Objects.requireNonNull(batchDate, "batchDate는 null일 수 없습니다.");
+        Objects.requireNonNull(userModeAtGeneration, "userModeAtGeneration는 null일 수 없습니다.");
+        return new DailyLearningBatch(userId, batchDate, userModeAtGeneration);
+    }
+
+    /**
+     * REV E1 · Story 1-2 — batch 생성 + 카드 큐 채우기 orchestration.
+     *
+     * <p>Application Service가 사용자 활성 카드 목록을 전달 · 도메인이 due/exhausted 판정 · entries 구성.
+     * exhausted 카드는 반환값(exhaustedCards)에 · Application Service가 archive 위임.
+     *
+     * @return 튜플 유사 결과 · Aggregate 자체 + exhaustedCards 리스트
+     */
+    public static GenerationResult generateFor(Long userId, LocalDate today, LearningMode userCurrentMode, List<Card> allUserCards) {
+        Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
+        Objects.requireNonNull(today, "today는 null일 수 없습니다.");
+        Objects.requireNonNull(userCurrentMode, "userCurrentMode는 null일 수 없습니다.");
+        Objects.requireNonNull(allUserCards, "allUserCards는 null일 수 없습니다.");
+
+        DailyLearningBatch batch = new DailyLearningBatch(userId, today, userCurrentMode);
+        List<Card> exhausted = new ArrayList<>();
+
+        for (Card card : allUserCards) {
+            if (card.isArchived() || card.isDeleted()) continue;
+            if (card.hasScheduleExhausted(userCurrentMode, today)) {
+                exhausted.add(card);
+                continue;
+            }
+            if (card.isDueOn(today, userCurrentMode)) {
+                int intervalDay = daysSinceEntered(card, today);
+                batch.entries.add(DailyCardEntry.expose(batch, card.getId(), intervalDay));
+            }
+        }
+
+        return new GenerationResult(batch, exhausted);
+    }
+
+    private static int daysSinceEntered(Card card, LocalDate today) {
+        if (card.getEnteredFieldAt() == null) return 0;
+        long days = java.time.temporal.ChronoUnit.DAYS.between(
+                card.getEnteredFieldAt().toLocalDate(), today);
+        return (int) Math.max(0, days);
+    }
+
+    /**
+     * REV E1 · Story 1-2 — 카드 view 기록. closed 상태에서 예외.
+     * 이미 viewed인 entry 재호출은 no-op (멱등).
+     */
+    public void markViewed(Long cardId, LocalDateTime viewedAt) {
+        if (isClosed()) {
+            throw ReviewSessionException.of(ErrorCode.DAILY_BATCH_CLOSED, "batchId=" + this.id);
+        }
+        Objects.requireNonNull(cardId, "cardId는 null일 수 없습니다.");
+        Objects.requireNonNull(viewedAt, "viewedAt은 null일 수 없습니다.");
+
+        entries.stream()
+                .filter(e -> e.getCardId().equals(cardId))
+                .findFirst()
+                .ifPresent(e -> e.markViewed(viewedAt));
+    }
+
+    /**
+     * REV E1 · Story 1-2 — 자정 close (00:05 KST cron).
+     * 재호출은 no-op (멱등).
+     */
+    public void close(LocalDateTime closedAt) {
+        if (this.closedAt != null) return;  // 멱등
+        Objects.requireNonNull(closedAt, "closedAt은 null일 수 없습니다.");
+        this.closedAt = closedAt;
+    }
+
+    public boolean isClosed() {
+        return this.closedAt != null;
+    }
+
+    public int totalCount() {
+        return entries.size();
+    }
+
+    public int viewedCount() {
+        return (int) entries.stream().filter(DailyCardEntry::isViewed).count();
+    }
+
+    public double completionRatio() {
+        int total = totalCount();
+        if (total == 0) return 1.0;  // 0으로 나누기 방지 · perfect clear
+        return (double) viewedCount() / total;
+    }
+
+    public boolean isPerfectClear() {
+        return completionRatio() >= 1.0;
+    }
+
+    public List<DailyCardEntry> getEntries() {
+        return Collections.unmodifiableList(entries);
+    }
+
+    public boolean isOwner(Long userId) {
+        return this.userId.equals(userId);
+    }
+
+    /** Story 1-2 — generateFor 결과 record. */
+    public record GenerationResult(DailyLearningBatch batch, List<Card> exhaustedCards) {}
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/service/BatchStreakCalculator.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/service/BatchStreakCalculator.java
@@ -1,0 +1,76 @@
+package com.example.thirdtool.Review.domain.service;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.infrastructure.DailyLearningBatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * REV E1 · M5 · Story 1-6 — 사용자 batch streak realtime 계산.
+ *
+ * <p>대시보드 캐시 필드 없이 realtime · Repository 쿼리 최적화 (dateRange bulk 조회 N+1 방지).
+ */
+@Component
+@RequiredArgsConstructor
+public class BatchStreakCalculator {
+
+    private final DailyLearningBatchRepository repository;
+
+    /** 기본 조회 창 · 최대 365일 소급. */
+    private static final int MAX_LOOKBACK = 365;
+
+    /**
+     * asOf부터 뒤로 하루씩 조회 · isPerfectClear() 연속 카운트.
+     * break 되는 순간 종료.
+     */
+    public int currentStreak(Long userId, LocalDate asOf) {
+        LocalDate from = asOf.minusDays(MAX_LOOKBACK);
+        List<DailyLearningBatch> history = repository
+                .findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, asOf);
+
+        Map<LocalDate, DailyLearningBatch> byDate = history.stream()
+                .collect(Collectors.toMap(DailyLearningBatch::getBatchDate, Function.identity()));
+
+        int streak = 0;
+        LocalDate cursor = asOf;
+        while (streak <= MAX_LOOKBACK) {
+            DailyLearningBatch batch = byDate.get(cursor);
+            if (batch == null || !batch.isPerfectClear()) break;
+            streak++;
+            cursor = cursor.minusDays(1);
+        }
+        return streak;
+    }
+
+    /**
+     * asOf 기준 최근 window 일 내 최장 perfect clear 연속.
+     */
+    public int longestStreak(Long userId, LocalDate asOf, int window) {
+        LocalDate from = asOf.minusDays(window);
+        List<DailyLearningBatch> history = repository
+                .findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, asOf);
+
+        Map<LocalDate, DailyLearningBatch> byDate = history.stream()
+                .collect(Collectors.toMap(DailyLearningBatch::getBatchDate, Function.identity()));
+
+        int longest = 0;
+        int current = 0;
+        for (int i = 0; i <= window; i++) {
+            LocalDate day = from.plusDays(i);
+            DailyLearningBatch batch = byDate.get(day);
+            if (batch != null && batch.isPerfectClear()) {
+                current++;
+                longest = Math.max(longest, current);
+            } else {
+                current = 0;
+            }
+        }
+        return longest;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/DailyLearningBatchJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/DailyLearningBatchJpaRepository.java
@@ -1,0 +1,25 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyLearningBatchJpaRepository extends JpaRepository<DailyLearningBatch, Long> {
+
+    Optional<DailyLearningBatch> findByUserIdAndBatchDate(Long userId, LocalDate batchDate);
+
+    @Query("""
+            SELECT b FROM DailyLearningBatch b
+            WHERE b.batchDate = :batchDate
+              AND b.closedAt IS NULL
+            """)
+    List<DailyLearningBatch> findAllOpenByBatchDate(@Param("batchDate") LocalDate batchDate);
+
+    List<DailyLearningBatch> findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+            Long userId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/DailyLearningBatchRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/DailyLearningBatchRepository.java
@@ -1,0 +1,27 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * DailyLearningBatch Repository port (REV E1 · M5 · Story 1-3).
+ */
+public interface DailyLearningBatchRepository {
+
+    DailyLearningBatch save(DailyLearningBatch batch);
+
+    Optional<DailyLearningBatch> findById(Long id);
+
+    /** 특정 사용자 · 특정 날짜의 batch 조회 (UNIQUE 기반). */
+    Optional<DailyLearningBatch> findByUserIdAndBatchDate(Long userId, LocalDate batchDate);
+
+    /** Story 1-5 · 자정 close cron — 특정 날짜에 open 상태인 batch 목록. */
+    List<DailyLearningBatch> findAllOpenByBatchDate(LocalDate batchDate);
+
+    /** Story 1-3 · queryHistory — 사용자 · 기간 batch 목록 (batchDate DESC). */
+    List<DailyLearningBatch> findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+            Long userId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/DailyLearningBatchRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/DailyLearningBatchRepositoryAdapter.java
@@ -1,0 +1,42 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyLearningBatchRepositoryAdapter implements DailyLearningBatchRepository {
+
+    private final DailyLearningBatchJpaRepository jpa;
+
+    @Override
+    public DailyLearningBatch save(DailyLearningBatch batch) {
+        return jpa.save(batch);
+    }
+
+    @Override
+    public Optional<DailyLearningBatch> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<DailyLearningBatch> findByUserIdAndBatchDate(Long userId, LocalDate batchDate) {
+        return jpa.findByUserIdAndBatchDate(userId, batchDate);
+    }
+
+    @Override
+    public List<DailyLearningBatch> findAllOpenByBatchDate(LocalDate batchDate) {
+        return jpa.findAllOpenByBatchDate(batchDate);
+    }
+
+    @Override
+    public List<DailyLearningBatch> findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+            Long userId, LocalDate from, LocalDate to) {
+        return jpa.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, to);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/DailyBatchController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/DailyBatchController.java
@@ -1,0 +1,64 @@
+package com.example.thirdtool.Review.presentation;
+
+import com.example.thirdtool.Review.application.service.DailyLearningBatchService;
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.presentation.dto.DailyBatchResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * REV E1 · M5 · Story 1-7 — DailyBatch API.
+ */
+@RestController
+@RequestMapping("/api/v1/daily-batch")
+@RequiredArgsConstructor
+public class DailyBatchController {
+
+    private final DailyLearningBatchService service;
+
+    /**
+     * POST /api/v1/daily-batch/today — 오늘 batch 조회 · 없으면 lazy 생성.
+     * 첫 호출 시 201 · 재호출 시 200 (SDD Story 1-7).
+     * SDD 정합 위해 항상 201로 통일 (단순화 · lazy vs cache 구분은 응답 필드 아님).
+     */
+    @PostMapping("/today")
+    public ResponseEntity<DailyBatchResponse.Detail> getOrCreateToday(
+            @AuthenticationPrincipal UserEntity currentUser) {
+        DailyLearningBatch batch = service.getOrCreateToday(currentUser.getId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(DailyBatchResponse.Detail.of(batch));
+    }
+
+    /**
+     * GET /api/v1/daily-batch/history?from=YYYY-MM-DD&to=YYYY-MM-DD — 이력 조회.
+     */
+    @GetMapping("/history")
+    public ResponseEntity<List<DailyBatchResponse.HistorySummary>> queryHistory(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @AuthenticationPrincipal UserEntity currentUser) {
+        List<DailyLearningBatch> history = service.queryHistory(currentUser.getId(), from, to);
+        List<DailyBatchResponse.HistorySummary> body =
+                history.stream().map(DailyBatchResponse.HistorySummary::of).toList();
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * GET /api/v1/daily-batch/{batchId} — batch 상세 조회.
+     */
+    @GetMapping("/{batchId}")
+    public ResponseEntity<DailyBatchResponse.Detail> findById(
+            @PathVariable Long batchId,
+            @AuthenticationPrincipal UserEntity currentUser) {
+        DailyLearningBatch batch = service.findByIdOwned(batchId, currentUser.getId());
+        return ResponseEntity.ok(DailyBatchResponse.Detail.of(batch));
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/dto/DailyBatchResponse.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/dto/DailyBatchResponse.java
@@ -1,0 +1,79 @@
+package com.example.thirdtool.Review.presentation.dto;
+
+import com.example.thirdtool.Review.domain.model.DailyCardEntry;
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DailyBatchResponse {
+
+    /** REV E1 · Story 1-7 — batch 상세 응답. */
+    public record Detail(
+            Long batchId,
+            LocalDate batchDate,
+            LocalDateTime generatedAt,
+            LocalDateTime closedAt,
+            boolean isClosed,
+            int totalCards,
+            int viewedCards,
+            double completionRatio,
+            List<EntryDto> entries
+    ) {
+        public static Detail of(DailyLearningBatch batch) {
+            return new Detail(
+                    batch.getId(),
+                    batch.getBatchDate(),
+                    batch.getGeneratedAt(),
+                    batch.getClosedAt(),
+                    batch.isClosed(),
+                    batch.totalCount(),
+                    batch.viewedCount(),
+                    batch.completionRatio(),
+                    batch.getEntries().stream().map(EntryDto::of).toList()
+            );
+        }
+    }
+
+    /** REV E1 · Story 1-7 — 이력 조회 응답 (entries 미포함). */
+    public record HistorySummary(
+            Long batchId,
+            LocalDate batchDate,
+            boolean isClosed,
+            int totalCards,
+            int viewedCards,
+            double completionRatio,
+            boolean isPerfectClear
+    ) {
+        public static HistorySummary of(DailyLearningBatch batch) {
+            return new HistorySummary(
+                    batch.getId(),
+                    batch.getBatchDate(),
+                    batch.isClosed(),
+                    batch.totalCount(),
+                    batch.viewedCount(),
+                    batch.completionRatio(),
+                    batch.isPerfectClear()
+            );
+        }
+    }
+
+    public record EntryDto(
+            Long cardId,
+            int cardIntervalDay,
+            LocalDateTime exposedAt,
+            LocalDateTime viewedAt,
+            boolean isViewed
+    ) {
+        public static EntryDto of(DailyCardEntry entry) {
+            return new EntryDto(
+                    entry.getCardId(),
+                    entry.getCardIntervalDay(),
+                    entry.getExposedAt(),
+                    entry.getViewedAt(),
+                    entry.isViewed()
+            );
+        }
+    }
+}

--- a/src/main/resources/db/migration/R35__rollback_daily_learning_batch.sql
+++ b/src/main/resources/db/migration/R35__rollback_daily_learning_batch.sql
@@ -1,0 +1,5 @@
+-- R35__rollback_daily_learning_batch.sql
+-- Rollback for V35 (REV E1 · M5 · Story 1-1)
+
+DROP TABLE IF EXISTS daily_card_entry;
+DROP TABLE IF EXISTS daily_learning_batch;

--- a/src/main/resources/db/migration/V35__daily_learning_batch.sql
+++ b/src/main/resources/db/migration/V35__daily_learning_batch.sql
@@ -1,0 +1,53 @@
+-- V35__daily_learning_batch.sql
+-- REV E1 · M5 · Story 1-1 · DailyLearningBatch + DailyCardEntry 테이블 신설
+--
+-- 근거:
+--   · SDD: product-review.md Epic 1 Story 1-1 (line 447~482)
+--   · 이슈: issue-24-daily-learning-batch.md
+--   · Topology: workflow/topologys/migration-policy/v1-migration-policy.md
+--
+-- 결정: batch 생성은 lazy (자정 배치가 아니라 사용자 진입 시)
+--   자정 close cron만 별도 (Story 1-5).
+
+-- ─── daily_learning_batch ────────────────────────────────
+CREATE TABLE daily_learning_batch (
+    id                        BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id                   BIGINT       NOT NULL,
+    batch_date                DATE         NOT NULL,
+    generated_at              DATETIME(6)  NOT NULL,
+    closed_at                 DATETIME(6)           DEFAULT NULL,
+    user_mode_at_generation   VARCHAR(20)  NOT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_daily_batch_user_date (user_id, batch_date),
+    CONSTRAINT chk_daily_batch_mode
+        CHECK (user_mode_at_generation IN ('MODE_7D', 'MODE_14D', 'MODE_28D', 'MODE_60D')),
+    CONSTRAINT fk_daily_batch_user
+        FOREIGN KEY (user_id) REFERENCES user_entity (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_daily_batch_user_date ON daily_learning_batch (user_id, batch_date);
+
+-- ─── daily_card_entry ────────────────────────────────────
+CREATE TABLE daily_card_entry (
+    id                  BIGINT       NOT NULL AUTO_INCREMENT,
+    batch_id            BIGINT       NOT NULL,
+    card_id             BIGINT       NOT NULL,
+    card_interval_day   INT          NOT NULL,
+    exposed_at          DATETIME(6)  NOT NULL,
+    viewed_at           DATETIME(6)           DEFAULT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_daily_entry_batch_card (batch_id, card_id),
+    CONSTRAINT fk_daily_entry_batch
+        FOREIGN KEY (batch_id) REFERENCES daily_learning_batch (id) ON DELETE CASCADE,
+    CONSTRAINT fk_daily_entry_card
+        FOREIGN KEY (card_id) REFERENCES card (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_entry_card ON daily_card_entry (card_id);
+CREATE INDEX idx_entry_batch_viewed ON daily_card_entry (batch_id, viewed_at);

--- a/src/test/java/com/example/thirdtool/Review/domain/model/DailyLearningBatchTest.java
+++ b/src/test/java/com/example/thirdtool/Review/domain/model/DailyLearningBatchTest.java
@@ -1,0 +1,118 @@
+package com.example.thirdtool.Review.domain.model;
+
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * REV E1 · M5 · Story 1-2 · DailyLearningBatch Aggregate 도메인 단위 테스트.
+ */
+@DisplayName("DailyLearningBatch (REV E1 · Story 1-2)")
+class DailyLearningBatchTest {
+
+    @Nested
+    @DisplayName("create · 초기 상태")
+    class Create {
+
+        @Test
+        @DisplayName("해피: 정상 인자 · 초기 open · entries 0 · completionRatio 1.0 (perfect clear 간주)")
+        void create_해피() {
+            DailyLearningBatch batch = DailyLearningBatch.create(1L, LocalDate.now(), LearningMode.MODE_14D);
+
+            assertThat(batch.getUserId()).isEqualTo(1L);
+            assertThat(batch.isClosed()).isFalse();
+            assertThat(batch.totalCount()).isZero();
+            assertThat(batch.completionRatio()).isEqualTo(1.0);
+            assertThat(batch.isPerfectClear()).isTrue();
+        }
+
+        @Test
+        @DisplayName("예외: userId null")
+        void create_userId_null() {
+            assertThatThrownBy(() -> DailyLearningBatch.create(null, LocalDate.now(), LearningMode.MODE_14D))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("close · 자정 cron")
+    class Close {
+
+        @Test
+        @DisplayName("해피: open batch에 close 호출 · closedAt 세팅")
+        void close_해피() {
+            DailyLearningBatch batch = DailyLearningBatch.create(1L, LocalDate.now(), LearningMode.MODE_14D);
+            LocalDateTime closedAt = LocalDateTime.now();
+
+            batch.close(closedAt);
+
+            assertThat(batch.isClosed()).isTrue();
+            assertThat(batch.getClosedAt()).isEqualTo(closedAt);
+        }
+
+        @Test
+        @DisplayName("엣지: 이미 closed batch에 재호출 · no-op (멱등 · 원 closedAt 유지)")
+        void close_재호출_no_op() {
+            DailyLearningBatch batch = DailyLearningBatch.create(1L, LocalDate.now(), LearningMode.MODE_14D);
+            LocalDateTime first = LocalDateTime.now();
+            batch.close(first);
+            LocalDateTime second = first.plusHours(1);
+
+            batch.close(second);
+
+            assertThat(batch.getClosedAt()).isEqualTo(first);  // 원 값 유지
+        }
+    }
+
+    @Nested
+    @DisplayName("markViewed · closed 상태에서 예외")
+    class MarkViewed {
+
+        @Test
+        @DisplayName("예외: closed batch에 markViewed · DAILY_BATCH_CLOSED")
+        void markViewed_closed_예외() {
+            DailyLearningBatch batch = DailyLearningBatch.create(1L, LocalDate.now(), LearningMode.MODE_14D);
+            batch.close(LocalDateTime.now());
+
+            assertThatThrownBy(() -> batch.markViewed(100L, LocalDateTime.now()))
+                    .isInstanceOf(ReviewSessionException.class)
+                    .hasMessageContaining("오늘 학습 세션이 종료되었습니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("completionRatio · 0으로 나누기 방지")
+    class CompletionRatio {
+
+        @Test
+        @DisplayName("엣지: entries 0 · 1.0 반환 (perfect clear 간주)")
+        void entries_0_1_0() {
+            DailyLearningBatch batch = DailyLearningBatch.create(1L, LocalDate.now(), LearningMode.MODE_14D);
+
+            assertThat(batch.completionRatio()).isEqualTo(1.0);
+            assertThat(batch.isPerfectClear()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwner")
+    class IsOwner {
+
+        @Test
+        @DisplayName("해피: 동일 userId · true")
+        void owner_일치() {
+            DailyLearningBatch batch = DailyLearningBatch.create(1L, LocalDate.now(), LearningMode.MODE_14D);
+
+            assertThat(batch.isOwner(1L)).isTrue();
+            assertThat(batch.isOwner(2L)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## 개요

M5 (0.0.5v) Epic PR #3 — Review Epic 1 (\`DailyLearningBatch\` Aggregate + \`DailyCardEntry\` 자식) 완주. Review BC 신설의 근간. 하루당 1개 batch로 cross-layer 짬뽕 큐 · 진행 상태 · 카드 관점 이력을 단일 도메인으로 응집.

## 왜 / 설계 결정

- **SDD 우선 정책** (사용자 지시): \`product-review.md\` Epic 1 (line 395~728) · issue-24 원안 착지
- **Lazy 생성**: 자정 배치 대신 사용자 진입 시 lazy 생성 · 자원 절약 + 안 오는 사용자 batch 안 만듦 (SDD § Epic 1 기술 결정)
- **DailyCardEntry가 카드 관점 이력 역할**: \`findByCardId\` 로 카드 노출 이력 커버 · 별도 \`CardExposureLog\` 테이블 미신설
- **generateFor archive orchestration은 Application 위임**: Aggregate가 다른 BC 호출 안 함 원칙 · \`CardCommandService.archiveMany\` 신설
- **자정 close cron**: "그날 못 본 카드 = 그냥 지나감" 원칙 강제 · 00:05 KST

## 작업 내용

### Story 1-1 · Flyway V35 daily_learning_batch
- \`daily_learning_batch\` 테이블 · UNIQUE(user_id, batch_date) · CHECK(mode) · FK user
- \`daily_card_entry\` 테이블 · UNIQUE(batch_id, card_id) · FK batch CASCADE · FK card
- 인덱스 3종

### Story 1-2 · Aggregate + Entity
- \`DailyLearningBatch\` (Aggregate Root) · \`generateFor\` GenerationResult 튜플 · markViewed · close (멱등) · completionRatio (entries=0 → 1.0) · isPerfectClear
- \`DailyCardEntry\` (자식 Entity) · expose · markViewed 멱등

### Story 1-3 · Repository + Service
- \`DailyLearningBatchRepository\` port + JPA + Adapter
- \`DailyLearningBatchService\` · getOrCreateToday (lazy) · markViewed · queryHistory · findByIdOwned

### Story 1-4 · generateFor orchestration
- \`CardCommandService.archiveMany(cardIds, reason)\` 신설
- Reason 판정: \`createdMode.maxDays() > userMode.maxDays()\` → MODE_DOWNGRADED · else SCHEDULE_EXHAUSTED
- 다중 reason 정교화는 v0.1.1v

### Story 1-5 · 자정 close cron
- \`DailyBatchCloseScheduler\` · \`@Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")\`
- 어제 open batch 모두 close · 멱등

### Story 1-6 · BatchStreakCalculator
- \`currentStreak(userId, asOf)\` · 하루씩 역행 · isPerfectClear 연속
- \`longestStreak(userId, asOf, window)\` · 최근 window 최장
- dateRange bulk 조회로 N+1 방지 · realtime

### Story 1-7 · DailyBatchController + DTO
- \`POST /api/v1/daily-batch/today\` (201 · lazy)
- \`GET /api/v1/daily-batch/history?from&to\`
- \`GET /api/v1/daily-batch/{batchId}\` (소유권 검증)
- \`DailyBatchResponse\`: Detail · HistorySummary · EntryDto

### Story 1-8 · ErrorCode 3종
- \`DAILY_BATCH_NOT_FOUND\` (DAILY001) · 404
- \`DAILY_BATCH_CLOSED\` (DAILY002) · 409
- \`DAILY_BATCH_FORBIDDEN\` (DAILY003) · 403

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- \`./gradlew test\` → **BUILD SUCCESSFUL**
- \`DailyLearningBatchTest\` · 5 nested class · 6 케이스 (해피/엣지/예외)

## v0.1.1v 이관 항목

- 다중 reason 정교화 (현재는 첫 카드 기준 단순 판정)
- @DataJpaTest Slice 테스트 (UNIQUE·CHECK·CASCADE 검증)
- @SpringBootTest 통합 테스트 (두 reason 시나리오)
- BatchStreakCalculator streak 시나리오 다중 케이스

## 체크리스트

- [x] 빌드 / 테스트 통과 (BUILD SUCCESSFUL)
- [x] BC 간 의존 방향 위반 없음 (Aggregate → Application → CardCommandService)
- [x] Base 브랜치 = develop 확인
- [x] ErrorCode 신설 3종 등록 · GlobalExceptionHandler 자동 처리

## 관련 이슈

- Product: workflow/task/pes/workspectrum/sdd/in-progress/product-review.md
- Epic 1: line 395~728 (DailyLearningBatch Aggregate + DailyCardEntry 자식)
- Story 1-1 (line 447) · S1-2 (line 484) · S1-3 (line 523) · S1-4 (line 563) · S1-5 (line 597) · S1-6 (line 631) · S1-7 (line 666) · S1-8 (line 699)
- 상위 이슈: fix/brainstorming/0.0.2v/issue-24-daily-learning-batch.md
- Milestone: workflow/task/milestones/version/0.0.5v/milestone.md § Epic PR #3