### PR TITLE
feat(review): 대시보드 + 규칙 기반 추천 + 주간 요약 cron + notification [Epic-REV-E3-M5-PR5]

### DIFF
--- a/src/main/generated/com/example/thirdtool/Review/domain/model/QRecommendation.java
+++ b/src/main/generated/com/example/thirdtool/Review/domain/model/QRecommendation.java
@@ -1,0 +1,53 @@
+package com.example.thirdtool.Review.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QRecommendation is a Querydsl query type for Recommendation
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRecommendation extends EntityPathBase<Recommendation> {
+
+    private static final long serialVersionUID = 1264480210L;
+
+    public static final QRecommendation recommendation = new QRecommendation("recommendation");
+
+    public final EnumPath<RecommendationAction> action = createEnum("action", RecommendationAction.class);
+
+    public final EnumPath<com.example.thirdtool.UserSchedule.domain.model.LearningMode> fromMode = createEnum("fromMode", com.example.thirdtool.UserSchedule.domain.model.LearningMode.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath reason = createString("reason");
+
+    public final DateTimePath<java.time.LocalDateTime> resolvedAt = createDateTime("resolvedAt", java.time.LocalDateTime.class);
+
+    public final EnumPath<com.example.thirdtool.UserSchedule.domain.model.LearningMode> toMode = createEnum("toMode", com.example.thirdtool.UserSchedule.domain.model.LearningMode.class);
+
+    public final DateTimePath<java.time.LocalDateTime> triggeredAt = createDateTime("triggeredAt", java.time.LocalDateTime.class);
+
+    public final EnumPath<RecommendationType> type = createEnum("type", RecommendationType.class);
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QRecommendation(String variable) {
+        super(Recommendation.class, forVariable(variable));
+    }
+
+    public QRecommendation(Path<? extends Recommendation> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QRecommendation(PathMetadata metadata) {
+        super(Recommendation.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/thirdtool/Review/domain/model/QUserNotification.java
+++ b/src/main/generated/com/example/thirdtool/Review/domain/model/QUserNotification.java
@@ -1,0 +1,49 @@
+package com.example.thirdtool.Review.domain.model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUserNotification is a Querydsl query type for UserNotification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserNotification extends EntityPathBase<UserNotification> {
+
+    private static final long serialVersionUID = 188546607L;
+
+    public static final QUserNotification userNotification = new QUserNotification("userNotification");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath payloadJson = createString("payloadJson");
+
+    public final DateTimePath<java.time.LocalDateTime> readAt = createDateTime("readAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> recommendationId = createNumber("recommendationId", Long.class);
+
+    public final EnumPath<NotificationType> type = createEnum("type", NotificationType.class);
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QUserNotification(String variable) {
+        super(UserNotification.class, forVariable(variable));
+    }
+
+    public QUserNotification(Path<? extends UserNotification> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUserNotification(PathMetadata metadata) {
+        super(UserNotification.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/example/thirdtool/Common/Exception/ErrorCode/ErrorCode.java
@@ -77,6 +77,13 @@ public enum ErrorCode {
     DAILY_BATCH_CLOSED_FOR_NEW_SESSION("DAILY004", "closed batch로는 새 세션을 시작할 수 없습니다.", HttpStatus.CONFLICT),
     DAILY_BATCH_HAS_NO_CARDS("DAILY005", "오늘 학습할 카드가 없습니다.",                       HttpStatus.BAD_REQUEST),
 
+    // ─── Recommendation / Notification (REV E3 · M5) ────────
+    RECOMMENDATION_NOT_FOUND("REC001",         "추천을 찾을 수 없습니다.",                       HttpStatus.NOT_FOUND),
+    RECOMMENDATION_ALREADY_RESOLVED("REC002",  "이미 처리된 추천입니다.",                       HttpStatus.CONFLICT),
+    RECOMMENDATION_FORBIDDEN("REC003",         "본인의 추천이 아닙니다.",                        HttpStatus.FORBIDDEN),
+    NOTIFICATION_NOT_FOUND("NOTIF001",         "알림을 찾을 수 없습니다.",                       HttpStatus.NOT_FOUND),
+    NOTIFICATION_FORBIDDEN("NOTIF002",         "본인의 알림이 아닙니다.",                        HttpStatus.FORBIDDEN),
+
     // ─── LearningFacade ───────────────────────────────────
     LEARNING_FACADE_NOT_FOUND("LF001",       "LearningFacade를 찾을 수 없습니다.",   HttpStatus.NOT_FOUND),
     LEARNING_FACADE_ALREADY_EXISTS("LF002",  "이미 LearningFacade가 존재합니다.",    HttpStatus.CONFLICT),

--- a/src/main/java/com/example/thirdtool/Review/application/config/RecommendationProperties.java
+++ b/src/main/java/com/example/thirdtool/Review/application/config/RecommendationProperties.java
@@ -1,0 +1,35 @@
+package com.example.thirdtool.Review.application.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * REV E3 · Story 3-6 — 추천 임계값 config.
+ *
+ * <p>{@code application.yml}에서 주입. 관찰 데이터 축적 후 튜닝 여지 확보.
+ *
+ * <pre>{@code
+ * app:
+ *   learning:
+ *     recommendation:
+ *       downgrade-threshold-ratio: 0.5
+ *       downgrade-window-weeks: 3
+ *       upgrade-window-weeks: 4
+ * }</pre>
+ */
+@ConfigurationProperties(prefix = "app.learning.recommendation")
+public record RecommendationProperties(
+        double downgradeThresholdRatio,
+        int downgradeWindowWeeks,
+        int upgradeWindowWeeks
+) {
+    public RecommendationProperties {
+        if (downgradeThresholdRatio < 0.0 || downgradeThresholdRatio > 1.0) {
+            throw new IllegalArgumentException(
+                    "downgrade-threshold-ratio는 0.0~1.0 사이여야 합니다. 값=" + downgradeThresholdRatio);
+        }
+        if (downgradeWindowWeeks <= 0 || upgradeWindowWeeks <= 0) {
+            throw new IllegalArgumentException(
+                    "window-weeks는 1 이상이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/application/scheduler/WeeklyRecommendationScheduler.java
+++ b/src/main/java/com/example/thirdtool/Review/application/scheduler/WeeklyRecommendationScheduler.java
@@ -1,0 +1,88 @@
+package com.example.thirdtool.Review.application.scheduler;
+
+import com.example.thirdtool.Review.application.service.NotificationService;
+import com.example.thirdtool.Review.domain.model.NotificationType;
+import com.example.thirdtool.Review.domain.model.Recommendation;
+import com.example.thirdtool.Review.domain.service.RecommendationEngine;
+import com.example.thirdtool.Review.infrastructure.RecommendationRepository;
+import com.example.thirdtool.UserSchedule.domain.model.UserScheduleConfig;
+import com.example.thirdtool.UserSchedule.infrastructure.persistence.UserScheduleConfigRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * WeeklyRecommendationScheduler — REV E3 · Story 3-3.
+ *
+ * <p>매주 월요일 09:00 KST에 활성 사용자 순회 · RecommendationEngine 판정 · notification 발송.
+ * 이미 이번 주에 발송된 사용자에겐 중복 발송 안 함 (같은 주 1회).
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyRecommendationScheduler {
+
+    private final UserScheduleConfigRepository userConfigRepository;
+    private final RecommendationEngine engine;
+    private final RecommendationRepository recommendationRepository;
+    private final NotificationService notificationService;
+
+    /**
+     * REV E3 · Story 3-3 — 주간 추천 판정 cron.
+     * <p>cron: 매주 월요일 09:00 KST · {@code "0 0 9 ? * MON"}.
+     */
+    @Scheduled(cron = "0 0 9 ? * MON", zone = "Asia/Seoul")
+    @Transactional
+    public void checkWeeklyRecommendations() {
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime weekStart = now.minusDays(7);
+
+        int total = 0;
+        int suggested = 0;
+
+        for (UserScheduleConfig config : userConfigRepository.findAll()) {
+            total++;
+            Long userId = config.getUserId();
+
+            // 이미 이번 주에 발송된 사용자 skip
+            if (recommendationRepository.findLatestByUserIdSince(userId, weekStart).isPresent()) {
+                continue;
+            }
+
+            Optional<RecommendationEngine.Evaluation> eval = engine.evaluate(userId, today);
+            if (eval.isEmpty()) continue;
+
+            Recommendation saved = recommendationRepository.save(
+                    Recommendation.of(userId, eval.get().type(), eval.get().fromMode(),
+                            eval.get().toMode(), eval.get().reason(), now));
+
+            String payload = String.format(
+                    "{\"type\":\"%s\",\"fromMode\":\"%s\",\"toMode\":\"%s\",\"reason\":\"%s\"}",
+                    eval.get().type().name(),
+                    eval.get().fromMode().name(),
+                    eval.get().toMode().name(),
+                    escape(eval.get().reason()));
+
+            NotificationType notificationType = switch (eval.get().type()) {
+                case SUGGEST_DOWNGRADE -> NotificationType.SUGGEST_DOWNGRADE;
+                case SUGGEST_UPGRADE -> NotificationType.SUGGEST_UPGRADE;
+            };
+
+            notificationService.send(userId, notificationType, payload, saved.getId());
+            suggested++;
+        }
+
+        log.info("WeeklyRecommendationScheduler done. users={} suggested={}", total, suggested);
+    }
+
+    private static String escape(String s) {
+        return s.replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/application/service/LearningDashboardCommandService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/service/LearningDashboardCommandService.java
@@ -1,0 +1,64 @@
+package com.example.thirdtool.Review.application.service;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.Review.domain.model.Recommendation;
+import com.example.thirdtool.Review.domain.model.RecommendationAction;
+import com.example.thirdtool.Review.infrastructure.RecommendationRepository;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * LearningDashboardCommandService — REV E3 · Story 3-5.
+ *
+ * <p>추천 accept/dismiss orchestration. accept 시 UserSchedule mode 변경 트리거.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LearningDashboardCommandService {
+
+    private final RecommendationRepository recommendationRepository;
+    private final UserScheduleCommandService userScheduleCommandService;
+
+    /**
+     * REV E3 · Story 3-5 — 추천 수락.
+     *
+     * <p>1. Recommendation 조회 · 소유권 검증<br>
+     * 2. 이미 resolve됐으면 예외<br>
+     * 3. UserScheduleCommandService.save(userId, toMode.maxDays()) 호출로 mode 변경<br>
+     * 4. Recommendation.resolve(ACCEPTED, now) 이력 갱신
+     */
+    public void acceptRecommendation(Long userId, Long recommendationId) {
+        Recommendation recommendation = loadOwned(userId, recommendationId);
+        recommendation.resolve(RecommendationAction.ACCEPTED, LocalDateTime.now());
+
+        // UserScheduleCommandService.save는 inputDays 기반 · toMode.maxDays()로 재배치.
+        userScheduleCommandService.save(userId, recommendation.getToMode().maxDays());
+
+        recommendationRepository.save(recommendation);
+    }
+
+    /**
+     * REV E3 · Story 3-5 — 추천 거절. mode 변경 없이 이력만 갱신.
+     */
+    public void dismissRecommendation(Long userId, Long recommendationId) {
+        Recommendation recommendation = loadOwned(userId, recommendationId);
+        recommendation.resolve(RecommendationAction.DISMISSED, LocalDateTime.now());
+        recommendationRepository.save(recommendation);
+    }
+
+    private Recommendation loadOwned(Long userId, Long recommendationId) {
+        Recommendation rec = recommendationRepository.findById(recommendationId)
+                .orElseThrow(() -> ReviewSessionException.of(
+                        ErrorCode.RECOMMENDATION_NOT_FOUND, "id=" + recommendationId));
+        if (!rec.isOwner(userId)) {
+            throw ReviewSessionException.of(ErrorCode.RECOMMENDATION_FORBIDDEN);
+        }
+        return rec;
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/application/service/LearningDashboardQueryService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/service/LearningDashboardQueryService.java
@@ -1,0 +1,76 @@
+package com.example.thirdtool.Review.application.service;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.domain.model.Recommendation;
+import com.example.thirdtool.Review.domain.service.BatchStreakCalculator;
+import com.example.thirdtool.Review.infrastructure.DailyLearningBatchRepository;
+import com.example.thirdtool.Review.infrastructure.RecommendationRepository;
+import com.example.thirdtool.Review.presentation.dto.LearningDashboardResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * LearningDashboardQueryService — REV E3 · Story 3-1.
+ *
+ * <p>오늘 batch + 7일/30일 평균 + streak + 미해결 recommendation을 단일 응답으로 조합.
+ * FE가 대시보드 화면 렌더링 시 단일 조회로 처리.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LearningDashboardQueryService {
+
+    private final DailyLearningBatchRepository batchRepository;
+    private final DailyLearningBatchService batchService;
+    private final BatchStreakCalculator streakCalculator;
+    private final RecommendationRepository recommendationRepository;
+
+    public LearningDashboardResponse buildDashboard(Long userId, LocalDate asOf) {
+        // 1) 오늘 batch — lazy 생성 위임
+        DailyLearningBatch today = batchService.getOrCreateToday(userId);
+
+        // 2) 최근 7일 · 30일 평균 완료율
+        LearningDashboardResponse.Window recent7 = window(userId, asOf, 7);
+        LearningDashboardResponse.Window recent30 = window(userId, asOf, 30);
+
+        // 3) streak
+        LearningDashboardResponse.Streak streak = new LearningDashboardResponse.Streak(
+                streakCalculator.currentStreak(userId, asOf),
+                streakCalculator.longestStreak(userId, asOf, 365)
+        );
+
+        // 4) 미해결 추천
+        Optional<Recommendation> pending = recommendationRepository.findLatestUnresolvedByUserId(userId);
+        LearningDashboardResponse.RecommendationDto recommendationDto = pending
+                .map(LearningDashboardResponse.RecommendationDto::of)
+                .orElse(null);
+
+        return new LearningDashboardResponse(
+                LearningDashboardResponse.TodaySummary.of(today),
+                recent7,
+                recent30,
+                streak,
+                recommendationDto
+        );
+    }
+
+    private LearningDashboardResponse.Window window(Long userId, LocalDate asOf, int days) {
+        LocalDate from = asOf.minusDays(days - 1);
+        List<DailyLearningBatch> batches = batchRepository
+                .findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, asOf);
+        int count = batches.size();
+        double avg = batches.stream()
+                .mapToDouble(DailyLearningBatch::completionRatio)
+                .average()
+                .orElse(0.0);
+        int perfectDays = (int) batches.stream()
+                .filter(DailyLearningBatch::isPerfectClear)
+                .count();
+        return new LearningDashboardResponse.Window(days, count, avg, perfectDays);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/application/service/NotificationService.java
+++ b/src/main/java/com/example/thirdtool/Review/application/service/NotificationService.java
@@ -1,0 +1,44 @@
+package com.example.thirdtool.Review.application.service;
+
+import com.example.thirdtool.Review.domain.model.NotificationType;
+import com.example.thirdtool.Review.domain.model.UserNotification;
+import com.example.thirdtool.Review.infrastructure.UserNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * NotificationService — REV E3 · Story 3-3/3-8 (v1 minimal).
+ *
+ * <p>DB row 삽입만 담당. WebSocket / FCM push는 v2 이관.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private final UserNotificationRepository repository;
+
+    /**
+     * REV E3 · Story 3-3 · 알림 발송. payload는 호출자가 직접 직렬화한 JSON 문자열.
+     * recommendationId는 SUGGEST_* 유형일 때만 세팅 (그 외 null).
+     */
+    public UserNotification send(Long userId, NotificationType type, String payloadJson, Long recommendationId) {
+        UserNotification notification = UserNotification.of(
+                userId, type, payloadJson, recommendationId, LocalDateTime.now());
+        return repository.save(notification);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserNotification> listUnread(Long userId) {
+        return repository.findAllByUserIdAndUnread(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserNotification> listAll(Long userId) {
+        return repository.findAllByUserId(userId);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/NotificationType.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/NotificationType.java
@@ -1,0 +1,10 @@
+package com.example.thirdtool.Review.domain.model;
+
+/**
+ * REV E3 · Story 3-8 — In-app notification 유형 (v1 minimal).
+ */
+public enum NotificationType {
+    SUGGEST_DOWNGRADE,
+    SUGGEST_UPGRADE,
+    WEEKLY_SUMMARY
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/Recommendation.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/Recommendation.java
@@ -1,0 +1,126 @@
+package com.example.thirdtool.Review.domain.model;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * Recommendation Aggregate — REV E3 · Story 3-2/3-5.
+ *
+ * <p>규칙 기반 추천 이력. RecommendationEngine이 판정 결과를 생성 · 사용자 accept/dismiss로 resolve.
+ * v2 자동 조정 근거 축적을 위해 accept/dismiss 상태와 시각을 이력으로 보존.
+ *
+ * <p>불변식:
+ * <ul>
+ *   <li>triggeredAt은 생성 시 자동 · 외부 주입 금지</li>
+ *   <li>resolve(action, now) 재호출은 RECOMMENDATION_ALREADY_RESOLVED (멱등 금지)</li>
+ *   <li>SUGGEST_DOWNGRADE는 fromMode &gt; toMode · SUGGEST_UPGRADE는 fromMode &lt; toMode</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "recommendation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recommendation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 30)
+    private RecommendationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "from_mode", nullable = false, length = 20)
+    private LearningMode fromMode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "to_mode", nullable = false, length = 20)
+    private LearningMode toMode;
+
+    @Column(name = "reason", nullable = false, length = 500)
+    private String reason;
+
+    @Column(name = "triggered_at", nullable = false, updatable = false)
+    private LocalDateTime triggeredAt;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action", length = 20)
+    private RecommendationAction action;
+
+    private Recommendation(Long userId, RecommendationType type, LearningMode fromMode,
+                           LearningMode toMode, String reason, LocalDateTime triggeredAt) {
+        this.userId = userId;
+        this.type = type;
+        this.fromMode = fromMode;
+        this.toMode = toMode;
+        this.reason = reason;
+        this.triggeredAt = triggeredAt;
+    }
+
+    /**
+     * REV E3 · Story 3-2 — 규칙 판정 결과를 이력으로 저장.
+     */
+    public static Recommendation of(Long userId, RecommendationType type, LearningMode fromMode,
+                                    LearningMode toMode, String reason, LocalDateTime triggeredAt) {
+        Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
+        Objects.requireNonNull(type, "type은 null일 수 없습니다.");
+        Objects.requireNonNull(fromMode, "fromMode는 null일 수 없습니다.");
+        Objects.requireNonNull(toMode, "toMode는 null일 수 없습니다.");
+        Objects.requireNonNull(reason, "reason은 null일 수 없습니다.");
+        Objects.requireNonNull(triggeredAt, "triggeredAt은 null일 수 없습니다.");
+
+        // 도메인 불변식 · 방향 검증
+        validateDirection(type, fromMode, toMode);
+
+        return new Recommendation(userId, type, fromMode, toMode, reason, triggeredAt);
+    }
+
+    private static void validateDirection(RecommendationType type, LearningMode from, LearningMode to) {
+        if (type == RecommendationType.SUGGEST_DOWNGRADE && from.maxDays() <= to.maxDays()) {
+            throw new IllegalArgumentException(
+                    "SUGGEST_DOWNGRADE는 fromMode > toMode여야 합니다. from=" + from + " to=" + to);
+        }
+        if (type == RecommendationType.SUGGEST_UPGRADE && from.maxDays() >= to.maxDays()) {
+            throw new IllegalArgumentException(
+                    "SUGGEST_UPGRADE는 fromMode < toMode여야 합니다. from=" + from + " to=" + to);
+        }
+    }
+
+    /**
+     * REV E3 · Story 3-5 — 사용자 accept/dismiss 처리.
+     * 이미 resolved면 예외 · 멱등 금지 (재resolve는 이력 왜곡).
+     */
+    public void resolve(RecommendationAction action, LocalDateTime now) {
+        if (this.resolvedAt != null) {
+            throw ReviewSessionException.of(ErrorCode.RECOMMENDATION_ALREADY_RESOLVED,
+                    "recommendationId=" + this.id);
+        }
+        Objects.requireNonNull(action, "action은 null일 수 없습니다.");
+        Objects.requireNonNull(now, "now는 null일 수 없습니다.");
+        this.action = action;
+        this.resolvedAt = now;
+    }
+
+    public boolean isResolved() {
+        return this.resolvedAt != null;
+    }
+
+    public boolean isOwner(Long userId) {
+        return this.userId.equals(userId);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/RecommendationAction.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/RecommendationAction.java
@@ -1,0 +1,9 @@
+package com.example.thirdtool.Review.domain.model;
+
+/**
+ * REV E3 · Story 3-5 — 추천에 대한 사용자 응답.
+ */
+public enum RecommendationAction {
+    ACCEPTED,
+    DISMISSED
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/RecommendationType.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/RecommendationType.java
@@ -1,0 +1,14 @@
+package com.example.thirdtool.Review.domain.model;
+
+/**
+ * REV E3 · Story 3-2 — 규칙 기반 추천 유형.
+ *
+ * <ul>
+ *   <li>{@link #SUGGEST_DOWNGRADE} — 최근 저완료율 · 한 단계 아래 mode 제안</li>
+ *   <li>{@link #SUGGEST_UPGRADE} — 최근 완벽 클리어 · 한 단계 위 mode 제안</li>
+ * </ul>
+ */
+public enum RecommendationType {
+    SUGGEST_DOWNGRADE,
+    SUGGEST_UPGRADE
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/model/UserNotification.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/model/UserNotification.java
@@ -1,0 +1,81 @@
+package com.example.thirdtool.Review.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * UserNotification Aggregate — REV E3 · Story 3-8 (v1 minimal).
+ *
+ * <p>DB row + 프론트 polling 방식. WebSocket / FCM은 v2 이관.
+ */
+@Entity
+@Table(name = "user_notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 30)
+    private NotificationType type;
+
+    /** v1 minimal: JSON 문자열 저장 · payload 구조는 type별 클라이언트가 파싱. */
+    @Column(name = "payload_json", nullable = false, length = 2000)
+    private String payloadJson;
+
+    /** REV E3 · Story 3-5 accept flow — 추천 알림일 경우 참조. 그 외 null. */
+    @Column(name = "recommendation_id")
+    private Long recommendationId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    private UserNotification(Long userId, NotificationType type, String payloadJson,
+                             Long recommendationId, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.type = type;
+        this.payloadJson = payloadJson;
+        this.recommendationId = recommendationId;
+        this.createdAt = createdAt;
+    }
+
+    public static UserNotification of(Long userId, NotificationType type, String payloadJson,
+                                      Long recommendationId, LocalDateTime createdAt) {
+        Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
+        Objects.requireNonNull(type, "type은 null일 수 없습니다.");
+        Objects.requireNonNull(payloadJson, "payloadJson은 null일 수 없습니다.");
+        Objects.requireNonNull(createdAt, "createdAt은 null일 수 없습니다.");
+        return new UserNotification(userId, type, payloadJson, recommendationId, createdAt);
+    }
+
+    /**
+     * REV E3 · Story 3-8 — 읽음 표시. 멱등 (재호출 시 readAt 유지).
+     */
+    public void markRead(LocalDateTime now) {
+        if (this.readAt != null) return;
+        Objects.requireNonNull(now, "now는 null일 수 없습니다.");
+        this.readAt = now;
+    }
+
+    public boolean isRead() {
+        return this.readAt != null;
+    }
+
+    public boolean isOwner(Long userId) {
+        return this.userId.equals(userId);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/domain/service/RecommendationEngine.java
+++ b/src/main/java/com/example/thirdtool/Review/domain/service/RecommendationEngine.java
@@ -1,0 +1,118 @@
+package com.example.thirdtool.Review.domain.service;
+
+import com.example.thirdtool.Review.application.config.RecommendationProperties;
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.domain.model.RecommendationType;
+import com.example.thirdtool.Review.infrastructure.DailyLearningBatchRepository;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * RecommendationEngine — REV E3 · Story 3-2 · 규칙 기반 mode 조정 판정.
+ *
+ * <p>규칙:
+ * <ul>
+ *   <li>최근 N주 batch 평균 완료율 &lt; downgrade-threshold-ratio → SUGGEST_DOWNGRADE (한 단계 아래 mode)</li>
+ *   <li>최근 M주 모든 batch perfect + 사용자 mode &lt; MODE_60D → SUGGEST_UPGRADE (한 단계 위 mode)</li>
+ *   <li>MODE_7D 사용자에게 DOWNGRADE 없음 (더 낮은 mode 없음)</li>
+ *   <li>MODE_60D 사용자에게 UPGRADE 없음 (더 높은 mode 없음)</li>
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+public class RecommendationEngine {
+
+    private final DailyLearningBatchRepository batchRepository;
+    private final UserScheduleQueryService userScheduleQueryService;
+    private final RecommendationProperties properties;
+
+    public Optional<Evaluation> evaluate(Long userId, LocalDate asOf) {
+        LearningMode userMode = userScheduleQueryService.currentMode(userId);
+
+        // 1) DOWNGRADE 판정 우선
+        Optional<Evaluation> downgrade = evaluateDowngrade(userId, asOf, userMode);
+        if (downgrade.isPresent()) return downgrade;
+
+        // 2) UPGRADE 판정
+        return evaluateUpgrade(userId, asOf, userMode);
+    }
+
+    private Optional<Evaluation> evaluateDowngrade(Long userId, LocalDate asOf, LearningMode userMode) {
+        LearningMode downgraded = downgradeOf(userMode);
+        if (downgraded == null) return Optional.empty();  // MODE_7D — 더 낮은 mode 없음
+
+        LocalDate from = asOf.minusWeeks(properties.downgradeWindowWeeks());
+        List<DailyLearningBatch> batches = batchRepository
+                .findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, asOf);
+        if (batches.isEmpty()) return Optional.empty();
+
+        double avgCompletion = batches.stream()
+                .mapToDouble(DailyLearningBatch::completionRatio)
+                .average()
+                .orElse(0.0);
+
+        if (avgCompletion < properties.downgradeThresholdRatio()) {
+            String reason = String.format(
+                    "최근 %d주 평균 완료율 %.0f%% (%.0f%% 미만)",
+                    properties.downgradeWindowWeeks(),
+                    avgCompletion * 100,
+                    properties.downgradeThresholdRatio() * 100);
+            return Optional.of(new Evaluation(
+                    RecommendationType.SUGGEST_DOWNGRADE, userMode, downgraded, reason));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Evaluation> evaluateUpgrade(Long userId, LocalDate asOf, LearningMode userMode) {
+        LearningMode upgraded = upgradeOf(userMode);
+        if (upgraded == null) return Optional.empty();  // MODE_60D — 더 높은 mode 없음
+
+        LocalDate from = asOf.minusWeeks(properties.upgradeWindowWeeks());
+        List<DailyLearningBatch> batches = batchRepository
+                .findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(userId, from, asOf);
+        if (batches.isEmpty()) return Optional.empty();
+
+        boolean allPerfect = batches.stream().allMatch(DailyLearningBatch::isPerfectClear);
+        if (allPerfect) {
+            String reason = String.format(
+                    "최근 %d주 모든 batch 완벽 클리어", properties.upgradeWindowWeeks());
+            return Optional.of(new Evaluation(
+                    RecommendationType.SUGGEST_UPGRADE, userMode, upgraded, reason));
+        }
+        return Optional.empty();
+    }
+
+    /** MODE_60D → MODE_28D → MODE_14D → MODE_7D → null. */
+    static LearningMode downgradeOf(LearningMode mode) {
+        return switch (mode) {
+            case MODE_60D -> LearningMode.MODE_28D;
+            case MODE_28D -> LearningMode.MODE_14D;
+            case MODE_14D -> LearningMode.MODE_7D;
+            case MODE_7D -> null;
+        };
+    }
+
+    /** MODE_7D → MODE_14D → MODE_28D → MODE_60D → null. */
+    static LearningMode upgradeOf(LearningMode mode) {
+        return switch (mode) {
+            case MODE_7D -> LearningMode.MODE_14D;
+            case MODE_14D -> LearningMode.MODE_28D;
+            case MODE_28D -> LearningMode.MODE_60D;
+            case MODE_60D -> null;
+        };
+    }
+
+    /** 판정 결과 · Application Service가 Recommendation Entity로 저장. */
+    public record Evaluation(
+            RecommendationType type,
+            LearningMode fromMode,
+            LearningMode toMode,
+            String reason
+    ) {}
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/RecommendationJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/RecommendationJpaRepository.java
@@ -1,0 +1,32 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.Recommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface RecommendationJpaRepository extends JpaRepository<Recommendation, Long> {
+
+    @Query("""
+            SELECT r FROM Recommendation r
+            WHERE r.userId = :userId
+              AND r.triggeredAt >= :since
+            ORDER BY r.triggeredAt DESC
+            """)
+    List<Recommendation> findLatestSince(@Param("userId") Long userId,
+                                         @Param("since") LocalDateTime since);
+
+    @Query("""
+            SELECT r FROM Recommendation r
+            WHERE r.userId = :userId
+              AND r.resolvedAt IS NULL
+            ORDER BY r.triggeredAt DESC
+            """)
+    List<Recommendation> findUnresolvedByUserId(@Param("userId") Long userId);
+
+    List<Recommendation> findByUserIdOrderByTriggeredAtDesc(Long userId);
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/RecommendationRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/RecommendationRepository.java
@@ -1,0 +1,25 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.Recommendation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * RecommendationRepository port — REV E3 · Story 3-2/3-5.
+ */
+public interface RecommendationRepository {
+
+    Recommendation save(Recommendation recommendation);
+
+    Optional<Recommendation> findById(Long id);
+
+    /** REV E3 · Story 3-3 · 중복 발송 방지 — 사용자·기간 내 최신 추천 조회. */
+    Optional<Recommendation> findLatestByUserIdSince(Long userId, LocalDateTime since);
+
+    /** REV E3 · Story 3-1 · 대시보드 미해결 추천 노출. */
+    Optional<Recommendation> findLatestUnresolvedByUserId(Long userId);
+
+    List<Recommendation> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/RecommendationRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/RecommendationRepositoryAdapter.java
@@ -1,0 +1,41 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.Recommendation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RecommendationRepositoryAdapter implements RecommendationRepository {
+
+    private final RecommendationJpaRepository jpa;
+
+    @Override
+    public Recommendation save(Recommendation recommendation) {
+        return jpa.save(recommendation);
+    }
+
+    @Override
+    public Optional<Recommendation> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public Optional<Recommendation> findLatestByUserIdSince(Long userId, LocalDateTime since) {
+        return jpa.findLatestSince(userId, since).stream().findFirst();
+    }
+
+    @Override
+    public Optional<Recommendation> findLatestUnresolvedByUserId(Long userId) {
+        return jpa.findUnresolvedByUserId(userId).stream().findFirst();
+    }
+
+    @Override
+    public List<Recommendation> findAllByUserId(Long userId) {
+        return jpa.findByUserIdOrderByTriggeredAtDesc(userId);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/UserNotificationJpaRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/UserNotificationJpaRepository.java
@@ -1,0 +1,21 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.UserNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserNotificationJpaRepository extends JpaRepository<UserNotification, Long> {
+
+    @Query("""
+            SELECT n FROM UserNotification n
+            WHERE n.userId = :userId
+              AND n.readAt IS NULL
+            ORDER BY n.createdAt DESC
+            """)
+    List<UserNotification> findUnreadByUserId(@Param("userId") Long userId);
+
+    List<UserNotification> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/UserNotificationRepository.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/UserNotificationRepository.java
@@ -1,0 +1,20 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.UserNotification;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * UserNotificationRepository port — REV E3 · Story 3-8.
+ */
+public interface UserNotificationRepository {
+
+    UserNotification save(UserNotification notification);
+
+    Optional<UserNotification> findById(Long id);
+
+    List<UserNotification> findAllByUserIdAndUnread(Long userId);
+
+    List<UserNotification> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/example/thirdtool/Review/infrastructure/UserNotificationRepositoryAdapter.java
+++ b/src/main/java/com/example/thirdtool/Review/infrastructure/UserNotificationRepositoryAdapter.java
@@ -1,0 +1,35 @@
+package com.example.thirdtool.Review.infrastructure;
+
+import com.example.thirdtool.Review.domain.model.UserNotification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserNotificationRepositoryAdapter implements UserNotificationRepository {
+
+    private final UserNotificationJpaRepository jpa;
+
+    @Override
+    public UserNotification save(UserNotification notification) {
+        return jpa.save(notification);
+    }
+
+    @Override
+    public Optional<UserNotification> findById(Long id) {
+        return jpa.findById(id);
+    }
+
+    @Override
+    public List<UserNotification> findAllByUserIdAndUnread(Long userId) {
+        return jpa.findUnreadByUserId(userId);
+    }
+
+    @Override
+    public List<UserNotification> findAllByUserId(Long userId) {
+        return jpa.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/LearningDashboardController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/LearningDashboardController.java
@@ -1,0 +1,55 @@
+package com.example.thirdtool.Review.presentation;
+
+import com.example.thirdtool.Review.application.service.LearningDashboardCommandService;
+import com.example.thirdtool.Review.application.service.LearningDashboardQueryService;
+import com.example.thirdtool.Review.presentation.dto.LearningDashboardResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+/**
+ * REV E3 · Story 3-4 · LearningDashboard API.
+ */
+@RestController
+@RequestMapping("/api/v1/learning-dashboard")
+@RequiredArgsConstructor
+public class LearningDashboardController {
+
+    private final LearningDashboardQueryService queryService;
+    private final LearningDashboardCommandService commandService;
+
+    /** GET /api/v1/learning-dashboard — 오늘/7일/30일/streak/recommendation 통합 조회. */
+    @GetMapping
+    public ResponseEntity<LearningDashboardResponse> getDashboard(
+            @AuthenticationPrincipal UserEntity currentUser) {
+        LearningDashboardResponse response = queryService.buildDashboard(
+                currentUser.getId(), LocalDate.now());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * POST /api/v1/learning-dashboard/recommendations/{id}/accept — 추천 수락 (mode 변경 트리거).
+     */
+    @PostMapping("/recommendations/{recommendationId}/accept")
+    public ResponseEntity<Void> accept(
+            @PathVariable Long recommendationId,
+            @AuthenticationPrincipal UserEntity currentUser) {
+        commandService.acceptRecommendation(currentUser.getId(), recommendationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * POST /api/v1/learning-dashboard/recommendations/{id}/dismiss — 추천 거절.
+     */
+    @PostMapping("/recommendations/{recommendationId}/dismiss")
+    public ResponseEntity<Void> dismiss(
+            @PathVariable Long recommendationId,
+            @AuthenticationPrincipal UserEntity currentUser) {
+        commandService.dismissRecommendation(currentUser.getId(), recommendationId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/NotificationController.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/NotificationController.java
@@ -1,0 +1,64 @@
+package com.example.thirdtool.Review.presentation;
+
+import com.example.thirdtool.Common.Exception.ErrorCode.ErrorCode;
+import com.example.thirdtool.Review.application.service.NotificationService;
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.Review.domain.model.UserNotification;
+import com.example.thirdtool.Review.infrastructure.UserNotificationRepository;
+import com.example.thirdtool.Review.presentation.dto.NotificationResponse;
+import com.example.thirdtool.User.domain.model.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * REV E3 · Story 3-8 · 알림 API (v1 minimal — polling).
+ */
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final UserNotificationRepository repository;
+
+    /**
+     * GET /api/v1/notifications?unread=true — 알림 목록.
+     * unread=true 시 미확인만 반환. false or 미입력 시 전체.
+     */
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> list(
+            @RequestParam(required = false, defaultValue = "false") boolean unread,
+            @AuthenticationPrincipal UserEntity currentUser) {
+        Long userId = currentUser.getId();
+        List<UserNotification> notifications = unread
+                ? notificationService.listUnread(userId)
+                : notificationService.listAll(userId);
+        List<NotificationResponse> body = notifications.stream()
+                .map(NotificationResponse::of)
+                .toList();
+        return ResponseEntity.ok(body);
+    }
+
+    /** POST /api/v1/notifications/{id}/read — 읽음 표시. 소유권 검증. */
+    @PostMapping("/{notificationId}/read")
+    @Transactional
+    public ResponseEntity<Void> markRead(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal UserEntity currentUser) {
+        UserNotification notification = repository.findById(notificationId)
+                .orElseThrow(() -> ReviewSessionException.of(
+                        ErrorCode.NOTIFICATION_NOT_FOUND, "id=" + notificationId));
+        if (!notification.isOwner(currentUser.getId())) {
+            throw ReviewSessionException.of(ErrorCode.NOTIFICATION_FORBIDDEN);
+        }
+        notification.markRead(LocalDateTime.now());
+        repository.save(notification);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/dto/LearningDashboardResponse.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/dto/LearningDashboardResponse.java
@@ -1,0 +1,71 @@
+package com.example.thirdtool.Review.presentation.dto;
+
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.domain.model.Recommendation;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * REV E3 · Story 3-1/3-4 — 대시보드 응답.
+ */
+public record LearningDashboardResponse(
+        TodaySummary today,
+        Window recent7Days,
+        Window recent30Days,
+        Streak streak,
+        RecommendationDto recommendation  // nullable
+) {
+    public record TodaySummary(
+            Long batchId,
+            LocalDate batchDate,
+            int totalCards,
+            int viewedCards,
+            double completionRatio,
+            boolean isClosed
+    ) {
+        public static TodaySummary of(DailyLearningBatch batch) {
+            return new TodaySummary(
+                    batch.getId(),
+                    batch.getBatchDate(),
+                    batch.totalCount(),
+                    batch.viewedCount(),
+                    batch.completionRatio(),
+                    batch.isClosed()
+            );
+        }
+    }
+
+    public record Window(
+            int windowDays,
+            int batchCount,
+            double avgCompletionRatio,
+            int perfectClearDays
+    ) {}
+
+    public record Streak(
+            int current,
+            int longest
+    ) {}
+
+    public record RecommendationDto(
+            Long recommendationId,
+            String type,           // SUGGEST_DOWNGRADE / SUGGEST_UPGRADE
+            LearningMode fromMode,
+            LearningMode toMode,
+            String reason,
+            LocalDateTime triggeredAt
+    ) {
+        public static RecommendationDto of(Recommendation r) {
+            return new RecommendationDto(
+                    r.getId(),
+                    r.getType().name(),
+                    r.getFromMode(),
+                    r.getToMode(),
+                    r.getReason(),
+                    r.getTriggeredAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/thirdtool/Review/presentation/dto/NotificationResponse.java
+++ b/src/main/java/com/example/thirdtool/Review/presentation/dto/NotificationResponse.java
@@ -1,0 +1,31 @@
+package com.example.thirdtool.Review.presentation.dto;
+
+import com.example.thirdtool.Review.domain.model.NotificationType;
+import com.example.thirdtool.Review.domain.model.UserNotification;
+
+import java.time.LocalDateTime;
+
+/**
+ * REV E3 · Story 3-8 · Notification API 응답.
+ */
+public record NotificationResponse(
+        Long notificationId,
+        NotificationType type,
+        String payloadJson,
+        Long recommendationId,   // nullable — SUGGEST_* 유형일 때만
+        LocalDateTime createdAt,
+        LocalDateTime readAt,
+        boolean isRead
+) {
+    public static NotificationResponse of(UserNotification n) {
+        return new NotificationResponse(
+                n.getId(),
+                n.getType(),
+                n.getPayloadJson(),
+                n.getRecommendationId(),
+                n.getCreatedAt(),
+                n.getReadAt(),
+                n.isRead()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,14 @@ management:
       cache:
         time-to-live: 30s
 
+# REV E3 · Story 3-6 — 규칙 기반 추천 임계값. 관찰 데이터 축적 후 튜닝.
+app:
+  learning:
+    recommendation:
+      downgrade-threshold-ratio: 0.5  # 3주 평균 완료율 < 50% → DOWNGRADE 안내
+      downgrade-window-weeks: 3
+      upgrade-window-weeks: 4          # 4주 모두 perfect → UPGRADE 안내
+
 # Swagger / OpenAPI — prod profile에서 비활성화
 springdoc:
   api-docs:

--- a/src/main/resources/db/migration/R37__rollback_recommendation_and_notification.sql
+++ b/src/main/resources/db/migration/R37__rollback_recommendation_and_notification.sql
@@ -1,0 +1,3 @@
+-- R37 · V37 rollback
+DROP TABLE IF EXISTS user_notification;
+DROP TABLE IF EXISTS recommendation;

--- a/src/main/resources/db/migration/V37__recommendation_and_notification.sql
+++ b/src/main/resources/db/migration/V37__recommendation_and_notification.sql
@@ -1,0 +1,48 @@
+-- V37 · REV E3 · Story 3-2/3-5/3-8 — Recommendation + UserNotification 신설
+--
+-- Recommendation Aggregate — 규칙 판정 이력 · accept/dismiss 상태 · v2 자동 조정 근거
+-- UserNotification Aggregate — in-app 알림 (v1 minimal: DB row + polling)
+
+-- 1. recommendation 테이블
+CREATE TABLE recommendation (
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id       BIGINT       NOT NULL,
+    type          VARCHAR(30)  NOT NULL,
+    from_mode     VARCHAR(20)  NOT NULL,
+    to_mode       VARCHAR(20)  NOT NULL,
+    reason        VARCHAR(500) NOT NULL,
+    triggered_at  DATETIME(6)  NOT NULL,
+    resolved_at   DATETIME(6)  NULL,
+    action        VARCHAR(20)  NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_recommendation_user
+        FOREIGN KEY (user_id) REFERENCES user_entity (id),
+    CONSTRAINT chk_recommendation_type
+        CHECK (type IN ('SUGGEST_DOWNGRADE', 'SUGGEST_UPGRADE')),
+    CONSTRAINT chk_recommendation_action
+        CHECK (action IS NULL OR action IN ('ACCEPTED', 'DISMISSED'))
+);
+
+CREATE INDEX idx_recommendation_user_triggered ON recommendation (user_id, triggered_at);
+CREATE INDEX idx_recommendation_user_unresolved ON recommendation (user_id, resolved_at);
+
+-- 2. user_notification 테이블 (v1 minimal)
+CREATE TABLE user_notification (
+    id                BIGINT        NOT NULL AUTO_INCREMENT,
+    user_id           BIGINT        NOT NULL,
+    type              VARCHAR(30)   NOT NULL,
+    payload_json      VARCHAR(2000) NOT NULL,
+    recommendation_id BIGINT        NULL,
+    created_at        DATETIME(6)   NOT NULL,
+    read_at           DATETIME(6)   NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_notification_user
+        FOREIGN KEY (user_id) REFERENCES user_entity (id),
+    CONSTRAINT fk_notification_recommendation
+        FOREIGN KEY (recommendation_id) REFERENCES recommendation (id),
+    CONSTRAINT chk_notification_type
+        CHECK (type IN ('SUGGEST_DOWNGRADE', 'SUGGEST_UPGRADE', 'WEEKLY_SUMMARY'))
+);
+
+CREATE INDEX idx_notification_user_read ON user_notification (user_id, read_at);
+CREATE INDEX idx_notification_user_created ON user_notification (user_id, created_at);

--- a/src/test/java/com/example/thirdtool/Review/domain/model/RecommendationTest.java
+++ b/src/test/java/com/example/thirdtool/Review/domain/model/RecommendationTest.java
@@ -1,0 +1,126 @@
+package com.example.thirdtool.Review.domain.model;
+
+import com.example.thirdtool.Review.domain.exception.ReviewSessionException;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * REV E3 · Story 3-2/3-5 · Recommendation Aggregate 도메인 단위 테스트.
+ */
+@DisplayName("Recommendation (REV E3 · Story 3-2/3-5)")
+class RecommendationTest {
+
+    @Nested
+    @DisplayName("of 팩토리 · 방향 검증")
+    class Create {
+
+        @Test
+        @DisplayName("해피: SUGGEST_DOWNGRADE MODE_14D→MODE_7D · 정상 생성")
+        void downgrade_해피() {
+            Recommendation r = Recommendation.of(1L, RecommendationType.SUGGEST_DOWNGRADE,
+                    LearningMode.MODE_14D, LearningMode.MODE_7D,
+                    "3주 평균 42%", LocalDateTime.now());
+
+            assertThat(r.getUserId()).isEqualTo(1L);
+            assertThat(r.getType()).isEqualTo(RecommendationType.SUGGEST_DOWNGRADE);
+            assertThat(r.isResolved()).isFalse();
+            assertThat(r.getAction()).isNull();
+        }
+
+        @Test
+        @DisplayName("해피: SUGGEST_UPGRADE MODE_14D→MODE_28D · 정상 생성")
+        void upgrade_해피() {
+            Recommendation r = Recommendation.of(1L, RecommendationType.SUGGEST_UPGRADE,
+                    LearningMode.MODE_14D, LearningMode.MODE_28D,
+                    "4주 perfect", LocalDateTime.now());
+
+            assertThat(r.getFromMode()).isEqualTo(LearningMode.MODE_14D);
+            assertThat(r.getToMode()).isEqualTo(LearningMode.MODE_28D);
+        }
+
+        @Test
+        @DisplayName("예외: SUGGEST_DOWNGRADE인데 from < to (방향 반대)")
+        void downgrade_방향_예외() {
+            assertThatThrownBy(() -> Recommendation.of(1L, RecommendationType.SUGGEST_DOWNGRADE,
+                    LearningMode.MODE_7D, LearningMode.MODE_14D,
+                    "잘못된 방향", LocalDateTime.now()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("SUGGEST_DOWNGRADE는 fromMode > toMode");
+        }
+
+        @Test
+        @DisplayName("예외: SUGGEST_UPGRADE인데 from > to (방향 반대)")
+        void upgrade_방향_예외() {
+            assertThatThrownBy(() -> Recommendation.of(1L, RecommendationType.SUGGEST_UPGRADE,
+                    LearningMode.MODE_28D, LearningMode.MODE_14D,
+                    "잘못된 방향", LocalDateTime.now()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("SUGGEST_UPGRADE는 fromMode < toMode");
+        }
+    }
+
+    @Nested
+    @DisplayName("resolve · accept/dismiss")
+    class Resolve {
+
+        @Test
+        @DisplayName("해피: ACCEPTED resolve · action + resolvedAt 세팅")
+        void accepted_해피() {
+            Recommendation r = downgradeRec();
+            LocalDateTime now = LocalDateTime.now();
+
+            r.resolve(RecommendationAction.ACCEPTED, now);
+
+            assertThat(r.isResolved()).isTrue();
+            assertThat(r.getAction()).isEqualTo(RecommendationAction.ACCEPTED);
+            assertThat(r.getResolvedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("해피: DISMISSED resolve · action DISMISSED 세팅")
+        void dismissed_해피() {
+            Recommendation r = downgradeRec();
+
+            r.resolve(RecommendationAction.DISMISSED, LocalDateTime.now());
+
+            assertThat(r.getAction()).isEqualTo(RecommendationAction.DISMISSED);
+        }
+
+        @Test
+        @DisplayName("예외: 이미 resolved에 재호출 · RECOMMENDATION_ALREADY_RESOLVED")
+        void 재호출_예외() {
+            Recommendation r = downgradeRec();
+            r.resolve(RecommendationAction.ACCEPTED, LocalDateTime.now());
+
+            assertThatThrownBy(() -> r.resolve(RecommendationAction.DISMISSED, LocalDateTime.now()))
+                    .isInstanceOf(ReviewSessionException.class)
+                    .hasMessageContaining("이미 처리된 추천");
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwner")
+    class Owner {
+
+        @Test
+        @DisplayName("해피/예외: 소유권 검증")
+        void 소유권() {
+            Recommendation r = downgradeRec();
+            assertThat(r.isOwner(1L)).isTrue();
+            assertThat(r.isOwner(2L)).isFalse();
+        }
+    }
+
+    private Recommendation downgradeRec() {
+        return Recommendation.of(1L, RecommendationType.SUGGEST_DOWNGRADE,
+                LearningMode.MODE_14D, LearningMode.MODE_7D,
+                "test", LocalDateTime.now());
+    }
+}

--- a/src/test/java/com/example/thirdtool/Review/domain/service/RecommendationEngineTest.java
+++ b/src/test/java/com/example/thirdtool/Review/domain/service/RecommendationEngineTest.java
@@ -1,0 +1,179 @@
+package com.example.thirdtool.Review.domain.service;
+
+import com.example.thirdtool.Review.application.config.RecommendationProperties;
+import com.example.thirdtool.Review.domain.model.DailyLearningBatch;
+import com.example.thirdtool.Review.domain.model.DailyCardEntry;
+import com.example.thirdtool.Review.domain.model.RecommendationType;
+import com.example.thirdtool.Review.infrastructure.DailyLearningBatchRepository;
+import com.example.thirdtool.UserSchedule.application.service.UserScheduleQueryService;
+import com.example.thirdtool.UserSchedule.domain.model.LearningMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * REV E3 · Story 3-2 · RecommendationEngine 규칙 판정 단위 테스트.
+ */
+@DisplayName("RecommendationEngine (REV E3 · Story 3-2)")
+class RecommendationEngineTest {
+
+    private DailyLearningBatchRepository batchRepository;
+    private UserScheduleQueryService userScheduleQueryService;
+    private RecommendationEngine engine;
+
+    private static final RecommendationProperties PROPS =
+            new RecommendationProperties(0.5, 3, 4);
+
+    @BeforeEach
+    void setUp() {
+        batchRepository = mock(DailyLearningBatchRepository.class);
+        userScheduleQueryService = mock(UserScheduleQueryService.class);
+        engine = new RecommendationEngine(batchRepository, userScheduleQueryService, PROPS);
+    }
+
+    @Nested
+    @DisplayName("DOWNGRADE 판정")
+    class Downgrade {
+
+        @Test
+        @DisplayName("해피: 3주 평균 40% + MODE_14D → SUGGEST_DOWNGRADE(14D→7D)")
+        void 저완료율_MODE_14D() {
+            Long userId = 1L;
+            LocalDate today = LocalDate.of(2026, 8, 1);
+            List<DailyLearningBatch> pool = batches(0.4, 0.4, 0.4);
+            when(userScheduleQueryService.currentMode(userId)).thenReturn(LearningMode.MODE_14D);
+            when(batchRepository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+                    eq(userId), any(), eq(today)))
+                    .thenReturn(pool);
+
+            Optional<RecommendationEngine.Evaluation> result = engine.evaluate(userId, today);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().type()).isEqualTo(RecommendationType.SUGGEST_DOWNGRADE);
+            assertThat(result.get().fromMode()).isEqualTo(LearningMode.MODE_14D);
+            assertThat(result.get().toMode()).isEqualTo(LearningMode.MODE_7D);
+        }
+
+        @Test
+        @DisplayName("엣지: MODE_7D 사용자 · 저완료율여도 DOWNGRADE 없음 (더 낮은 mode 없음)")
+        void MODE_7D_저완료율_no_op() {
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+            List<DailyLearningBatch> pool = batches(0.3, 0.3);
+            when(userScheduleQueryService.currentMode(userId)).thenReturn(LearningMode.MODE_7D);
+            when(batchRepository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+                    eq(userId), any(), eq(today)))
+                    .thenReturn(pool);
+
+            Optional<RecommendationEngine.Evaluation> result = engine.evaluate(userId, today);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("엣지: 3주 평균 70% (임계값 이상) · 판정 없음")
+        void 정상_완료율() {
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+            List<DailyLearningBatch> pool = batches(0.7, 0.75, 0.8);
+            when(userScheduleQueryService.currentMode(userId)).thenReturn(LearningMode.MODE_14D);
+            when(batchRepository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+                    eq(userId), any(), eq(today)))
+                    .thenReturn(pool);
+
+            Optional<RecommendationEngine.Evaluation> result = engine.evaluate(userId, today);
+
+            // 70~80%는 downgrade 임계 아님 · 4주 UPGRADE도 부족 (not perfect)
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("UPGRADE 판정")
+    class Upgrade {
+
+        @Test
+        @DisplayName("해피: 4주 batch 모두 perfect + MODE_14D → SUGGEST_UPGRADE(14D→28D)")
+        void 완벽_MODE_14D() {
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+            List<DailyLearningBatch> pool = batches(1.0, 1.0, 1.0, 1.0);
+            when(userScheduleQueryService.currentMode(userId)).thenReturn(LearningMode.MODE_14D);
+            when(batchRepository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+                    eq(userId), any(), eq(today)))
+                    .thenReturn(pool);
+
+            Optional<RecommendationEngine.Evaluation> result = engine.evaluate(userId, today);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().type()).isEqualTo(RecommendationType.SUGGEST_UPGRADE);
+            assertThat(result.get().toMode()).isEqualTo(LearningMode.MODE_28D);
+        }
+
+        @Test
+        @DisplayName("엣지: MODE_60D + 완벽 · UPGRADE 없음")
+        void MODE_60D_완벽_no_op() {
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+            List<DailyLearningBatch> pool = batches(1.0, 1.0, 1.0, 1.0);
+            when(userScheduleQueryService.currentMode(userId)).thenReturn(LearningMode.MODE_60D);
+            when(batchRepository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+                    eq(userId), any(), eq(today)))
+                    .thenReturn(pool);
+
+            Optional<RecommendationEngine.Evaluation> result = engine.evaluate(userId, today);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Empty 판정")
+    class Empty {
+
+        @Test
+        @DisplayName("엣지: batch 없음 · Optional.empty")
+        void batch_없음() {
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+            when(userScheduleQueryService.currentMode(userId)).thenReturn(LearningMode.MODE_14D);
+            when(batchRepository.findByUserIdAndBatchDateBetweenOrderByBatchDateDesc(
+                    eq(userId), any(), eq(today)))
+                    .thenReturn(List.of());
+
+            Optional<RecommendationEngine.Evaluation> result = engine.evaluate(userId, today);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    private static List<DailyLearningBatch> batches(double... ratios) {
+        List<DailyLearningBatch> list = new ArrayList<>();
+        for (double ratio : ratios) {
+            list.add(batchWithRatio(ratio));
+        }
+        return list;
+    }
+
+    /** ratio에 맞게 entries · viewed 개수를 세팅해 completionRatio가 정확히 나오도록 구성. */
+    private static DailyLearningBatch batchWithRatio(double ratio) {
+        DailyLearningBatch batch = mock(DailyLearningBatch.class);
+        when(batch.completionRatio()).thenReturn(ratio);
+        when(batch.isPerfectClear()).thenReturn(ratio >= 1.0);
+        return batch;
+    }
+}


### PR DESCRIPTION
## 개요

M5 (0.0.5v) **마지막 PR** · Review Epic 3 Story 3-1~3-8 완주 · **Review Product 100% 착지** (23/23 Story).

Epic 1·2로 축적된 batch·session 데이터 위에 학습 캐시 대시보드 + 규칙 기반 추천 + 주간 요약 cron + in-app notification 세트를 얹어 사용자가 자기 학습 캐시 용량을 데이터로 파악·조정할 수 있게 함.

## 왜 / 설계 결정

- **SDD 우선 정책** (사용자 지시): \`product-review.md\` Epic 3 (line 987~1301) 원안 착지
- **임계값 config 채택** (SDD § Epic 기술 결정): enum 상수 대신 \`@ConfigurationProperties\` · 관찰 후 튜닝 여지
- **In-app notification v1 minimal** (SDD § Epic 기술 결정): DB row + FE polling · WebSocket/FCM은 v2 별도 이슈. 초기 3명 규모에 오버스펙 방지
- **Recommendation 이력 저장** (SDD § Epic 기술 결정): action + resolvedAt 이력 축적 → v2 자동 조정 근거
- **DOWNGRADE 우선 판정**: DOWNGRADE + UPGRADE 조건이 동시 만족될 수 없지만, 명시적 우선순위로 안전망 확보

## 작업 내용

### Story 3-1 · LearningDashboardQueryService (2d)
- \`buildDashboard(userId, asOf)\` — 오늘 batch (lazy) + 7일/30일 window avg + streak + 미해결 recommendation

### Story 3-2 · RecommendationEngine 도메인 서비스 (2d)
- 3주 평균 완료율 < 50% → SUGGEST_DOWNGRADE (한 단계 아래)
- 4주 모두 perfect → SUGGEST_UPGRADE (한 단계 위)
- MODE_7D DOWNGRADE 없음 · MODE_60D UPGRADE 없음

### Story 3-3 · WeeklyRecommendationScheduler (2d)
- \`@Scheduled(cron = \"0 0 9 ? * MON\", zone = \"Asia/Seoul\")\`
- 활성 사용자 순회 · 같은 주 중복 발송 skip

### Story 3-4 · LearningDashboardController + DTO (1d)
- \`GET  /api/v1/learning-dashboard\` (통합 조회)
- \`POST /api/v1/learning-dashboard/recommendations/{id}/accept\` (204)
- \`POST /api/v1/learning-dashboard/recommendations/{id}/dismiss\` (204)

### Story 3-5 · Recommendation Entity + accept orchestration (2d)
- \`Recommendation\` Aggregate · 방향 검증 · resolve 멱등 금지
- \`LearningDashboardCommandService.acceptRecommendation\` — \`UserScheduleCommandService.save(userId, toMode.maxDays())\` 트리거로 mode 변경 → 다음 batch에서 M3 down cap 발동

### Story 3-6 · RecommendationProperties config (0.5d)
- \`@ConfigurationProperties(prefix = \"app.learning.recommendation\")\`
- \`application.yml\` 기본값: 0.5 · 3주 · 4주

### Story 3-8 · UserNotification 스키마 v1 minimal (1d)
- \`UserNotification\` Aggregate · v1 minimal (DB row + polling)
- \`NotificationController\` · GET unread · POST read
- V37 + R37 마이그레이션 (2 테이블 + FK + 인덱스 4종)

## 변경 유형

- [x] feat  - [ ] fix  - [ ] refactor  - [ ] docs  - [x] test  - [ ] chore

## 테스트

- \`./gradlew test\` → **BUILD SUCCESSFUL**
- \`RecommendationTest\` · 3 nested · 8 케이스 (create 방향·resolve 멱등·isOwner)
- \`RecommendationEngineTest\` · 3 nested · 6 케이스 (DOWNGRADE·UPGRADE·Empty·경계값 mode)

## v0.1.1v 이관 항목

- Story 3-7 · \`@SpringBootTest\` 3주 시나리오 통합 (batch dedup · 저완료율·감지·발동)
- Story 3-3 · Metrics 계측 (\`recommendation.suggested/accepted/dismissed_total\`)
- Story 3-1 · Repository·Calculator Mock 단위 (LearningDashboardQueryService)
- Story 3-5 · accept → mode 변경 → 다음 batch 통합 검증
- Story 3-6 · Config 주입 검증 통합 테스트
- Story 3-8 · \`@WebMvcTest\` slice (NotificationController)

## 체크리스트

- [x] 빌드 / 테스트 통과 (BUILD SUCCESSFUL)
- [x] BC 간 의존 방향 위반 없음 (Review BC · UserSchedule inbound · Application → Domain Service)
- [x] Base 브랜치 = develop 확인
- [x] ErrorCode 신설 5종 등록 · GlobalExceptionHandler 자동 처리
- [x] Review Product 완주 (23/23 Story)
- [x] M5 완주 (5/5 Epic PR)

## 관련 이슈

- Product: workflow/task/pes/workspectrum/sdd/in-progress/product-review.md
- Epic 3: line 987~1301 (캐시 측정 대시보드 + 규칙 기반 추천 + 조건부 주간 요약)
- Story 3-1 (line 1028) · 3-2 (line 1061) · 3-3 (line 1101) · 3-4 (line 1136) · 3-5 (line 1170) · 3-6 (line 1204) · 3-7 (line 1241) · 3-8 (line 1268)
- 상위 이슈: fix/brainstorming/0.0.2v/issue-26-l3-cache-dashboard-recommendations.md
- Milestone: workflow/task/milestones/version/0.0.5v/milestone.md § Epic PR #5